### PR TITLE
[Refactor] Make autopairs configuration more consistent

### DIFF
--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.config = function()
-  lvim.builtin.dap = {
+  lvim.builtin.autopairs = {
     active = true,
   }
 end

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -15,15 +15,10 @@ M.setup = function()
 
   vim.g.completion_confirm_key = ""
   MUtils.completion_confirm = function()
-    if vim.fn.pumvisible() ~= 0 then
-      if vim.fn.complete_info()["selected"] ~= -1 then
-        return vim.fn["compe#confirm"](npairs.esc "<cr>")
-      else
-        return npairs.esc "<cr>"
-      end
-    else
-      return npairs.autopairs_cr()
+    if vim.fn.complete_info()["selected"] ~= -1 then
+      return vim.fn["compe#confirm"](npairs.esc "<cr>")
     end
+    return npairs.esc "<cr>"
   end
 
   if package.loaded["compe"] then

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -15,10 +15,13 @@ M.setup = function()
 
   vim.g.completion_confirm_key = ""
   MUtils.completion_confirm = function()
-    if vim.fn.complete_info()["selected"] ~= -1 then
-      return vim.fn["compe#confirm"](npairs.esc "<cr>")
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
+      end
+      return npairs.esc "<cr>"
     end
-    return npairs.esc "<cr>"
+    return npairs.autopairs_cr()
   end
 
   if package.loaded["compe"] then

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -7,10 +7,6 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, _ = pcall(require, "nvim-autopairs")
-  if not status_ok then
-    return
-  end
   local npairs = require "nvim-autopairs"
   local Rule = require "nvim-autopairs.rule"
 
@@ -55,6 +51,8 @@ M.setup = function()
     Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
     Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
   }
+
+  return npairs
 end
 
 return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -1,51 +1,60 @@
--- if not package.loaded['nvim-autopairs'] then
---   return
--- end
-local status_ok, _ = pcall(require, "nvim-autopairs")
-if not status_ok then
-  return
-end
-local npairs = require "nvim-autopairs"
-local Rule = require "nvim-autopairs.rule"
+local M = {}
 
--- skip it, if you use another global object
-_G.MUtils = {}
-
-vim.g.completion_confirm_key = ""
-MUtils.completion_confirm = function()
-  if vim.fn.pumvisible() ~= 0 then
-    if vim.fn.complete_info()["selected"] ~= -1 then
-      return vim.fn["compe#confirm"](npairs.esc "<cr>")
-    else
-      return npairs.esc "<cr>"
-    end
-  else
-    return npairs.autopairs_cr()
-  end
-end
-
-if package.loaded["compe"] then
-  require("nvim-autopairs.completion.compe").setup {
-    map_cr = true, --  map <CR> on insert mode
-    map_complete = true, -- it will auto insert `(` after select function or method item
+M.config = function()
+  lvim.builtin.dap = {
+    active = true,
   }
 end
 
-npairs.setup {
-  check_ts = true,
-  ts_config = {
-    lua = { "string" }, -- it will not add pair on that treesitter node
-    javascript = { "template_string" },
-    java = false, -- don't check treesitter on java
-  },
-}
+M.setup = function()
+  local status_ok, _ = pcall(require, "nvim-autopairs")
+  if not status_ok then
+    return
+  end
+  local npairs = require "nvim-autopairs"
+  local Rule = require "nvim-autopairs.rule"
 
-require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+  -- skip it, if you use another global object
+  _G.MUtils = {}
 
-local ts_conds = require "nvim-autopairs.ts-conds"
+  vim.g.completion_confirm_key = ""
+  MUtils.completion_confirm = function()
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
+      else
+        return npairs.esc "<cr>"
+      end
+    else
+      return npairs.autopairs_cr()
+    end
+  end
 
--- press % => %% is only inside comment or string
-npairs.add_rules {
-  Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-  Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
-}
+  if package.loaded["compe"] then
+    require("nvim-autopairs.completion.compe").setup {
+      map_cr = true, --  map <CR> on insert mode
+      map_complete = true, -- it will auto insert `(` after select function or method item
+    }
+  end
+
+  npairs.setup {
+    check_ts = true,
+    ts_config = {
+      lua = { "string" }, -- it will not add pair on that treesitter node
+      javascript = { "template_string" },
+      java = false, -- don't check treesitter on java
+    },
+  }
+
+  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+  local ts_conds = require "nvim-autopairs.ts-conds"
+
+  -- press % => %% is only inside comment or string
+  npairs.add_rules {
+    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  }
+end
+
+return M

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1002,6 +1002,7 @@ lvim.lang = {
   },
 }
 
+require("core.autopairs").config()
 require("core.which-key").config()
 require "core.status_colors"
 require("core.gitsigns").config()

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -75,7 +75,7 @@ return {
         lvim.builtin.autopairs.on_config_done(require "nvim-autopairs")
       end
     end,
-    disble = not lvim.builtin.autopairs.active,
+    disable = not lvim.builtin.autopairs.active,
   },
 
   -- Treesitter

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -70,11 +70,12 @@ return {
     -- event = "InsertEnter",
     after = "nvim-compe",
     config = function()
-      require "core.autopairs"
+      require("core.autopairs").setup()
       if lvim.builtin.autopairs.on_config_done then
         lvim.builtin.autopairs.on_config_done(require "nvim-autopairs")
       end
     end,
+    disble = not lvim.builtin.autopairs.active,
   },
 
   -- Treesitter

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -70,9 +70,9 @@ return {
     -- event = "InsertEnter",
     after = "nvim-compe",
     config = function()
-      require("core.autopairs").setup()
+      local autopairs = require("core.autopairs").setup()
       if lvim.builtin.autopairs.on_config_done then
-        lvim.builtin.autopairs.on_config_done(require "nvim-autopairs")
+        lvim.builtin.autopairs.on_config_done(autopairs)
       end
     end,
     disable = not lvim.builtin.autopairs.active,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Autopairs configuration were run when module was loaded with require. This was inconsistent with other plugins. As well as not being able to disable the builtin plugin as with other ones. This makes it more consistent with other plugins and you can disable it with the expected variables.

## How Has This Been Tested?
Tested with `lvim.builtin.autopairs.active = false` and `lvim.builtin.autopairs.active = true` in my `~/.config/lvim/lv-config.lua` with a `:PackerSync` in between