### PR TITLE
[Refactor]:Added space after plug icon

### DIFF
--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -72,7 +72,7 @@ M.setup = function()
 
   vim.api.nvim_exec(
     [[
-    let g:dashboard_custom_footer = ['LunarVim loaded '..packages..' plugins ']
+    let g:dashboard_custom_footer = ['LunarVim loaded '..packages..' plugins  ']
 ]],
     false
   )


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
I've added a space after the plug unicode icon cause it doe'snt appear fully in LunarVim for me. So though would be better.
Pretty useless PR. xD


# test
I reran lunarvim now it works

