### PR TITLE
[Refactor] Clean-up redundant module-load checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,7 @@ repos:
       - id: shfmt
         name: shfmt
         minimum_pre_commit_version: 2.4.0
-        language: golang
-        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.2.2]
+        language: system
         entry: shfmt
         args: [-i=2, -ci, -w]
         types: [shell]
@@ -21,7 +20,7 @@ repos:
         language: rust
         entry: stylua
         types: [lua]
-        args: [.]
+        args: ['-']
       - id: luacheck
         name: luacheck
         language: system

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -1,5 +1,4 @@
 local M = {}
-local Log = require "core.log"
 M.config = function()
   lvim.builtin.compe = {
     enabled = true,
@@ -61,11 +60,7 @@ end
 M.setup = function()
   vim.g.vsnip_snippet_dir = lvim.vsnip_dir
 
-  local status_ok, compe = pcall(require, "compe")
-  if not status_ok then
-    Log:get_default().error "Failed to load compe"
-    return
-  end
+  local compe = require "compe"
 
   compe.setup(lvim.builtin.compe)
 

--- a/lua/core/dap.lua
+++ b/lua/core/dap.lua
@@ -1,5 +1,4 @@
 local M = {}
-local Log = require "core.log"
 M.config = function()
   lvim.builtin.dap = {
     active = false,
@@ -13,11 +12,7 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, dap = pcall(require, "dap")
-  if not status_ok then
-    Log:get_default().error "Failed to load dap"
-    return
-  end
+  local dap = require "dap"
 
   vim.fn.sign_define("DapBreakpoint", lvim.builtin.dap.breakpoint)
   dap.defaults.fallback.terminal_win_cmd = "50vsplit new"

--- a/lua/core/gitsigns.lua
+++ b/lua/core/gitsigns.lua
@@ -1,5 +1,4 @@
 local M = {}
-local Log = require "core.log"
 M.config = function()
   lvim.builtin.gitsigns = {
     signs = {
@@ -49,12 +48,7 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, gitsigns = pcall(require, "gitsigns")
-  if not status_ok then
-    Log:get_default().error "Failed to load gitsigns"
-    return
-  end
-  gitsigns.setup(lvim.builtin.gitsigns)
+  require("gitsigns").setup(lvim.builtin.gitsigns)
 end
 
 return M

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -1,5 +1,4 @@
 local M = {}
-local Log = require "core.log"
 function M.config()
   local status_ok, actions = pcall(require, "telescope.actions")
   if not status_ok then
@@ -114,6 +113,7 @@ end
 function M.setup()
   local status_ok, telescope = pcall(require, "telescope")
   if not status_ok then
+    local Log = require "core.log"
     Log:get_default().error "Failed to load telescope"
     return
   end

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -1,5 +1,4 @@
 local M = {}
-local Log = require "core.log"
 local utils = require "utils"
 
 M.config = function()
@@ -46,20 +45,11 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, terminal = pcall(require, "toggleterm")
-  if not status_ok then
-    Log:get_default().error "Failed to load toggleterm"
-    print(terminal)
-    return
-  end
+  local terminal = require "toggleterm"
   for _, exec in pairs(lvim.builtin.terminal.execs) do
     require("core.terminal").add_exec(exec[1], exec[2], exec[3])
   end
   terminal.setup(lvim.builtin.terminal)
-end
-
-local function is_installed(exe)
-  return vim.fn.executable(exe) == 1
 end
 
 M.add_exec = function(exec, keymap, name)
@@ -85,8 +75,9 @@ end
 
 M._exec_toggle = function(exec)
   local binary = M._split(exec)[1]
-  if is_installed(binary) ~= true then
-    print("Please install executable " .. binary .. ". Check documentation for more information")
+  if vim.fn.executable(binary) ~= 1 then
+    local Log = require "core.log"
+    Log:get_default().error("Unable to run executable " .. binary .. ". Please make sure it is installed properly.")
     return
   end
   local Terminal = require("toggleterm.terminal").Terminal

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -1,5 +1,4 @@
 local M = {}
-local Log = require "core.log"
 M.config = function()
   lvim.builtin.which_key = {
     active = false,
@@ -230,14 +229,7 @@ M.config = function()
 end
 
 M.setup = function()
-  -- if not package.loaded['which-key'] then
-  --  return
-  -- end
-  local status_ok, which_key = pcall(require, "which-key")
-  if not status_ok then
-    Log:get_default "Failed to load whichkey"
-    return
-  end
+  local which_key = require "which-key"
 
   which_key.setup(lvim.builtin.which_key.setup)
 
@@ -247,10 +239,8 @@ M.setup = function()
   local mappings = lvim.builtin.which_key.mappings
   local vmappings = lvim.builtin.which_key.vmappings
 
-  local wk = require "which-key"
-
-  wk.register(mappings, opts)
-  wk.register(vmappings, vopts)
+  which_key.register(mappings, opts)
+  which_key.register(vmappings, vopts)
 end
 
 return M

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -131,15 +131,9 @@ return {
     "terrortylor/nvim-comment",
     event = "BufRead",
     config = function()
-      local status_ok, nvim_comment = pcall(require, "nvim_comment")
-      if not status_ok then
-        local Log = require "core.log"
-        Log:get_default().error "Failed to load nvim-comment"
-        return
-      end
-      nvim_comment.setup()
+      require("nvim_comment").setup()
       if lvim.builtin.comment.on_config_done then
-        lvim.builtin.comment.on_config_done(nvim_comment)
+        lvim.builtin.comment.on_config_done(require "nvim_comment")
       end
     end,
   },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

It's unncessary to check if a plugin is loaded during `config` part in Packer, since it "Specifies code to run after this plugin is loaded."

See: `:h packer.use()`

Also remove the redundant `augroup` logic for linter and formatter since each file is only sourced ones.

Fixes #1003

## How Has This Been Tested?

Run on a clean install

```shell
rm -rf ~/.local/share/nvim ~/.config/nvim/plugin/*
nvim --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerInstall
nvim --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerSync
nvim +PackerCompile
```
