### PR TITLE
Add LunarVim info panel (Experimental)

### DIFF
--- a/lua/core/info.lua
+++ b/lua/core/info.lua
@@ -73,7 +73,7 @@ function M.create_simple_popup(buf_lines, callback)
   -- runtime/lua/vim/lsp/util.lua
   local bufnr = vim.api.nvim_create_buf(false, true)
   local height_percentage = 0.7
-  local width_percentage = 0.6
+  local width_percentage = 0.8
   local row_start_percentage = (1 - height_percentage) / 2
   local col_start_percentage = (1 - width_percentage) / 2
   local opts = {}
@@ -99,6 +99,7 @@ function M.create_simple_popup(buf_lines, callback)
   -- this needs to be window option!
   vim.api.nvim_win_set_option(win_id, "number", false)
   vim.cmd "setlocal nocursorcolumn"
+  vim.cmd "setlocal wrap"
   -- set buffer options
   vim.api.nvim_buf_set_option(bufnr, "filetype", "lspinfo")
   vim.lsp.util.close_preview_autocmd({ "BufHidden", "BufLeave" }, win_id)

--- a/lua/core/info.lua
+++ b/lua/core/info.lua
@@ -1,0 +1,127 @@
+local M = {}
+local lspui = require "lspconfig/_lspui"
+local job = require "plenary.job"
+local u = require "utils"
+local indent = "  "
+local sep = {
+  "",
+  "-------------------------------------------------------------------",
+  "",
+}
+
+M.banner = {
+  "",
+  "",
+  "⠀⣿⡟⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ⠀⠀     ⠀⠀⠀   ⠀⠀ ⣺⡿⠀⠀⠀⠀⠀⠀⠀ ⠀⠀⠀",
+  "⠀⣿⠇⠀⠀⠀⠀⠀⣤⡄⠀⠀⢠⣤⡄⠀.⣠⣤⣤⣤⡀⠀⠀⢀⣤⣤⣤⣤⡄⠀⠀⠀⣤⣄⣤⣤⣤⠀⠀ ⣿⣯  ⣿⡟⠀   ⣤⣤⠀⠀⠀⠀⣠⣤⣤⣤⣄⣤⣤",
+  "⢠⣿⠀⠀⠀⠀⠀⠀⣿⠃⠀⠀⣸⣿⠁⠀⣿⣿⠉⠀⠈⣿⡇⠀⠀⠛⠋⠀⠀⢹⣿⠀⠀⠀⣿⠏⠀⠸⠿⠃⠀⣿⣿⠀⣰⡟⠀⠀⠀⠀⠀⢸⣿⠀⠀⠀⠀⣿⡟⢸⣿⡇⢀⣿",
+  "⣸⡇⠀⠀⠀⠀⠀⢸⣿⠀⠀⠀⣿⡟⠀⢠⣿⡇⠀⠀⢰⣿⡇⠀⣰⣾⠟⠛⠛⣻⡇⠀⠀⢸⡿⠀⠀⠀⠀⠀⠀⢻⣿⢰⣿⠀⠀⠀⠀⠀⠀⣾⡇⠀⠀⠀⢸⣿⠇⢸⣿⠀⢸⡏",
+  "⣿⣧⣤⣤⣤⡄⠀⠘⣿⣤⣤⡤⣿⠇⠀⢸⣿⠁⠀⠀⣼⣿⠀⠀⢿⣿⣤⣤⠔⣿⠃⠀⠀⣾⡇⠀⠀⠀⠀⠀⠀⢸⣿⣿⠋⠀⠀⠀⢠⣤⣤⣿⣥⣤⡄⠀⣼⣿⠀⣸⡏⠀⣿⠃",
+  "⠉⠉⠉⠉⠉⠁⠀⠀⠈⠉⠉⠀⠉⠀⠀⠈⠉⠀⠀⠀⠉⠉⠀⠀⠀⠉⠉⠁⠈⠉⠀⠀⠀⠉⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠀⠀⠀⠀⠈⠉⠉⠉⠉⠉⠁⠀⠉⠁⠀⠉⠁⠀⠉⠀",
+  "",
+  "",
+}
+
+local function str_list(list)
+  return "[ " .. table.concat(list, ", ") .. " ]"
+end
+
+local function get_formatter_suggestion_msg(ft)
+  local supported_formatters = u.get_supported_formatters_by_filetype(ft)
+  return {
+    "-------------------------------------------------------------------",
+    "",
+    "HINT!",
+    "",
+    indent .. "* List of supported formatters: " .. str_list(supported_formatters),
+    "",
+    indent .. "You can enable a supported formatter by adding this to your config.lua",
+    "",
+    indent
+      .. "lvim.lang."
+      .. tostring(ft)
+      .. [[.formatting = { { exe = ']]
+      .. table.concat(supported_formatters, "|")
+      .. [[' } }]],
+    "",
+    "-------------------------------------------------------------------",
+  }
+end
+
+local function get_linter_suggestion_msg(ft)
+  local supported_linters = u.get_supported_linters_by_filetype(ft)
+  return {
+    "-------------------------------------------------------------------",
+    "",
+    "HINT!",
+    "",
+    indent .. "* List of supported linters: " .. str_list(supported_linters),
+    "",
+    indent .. "You can enable a supported linter by adding this to your config.lua",
+    "",
+    indent
+      .. "lvim.lang."
+      .. tostring(ft)
+      .. [[.linters = { { exe = ']]
+      .. table.concat(supported_linters, "|")
+      .. [[' } }]],
+    "",
+    "-------------------------------------------------------------------",
+  }
+end
+
+function M.toggle_display(ft)
+  --- set floating window option
+  local win_info = lspui.percentage_range_window(0.7, 0.7)
+  local bufnr, win_id = win_info.bufnr, win_info.win_id
+
+  local null_ls_providers = require("lsp.null-ls").get_registered_providers_by_filetype(ft)
+  local client = u.get_active_client_by_ft(ft)
+  local is_client_active = not client.is_stopped()
+  local client_enabled_caps = require("lsp").get_ls_capabilities(client.id)
+  local num_caps = vim.tbl_count(client_enabled_caps)
+
+  local buf_lines = {}
+  vim.list_extend(buf_lines, M.banner)
+
+  local header = {
+    "Detected filetype is: " .. tostring(ft),
+    "",
+    "Treesitter active: " .. tostring(next(vim.treesitter.highlighter.active) ~= nil),
+    "",
+    "",
+  }
+  vim.list_extend(buf_lines, header)
+
+  local lsp_info = {
+    "Associated language-server: " .. client.name,
+    indent .. "* Active: " .. tostring(is_client_active) .. ", id: " .. tostring(client.id),
+    indent .. "* Formatting support: " .. tostring(client.resolved_capabilities.document_formatting),
+    indent .. "* Capabilities list: " .. table.concat(vim.list_slice(client_enabled_caps, 1, num_caps / 2), ", "),
+    indent .. indent .. indent .. table.concat(vim.list_slice(client_enabled_caps, ((num_caps / 2) + 1)), ", "),
+    "",
+  }
+  vim.list_extend(buf_lines, lsp_info)
+
+  local null_ls_info = {
+    "Other active providers: " .. table.concat(null_ls_providers, ", "),
+    "",
+    "-------------------------------------------------------------------",
+  }
+  vim.list_extend(buf_lines, null_ls_info)
+
+  vim.list_extend(buf_lines, get_formatter_suggestion_msg(ft))
+
+  vim.list_extend(buf_lines, get_linter_suggestion_msg(ft))
+
+  buf_lines = vim.lsp.util._trim(buf_lines, {})
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, buf_lines)
+  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+  vim.api.nvim_buf_set_option(bufnr, "filetype", "lspinfo")
+  vim.lsp.util.close_preview_autocmd({ "BufHidden", "BufLeave" }, win_id)
+  vim.cmd("syntax match Identifier /filetype is: .*\\zs\\<" .. ft .. "\\>/")
+  vim.cmd("syntax match Identifier /server: .*\\zs\\<" .. client.name .. "\\>/")
+  vim.cmd("syntax match Identifier /providers: .*\\zs\\<" .. table.concat(null_ls_providers, ", ") .. "\\>/")
+end
+
+return M

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -169,6 +169,10 @@ M.config = function()
       L = {
         name = "+LunarVim",
         k = { "<cmd>lua require('keymappings').print()<cr>", "View LunarVim's default keymappings" },
+        i = {
+          "<cmd>lua require('core.info').toggle_popup(vim.bo.filetype)<cr>",
+          "Toggle LunarVim Info",
+        },
       },
 
       s = {

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -64,6 +64,36 @@ function M.common_capabilities()
   return capabilities
 end
 
+function M.get_ls_capabilities(client_id)
+  local client
+  if not client_id then
+    local buf_clients = vim.lsp.buf_get_clients()
+    for _, client in ipairs(buf_clients) do
+      if client.name ~= "null-ls" then
+        client_id = client.id
+        break
+      end
+    end
+  end
+  if not client_id then
+    error "Unable to determine client_id"
+  end
+
+  client = vim.lsp.get_client_by_id(tonumber(client_id))
+
+  local enabled_caps = {}
+
+  for k, v in pairs(client.resolved_capabilities) do
+    if v == true then
+      -- print("got cap: ", vim.inspect(caps))
+      table.insert(enabled_caps, k)
+      -- vim.list_extend(enabled_caps, cap)
+    end
+  end
+
+  return enabled_caps
+end
+
 function M.common_on_init(client, bufnr)
   if lvim.lsp.on_init_callback then
     lvim.lsp.on_init_callback(client, bufnr)

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -68,9 +68,9 @@ function M.get_ls_capabilities(client_id)
   local client
   if not client_id then
     local buf_clients = vim.lsp.buf_get_clients()
-    for _, client in ipairs(buf_clients) do
-      if client.name ~= "null-ls" then
-        client_id = client.id
+    for _, buf_client in ipairs(buf_clients) do
+      if buf_client.name ~= "null-ls" then
+        client_id = buf_client.id
         break
       end
     end

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -113,6 +113,34 @@ function utils.get_active_client_by_ft(filetype)
   return nil
 end
 
+-- TODO: consider porting this logic to null-ls instead
+function utils.get_supported_linters_by_filetype(filetype)
+  local null_ls = require "null-ls"
+  local matches = {}
+  for _, provider in pairs(null_ls.builtins.diagnostics) do
+    if vim.tbl_contains(provider.filetypes, filetype) then
+      local provider_name = provider.name
+
+      table.insert(matches, provider_name)
+    end
+  end
+
+  return matches
+end
+
+function utils.get_supported_formatters_by_filetype(filetype)
+  local null_ls = require "null-ls"
+  local matches = {}
+  for _, provider in pairs(null_ls.builtins.formatting) do
+    if provider.filetypes and vim.tbl_contains(provider.filetypes, filetype) then
+      -- table.insert(matches, { provider.name, ft })
+      table.insert(matches, provider.name)
+    end
+  end
+
+  return matches
+end
+
 function utils.unrequire(m)
   package.loaded[m] = nil
   _G[m] = nil


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add an info panel with some useful status reports for the current lunarvim configuration. 
It operates per files, and tries to give suggestions about setting up linters and formatters. 

Todos:
- [x] show missing providers
- [ ] accessibility concerns: colors, line wrapping, etc.
- [ ] use icons?
- [ ] add more/different info?



## Screenshots

### Lua
![image](https://user-images.githubusercontent.com/59826753/128524688-a595f31b-72d0-40ec-a9a1-253fa02d44c5.png)


### C (clangd supports formatting)
![c](https://user-images.githubusercontent.com/59826753/128524784-875c6f2e-0d98-4d84-b5fb-a03f1b3ed19a.png)


### typescript (forced formatting off)
![ts](https://user-images.githubusercontent.com/59826753/128524853-1a098ba3-bf48-452e-a08d-b8fa6b7e7f4b.png)




Fixes #1187 

## How Has This Been Tested?

```lua
-- Add this to your `config.lua` 
lvim.builtin.which_key.mappings["Li"] = {
	"<cmd>lua package.loaded['core.info']=nil; require('core.info').toggle_display(vim.bo.filetype)<cr>",
	"Toggle LunarVim Info",
}
```

