### PR TITLE
use_decoration_api has been removed from gitsigns

### DIFF
--- a/lua/core/gitsigns.lua
+++ b/lua/core/gitsigns.lua
@@ -44,7 +44,6 @@ M.config = function()
     sign_priority = 6,
     update_debounce = 200,
     status_formatter = nil, -- Use default
-    use_decoration_api = false,
   }
 end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

as mentioned [here](https://github.com/lewis6991/gitsigns.nvim/commit/27e1e95e1aa8d4ec0aabbf5148013f58a1bc4b40)


<img width="557" alt="Screen Shot 2021-08-05 at 11 41 42 PM" src="https://user-images.githubusercontent.com/10992695/128407588-80f67367-35ba-4dee-9354-31a575dec5a1.png">
