### PR TITLE
[Feature] Add option to disable fancy icons

### DIFF
--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -26,3 +26,19 @@ O.plugin.which_key.mappings["b"] = {
     "sort BufferLines automatically by language",
   },
 }
+
+if O.experimental.disable_fancy_icons then
+  -- TODO: How to do this initialise `g` lua?
+  vim.cmd [[let bufferline = get(g:, 'bufferline', {})]]
+
+  -- TODO: Setting these in lua doesn't seem to work
+  -- vim.g.bufferline = {
+  --   icon_close_tab = '×',
+  --   icon_close_tab_modified = '●',
+  --   icons = false
+  -- }
+  vim.cmd [[let bufferline.icon_close_tab = '×']]
+  vim.cmd [[let bufferline.icon_close_tab_modified = '●']]
+  vim.cmd [[let bufferline.icons = v:false]]
+end
+

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -56,6 +56,42 @@ M.setup = function()
       symlink = "",
     },
   }
+
+  if O.experimental.disable_fancy_icons then
+    g.nvim_tree_show_icons = {
+      git = 1,
+      folders = 1,
+      files = 0,
+      folder_arrows = 0,
+    }
+    vim.g.nvim_tree_icons = {
+      default = '',
+      symlink = '',
+      git = {
+        unstaged = '×',
+        staged = '✓',
+        unmerged = '◇',
+        renamed = '➜',
+        deleted = ' ',
+        untracked = '★',
+        ignored = '◌',
+      },
+      folder = {
+        default = '>',
+        open = '▼',
+        empty = '≥',
+        empty_open = '≤',
+        symlink = '↔',
+      },
+      lsp = {
+        hint = '?',
+        info = 'i',
+        warning = '△',
+        error = '×',
+      },
+    }
+  end
+
   local tree_cb = nvim_tree_config.nvim_tree_callback
 
   vim.g.nvim_tree_bindings = {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -330,6 +330,9 @@ O = {
       },
     },
   },
+  experimental = {
+    disable_fancy_icons = false
+  }
 }
 
 require "core.status_colors"

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -138,7 +138,7 @@ return require("packer").startup(function(use)
   }
 
   -- Icons
-  use { "kyazdani42/nvim-web-devicons" }
+  use { "kyazdani42/nvim-web-devicons", disable = O.experimental.disable_fancy_icons }
 
   -- Status Line and Bufferline
   use {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add option to disable all (current) ui icons. This should allow a decent experience without the devicons package and without nerd fonts. This is something I personally use and in the distant future could be a good solution to fallback on if no nerd fonts are detected on install.

This may be an unpopular setting, however it is marked experimental and completely opt-in.

This feature:
- Conditionally disables `nvim-web-devicons` (again, this is opt-in)
- Adds fallback icons for `nvim-tree`
- Adds fallback icons for `bufferline` (barbar)
