### PR TITLE
chore: remove now-redundant utility function

### DIFF
--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -203,7 +203,6 @@ table.insert(gls.right, {
 local function get_attached_provider_name(msg)
   msg = msg or "LSP Inactive"
   local buf_clients = vim.lsp.buf_get_clients()
-  local utils = require "utils"
   if next(buf_clients) == nil then
     return msg
   end
@@ -215,7 +214,7 @@ local function get_attached_provider_name(msg)
       table.insert(buf_client_names, client.name)
     end
   end
-  utils.list_extend_unique(buf_client_names, null_ls_providers)
+  vim.list_extend(buf_client_names, null_ls_providers)
   return table.concat(buf_client_names, ", ")
 end
 

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -113,32 +113,6 @@ function utils.get_active_client_by_ft(filetype)
   return nil
 end
 
---- Extends a list-like table with the unique values of another list-like table.
----
---- NOTE: This mutates dst!
----
---@see |vim.tbl_extend()|
----
---@param dst list which will be modified and appended to.
---@param src list from which values will be inserted.
---@param start Start index on src. defaults to 1
---@param finish Final index on src. defaults to #src
---@returns dst
-function utils.list_extend_unique(dst, src, start, finish)
-  vim.validate {
-    dst = { dst, "t" },
-    src = { src, "t" },
-    start = { start, "n", true },
-    finish = { finish, "n", true },
-  }
-  for i = start or 1, finish or #src do
-    if not vim.tbl_contains(dst, src[i]) then
-      table.insert(dst, src[i])
-    end
-  end
-  return dst
-end
-
 function utils.unrequire(m)
   package.loaded[m] = nil
   _G[m] = nil


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

We don't need `util.list_extend_unique` after #1240 

