### PR TITLE
Fix slow CI by installing a neovim binary directly

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -22,19 +22,17 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
-      
-      - name: Install dependencies for Linux
-        if: matrix.os == 'linux'
-        run: |
-          sudo add-apt-repository ppa:neovim-ppa/unstable -y
-          sudo apt-get update
-          sudo apt-get install neovim -y
 
-      - name: Install dependencies for OSX
+      # sha256sum is not available by default
+      - name: Installl dependencies for OSX
         if: matrix.os == 'osx'
         run: |
-          brew update >/dev/null
-          brew install neovim
+          brew install coreutils
+
+      - name: Install neovim binary
+        run: |
+          bash ./utils/installer/install-neovim-from-release
+          sudo cp "$HOME/.local/bin/nvim" /usr/local/bin/nvim
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -27,12 +27,13 @@ jobs:
       - name: Installl dependencies for OSX
         if: matrix.os == 'osx'
         run: |
+          echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $GITHUB_ENV
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           brew install coreutils
 
       - name: Install neovim binary
         run: |
           bash ./utils/installer/install-neovim-from-release
-          sudo cp "$HOME/.local/bin/nvim" /usr/local/bin/nvim
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/utils/bin/install-latest-neovim
+++ b/utils/bin/install-latest-neovim
@@ -1,9 +1,0 @@
-!#/bin/bash
-cd ~
-sudo rm -r neovim
-git clone --branch master --depth 1 https://github.com/neovim/neovim
-cd neovim
-sudo make CMAKE_BUILD_TYPE=Release install
-cd ~
-sudo rm -r neovim
-

--- a/utils/installer/install-neovim-from-release
+++ b/utils/installer/install-neovim-from-release
@@ -2,7 +2,7 @@
 
 set -eu pipefall
 
-declare -r INSTALL_PREFIX="${INSTALL_PREFIX:-"$HOME/.local"}"
+declare -r LV_INSTALL_PREFIX="${INSTALL_PREFIX:-"$HOME/.local"}"
 declare -r RELEASE_VER="${RELEASE_VER:-latest}" # can be set to nightly
 
 declare ARCHIVE_NAME
@@ -33,8 +33,8 @@ RELEASE_SHA="$(curl -Ls "$CHECKSUM_URL" | awk '{print $1}')"
 readonly RELEASE_SHA
 
 function main() {
-  if [ ! -d "$INSTALL_PREFIX" ]; then
-    mkdir -p "INSTALL_PREFIX" || __invalid__prefix__handler
+  if [ ! -d "$LV_INSTALL_PREFIX" ]; then
+    mkdir -p "$LV_INSTALL_PREFIX" || __invalid__prefix__handler
   fi
   download_neovim
   verify_neovim
@@ -69,13 +69,13 @@ function install_neovim() {
   tar -xzf "$DOWNLOAD_DIR/$ARCHIVE_NAME.tar.gz"
   popd
   # https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
-  cp -r "$DOWNLOAD_DIR/$RELEASE_NAME/." "$INSTALL_PREFIX"
-  echo "Installtion complete!"
-  echo "Now you can run $INSTALL_PREFIX/bin/nvim"
+  cp -r "$DOWNLOAD_DIR/$RELEASE_NAME/." "$LV_INSTALL_PREFIX"
+  echo "Installation complete!"
+  echo "Now you can run $LV_INSTALL_PREFIX/bin/nvim"
 }
 
 function __invalid__prefix__handler() {
-  echo "Error! Invalid value for INSTALL_PREFIX: [$INSTALL_PREFIX]"
+  echo "Error! Invalid value for LV_INSTALL_PREFIX: [$INSTALL_PREFIX]"
   echo "Please verify that the folder exists and re-run the installer!"
   exit 1
 }

--- a/utils/installer/install-neovim-from-release
+++ b/utils/installer/install-neovim-from-release
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -eu pipefall
+
+declare -r INSTALL_PREFIX="${INSTALL_PREFIX:-"$HOME/.local"}"
+declare -r RELEASE_VER="${RELEASE_VER:-latest}" # can be set to nightly
+
+declare ARCHIVE_NAME
+declare RELEASE_NAME
+declare OS
+
+OS="$(uname -s)"
+
+if [ "$OS" == "Linux" ]; then
+  ARCHIVE_NAME="nvim-linux64"
+  RELEASE_NAME="nvim-linux64"
+elif [ "$OS" == "Darwin" ]; then
+  ARCHIVE_NAME="nvim-macos"
+  # for some reason the archive has a different name
+  RELEASE_NAME="nvim-osx64"
+else
+  echo "$OS platform is not supported currently"
+  exit 1
+fi
+
+declare -r RELEASE_URL="https://github.com/neovim/neovim/releases/$RELEASE_VER/download/$ARCHIVE_NAME.tar.gz"
+declare -r CHECKSUM_URL="$RELEASE_URL.sha256sum"
+
+DOWNLOAD_DIR="$(mktemp -d)"
+readonly DOWNLOAD_DIR
+
+RELEASE_SHA="$(curl -Ls "$CHECKSUM_URL" | awk '{print $1}')"
+readonly RELEASE_SHA
+
+function main() {
+  if [ ! -d "$INSTALL_PREFIX" ]; then
+    mkdir -p "INSTALL_PREFIX" || __invalid__prefix__handler
+  fi
+  download_neovim
+  verify_neovim
+  install_neovim
+}
+
+function download_neovim() {
+  echo "Downloading Neovim's binary from $RELEASE_VER release.."
+  if ! curl --progress-bar --fail -L "$RELEASE_URL" -o "$DOWNLOAD_DIR/$ARCHIVE_NAME.tar.gz"; then
+    echo "Download failed.  Check that the release/filename are correct."
+    exit 1
+  fi
+  echo "Download complete!"
+}
+
+function verify_neovim() {
+  echo "Verifying the installation.."
+  DOWNLOADED_SHA="$(sha256sum "$DOWNLOAD_DIR/$ARCHIVE_NAME.tar.gz" | awk '{print $1}')"
+
+  if [ "$RELEASE_SHA" != "$DOWNLOADED_SHA" ]; then
+    echo "Error! checksum mis-match."
+    echo "Expected: $RELEASE_SHA but got: $DOWNLOADED_SHA"
+    exit 1
+  fi
+  echo "Verification complete!"
+}
+
+function install_neovim() {
+
+  echo "Installing Neovim.."
+  pushd "$DOWNLOAD_DIR"
+  tar -xzf "$DOWNLOAD_DIR/$ARCHIVE_NAME.tar.gz"
+  popd
+  # https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
+  cp -r "$DOWNLOAD_DIR/$RELEASE_NAME/." "$INSTALL_PREFIX"
+  echo "Installtion complete!"
+  echo "Now you can run $INSTALL_PREFIX/bin/nvim"
+}
+
+function __invalid__prefix__handler() {
+  echo "Error! Invalid value for INSTALL_PREFIX: [$INSTALL_PREFIX]"
+  echo "Please verify that the folder exists and re-run the installer!"
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix the slow CI workflow by using a neovim binary directly from the github release page instead of installing all the build dependencies. 


## How Has This Been Tested?

We'll test it directly and then install any missing deps individually.
