### PR TITLE
[Feature]: Add support for saving a file without formatting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -30,8 +30,6 @@ plugin_loader:load { plugins, lvim.plugins }
 vim.g.colors_name = lvim.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
 vim.cmd("colorscheme " .. lvim.colorscheme)
 
-local utils = require "utils"
-utils.toggle_autoformat()
 local commands = require "core.commands"
 commands.load(commands.defaults)
 

--- a/lua/core/commands.lua
+++ b/lua/core/commands.lua
@@ -11,18 +11,19 @@ M.defaults = {
   endfunction
   ]],
 
+  -- NOTE: Make sure that `<q-args>` is quoted with single quotes only or there will be errors!
   -- Save files
   -- Save file without formatting the file
-  [[command! -bang -bar SaveWithoutFormatting lua require 'utils'.save_file(false, "<bang>" == "!")]],
+  [[command! -nargs=* -bang -bar SaveWithoutFormatting lua require 'utils'.save_file(false, "<bang>" == "!", nil, <q-args>)]],
   -- Save file and also format the file
-  [[command! -bang -bar SaveWithFormatting  lua require 'utils'.save_file(true, "<bang>" == "!")]],
+  [[command! -nargs=* -bang -bar SaveWithFormatting  lua require 'utils'.save_file(true, "<bang>" == "!", nil, <q-args>)]],
   -- Save file but respect auto format settings
-  [[command! -bang -bar SaveFile lua require 'utils'.save_file(nil, "<bang>" == "!")]],
+  [[command! -nargs=* -bang -bar SaveFile lua require 'utils'.save_file(nil, "<bang>" == "!", nil, <q-args>)]],
 
   -- Like above command but also quit immediately
-  [[command! -bang -bar SaveWithoutFormattingAndQuit lua require 'utils'.save_file(false, "<bang>" == "!", true)]],
-  [[command! -bang -bar SaveWithFormattingAndQuit  lua require 'utils'.save_file(true, "<bang>" == "!", true)]],
-  [[command! -bang -bar SaveFileAndQuit lua require 'utils'.save_file(nil, "<bang>" == "!", true)]],
+  [[command! -nargs=* -bang -bar SaveWithoutFormattingAndQuit lua require 'utils'.save_file(false, "<bang>" == "!", true, <q-args>)]],
+  [[command! -nargs=* -bang -bar SaveWithFormattingAndQuit  lua require 'utils'.save_file(true, "<bang>" == "!", true, <q-args>)]],
+  [[command! -nargs=* -bang -bar SaveFileAndQuit lua require 'utils'.save_file(nil, "<bang>" == "!", true, <q-args>)]],
 
   -- Map vim commands to our new commands
   [[cnoreabbrev w SaveFile]],

--- a/lua/core/commands.lua
+++ b/lua/core/commands.lua
@@ -10,6 +10,25 @@ M.defaults = {
     endif
   endfunction
   ]],
+
+  -- Save files
+  -- Save file without formatting the file
+  [[command! -bang -bar SaveWithoutFormatting lua require 'utils'.save_file(false, "<bang>" == "!")]],
+  -- Save file and also format the file
+  [[command! -bang -bar SaveWithFormatting  lua require 'utils'.save_file(true, "<bang>" == "!")]],
+  -- Save file but respect auto format settings
+  [[command! -bang -bar SaveFile lua require 'utils'.save_file(nil, "<bang>" == "!")]],
+
+  -- Like above command but also quit immediately
+  [[command! -bang -bar SaveWithoutFormattingAndQuit lua require 'utils'.save_file(false, "<bang>" == "!", true)]],
+  [[command! -bang -bar SaveWithFormattingAndQuit  lua require 'utils'.save_file(true, "<bang>" == "!", true)]],
+  [[command! -bang -bar SaveFileAndQuit lua require 'utils'.save_file(nil, "<bang>" == "!", true)]],
+
+  -- Map vim commands to our new commands
+  [[cnoreabbrev w SaveFile]],
+  [[cnoreabbrev w! SaveFile!]],
+  [[cnoreabbrev wq SaveFileAndQuit]],
+  [[cnoreabbrev wq! SaveFileAndQuit!]],
 }
 
 M.load = function(commands)

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -61,7 +61,8 @@ M.config = function()
       ["/"] = { ":CommentToggle<CR>", "Comment" },
     },
     mappings = {
-      ["w"] = { "<cmd>w!<CR>", "Save" },
+      ["w"] = { "<cmd>SaveFile!<CR>", "Save" },
+      ["W"] = { "<cmd>SaveWithoutFormatting!<CR>", "Save without formatting" },
       ["q"] = { "<cmd>q!<CR>", "Quit" },
       ["/"] = { "<cmd>CommentToggle<CR>", "Comment" },
       ["c"] = { "<cmd>BufferClose!<CR>", "Close Buffer" },

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -1,18 +1,12 @@
 local utils = {}
 
-function utils.save_file(format, force, quit)
-  print(format, force)
-  if lvim.format_on_save and format ~= false then
-    vim.lsp.buf.formatting()
-  elseif format then
+function utils.save_file(format, force, quit, files)
+  if (lvim.format_on_save and format ~= false) or format then
     vim.lsp.buf.formatting()
   end
 
-  if force then
-    vim.cmd "write!"
-  else
-    vim.cmd "write"
-  end
+  local bang = force and "!" or ""
+  vim.cmd("write" .. bang .. " " .. (files or ""))
 
   if quit then
     vim.cmd "quit"

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -1,5 +1,24 @@
 local utils = {}
 
+function utils.save_file(format, force, quit)
+  print(format, force)
+  if lvim.format_on_save and format ~= false then
+    vim.lsp.buf.formatting()
+  elseif format then
+    vim.lsp.buf.formatting()
+  end
+
+  if force then
+    vim.cmd "write!"
+  else
+    vim.cmd "write"
+  end
+
+  if quit then
+    vim.cmd "quit"
+  end
+end
+
 -- recursive Print (structure, limit, separator)
 local function r_inspect_settings(structure, limit, separator)
   limit = limit or 100 -- default item limit
@@ -56,36 +75,12 @@ function utils.generate_settings()
   io.close(file)
 end
 
--- autoformat
-function utils.toggle_autoformat()
-  if lvim.format_on_save then
-    require("core.autocmds").define_augroups {
-      autoformat = {
-        {
-          "BufWritePre",
-          "*",
-          ":silent lua vim.lsp.buf.formatting_sync()",
-        },
-      },
-    }
-  end
-
-  if not lvim.format_on_save then
-    vim.cmd [[
-      if exists('#autoformat#BufWritePre')
-        :autocmd! autoformat
-      endif
-    ]]
-  end
-end
-
 function utils.reload_lv_config()
   vim.cmd "source ~/.local/share/lunarvim/lvim/lua/settings.lua"
   vim.cmd "source ~/.config/lvim/lv-config.lua"
   vim.cmd "source ~/.local/share/lunarvim/lvim/lua/plugins.lua"
   local plugins = require "plugins"
   local plugin_loader = require("plugin-loader").init()
-  utils.toggle_autoformat()
   plugin_loader:load { plugins, lvim.plugins }
   vim.cmd ":PackerCompile"
   vim.cmd ":PackerInstall"


### PR DESCRIPTION
# Description

Now you can save a file without formatting even if format on save is enabled
You no longer have to go and disable the format on save option if you want to save a file without formatting just once!

Also, if you have format on save disabled, now you can save a file and also format it at the same time with the new command!

# Changes

I recommend that you go through the changes once but here's a summary:
 - Added `SaveWithoutFormatting`, `SaveWithFormatting`, and `SaveFile` commands
 - Added `SaveWithoutFormattingAndQuit`, `SaveWithFormattingAndQuit`, and `SaveFileAndQuit` commands
 - Changed the built in vim command `w`, and `wq` to use these new commands

# What do the new commands do?

 - `SaveWithoutFormatting`: Save the file without formatting
 - `SaveWithFormatting`: Save the file and format it
 - `SaveFile`: Save the file but respect the `format_on_save` option from the user's config file
 - The other three commands do the same actions but also quit after that!

## How Has This Been Tested?

Just try to do save a file without formatting using vim's built in commands or the new ones that I have created or just use the provided keybindings(defined in `which-key`)