### PR TITLE
[Feature] Add PowerShell language server support

### DIFF
--- a/ftplugin/ps1.lua
+++ b/ftplugin/ps1.lua
@@ -1,0 +1,3 @@
+require("lsp").setup "ps1"
+
+vim.cmd [[setlocal ts=4 sw=4]]

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1234,7 +1234,7 @@ lvim.lang = {
     },
   },
   gdscript = {
-    formatter = {},
+    formatters = {},
     linters = {},
     lsp = {
       provider = "gdscript",
@@ -1251,7 +1251,7 @@ lvim.lang = {
     },
   },
   ps1 = {
-    formatter = {},
+    formatters = {},
     linters = {},
     lsp = {
       provider = "powershell_es",

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1250,6 +1250,19 @@ lvim.lang = {
       },
     },
   },
+  ps1 = {
+    formatter = {},
+    linters = {},
+    lsp = {
+      provider = "powershell_es",
+      setup = {
+        bundle_path = "",
+        on_attach = common_on_attach,
+        on_init = common_on_init,
+        capabilities = common_capabilities,
+      },
+    },
+  },
 }
 
 require("keymappings").config()


### PR DESCRIPTION
# Description

Adds support for PowerShell language server (powershell_es) configuration

## How Has This Been Tested?

1. Installed Microsoft PowerShell: https://github.com/PowerShell/PowerShell/releases
2. Installed PowerShellEditorServices: https://github.com/PowerShell/PowerShellEditorServices/releases
3. Added configuration e.g. `lvim.lang.ps1.lsp.setup.bundle_path = "/path/to/PowerShellEditorServices"`
4. Opened a PowerShell `.ps1` file and saw powershell_es language server activated.
