### PR TITLE
feat: add installation script for Windows

### DIFF
--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -1,11 +1,14 @@
 local M = {}
 -- It's not safe to require 'utils' without adjusting the runtimepath
-function _G.join_paths(...)
-  local uv = vim.loop
+
+local uv = vim.loop
+local function join_paths(...)
   local path_sep = uv.os_uname().version:match "Windows" and "\\" or "/"
   local result = table.concat({ ... }, path_sep)
   return result
 end
+
+_G.join_paths = join_paths
 
 function _G.get_runtime_dir()
   local lvim_runtime_dir = os.getenv "LUNARVIM_RUNTIME_DIR"
@@ -70,13 +73,15 @@ function M:init()
     vim.cmd("set spellfile=" .. join_paths(self.config_dir, "spell", "en.utf-8.add"))
   end
 
+  vim.fn.mkdir(vim.fn.stdpath "cache", "p")
   -- FIXME: currently unreliable in unit-tests
-  if not os.getenv "LVIM_TEST_ENV" then
-    vim.fn.mkdir(vim.fn.stdpath "cache", "p")
-    require("impatient").setup {
-      path = vim.fn.stdpath "cache" .. "/lvim_cache",
-      enable_profiling = true,
-    }
+  if not vim.loop.os_uname().version:match "Windows" then
+    if not os.getenv "LVIM_TEST_ENV" then
+      require("impatient").setup {
+        path = vim.fn.stdpath "cache" .. "/lvim_cache",
+        enable_profiling = true,
+      }
+    end
   end
 
   local config = require "config"

--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -75,13 +75,11 @@ function M:init()
 
   vim.fn.mkdir(vim.fn.stdpath "cache", "p")
   -- FIXME: currently unreliable in unit-tests
-  if not vim.loop.os_uname().version:match "Windows" then
-    if not os.getenv "LVIM_TEST_ENV" then
-      require("impatient").setup {
-        path = vim.fn.stdpath "cache" .. "/lvim_cache",
-        enable_profiling = true,
-      }
-    end
+  if not os.getenv "LVIM_TEST_ENV" then
+    require("impatient").setup {
+      path = vim.fn.stdpath "cache" .. "/lvim_cache",
+      enable_profiling = true,
+    }
   end
 
   local config = require "config"

--- a/og_install.ps1
+++ b/og_install.ps1
@@ -1,0 +1,255 @@
+$ErrorActionPreference = "Stop" # exit when command fails
+
+# set script variables
+$LV_BRANCH = ($LV_BRANCH, "rolling", 1 -ne $null)[0]
+$LV_REMOTE = ($LV_REMOTE, "lunarvim/lunarvim.git", 1 -ne $null)[0]
+$INSTALL_PREFIX = ($INSTALL_PREFIX, "$HOME\.local", 1 -ne $null)[0]
+
+$XDG_DATA_HOME = ($XDG_DATA_HOME, "$HOME\.local\share", 1 -ne $null)[0]
+$XDG_CACHE_HOME = ($XDG_CACHE_HOME, "$HOME\.cache", 1 -ne $null)[0]
+$XDG_CONFIG_HOME = ($XDG_CONFIG_HOME, "$HOME\.config", 1 -ne $null)[0]
+
+$NEOVIM_CACHE_DIR = "$XDG_CACHE_HOME\nvim"
+
+
+$LUNARVIM_RUNTIME_DIR = ($LUNARVIM_RUNTIME_DIR, "$XDG_DATA_HOME\lunarvim", 1 -ne $null)[0]
+$LUNARVIM_CONFIG_DIR = ($LUNARVIM_CONFIG_DIR, "$XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]
+
+$__lvim_dirs = (
+	"$LUNARVIM_CONFIG_DIR",
+	"$LUNARVIM_RUNTIME_DIR",
+	"$NEOVIM_CACHE_DIR" # for now this is shared with neovim
+)
+
+$__npm_deps = (
+	"neovim",
+	"tree-sitter-cli"
+)
+
+$__pip_deps = (
+	"pynvim"
+)
+
+function main($cliargs) {
+	Write-Output "  
+
+		88\                                                   88\               
+		88 |                                                  \__|              
+		88 |88\   88\ 888888$\   888888\   888888\ 88\    88\ 88\ 888888\8888\  
+		88 |88 |  88 |88  __88\  \____88\ 88  __88\\88\  88  |88 |88  _88  _88\ 
+		88 |88 |  88 |88 |  88 | 888888$ |88 |  \__|\88\88  / 88 |88 / 88 / 88 |
+		88 |88 |  88 |88 |  88 |88  __88 |88 |       \88$  /  88 |88 | 88 | 88 |
+		88 |\888888  |88 |  88 |\888888$ |88 |        \$  /   88 |88 | 88 | 88 |
+		\__| \______/ \__|  \__| \_______|\__|         \_/    \__|\__| \__| \__|
+  
+  "
+  
+	__add_separator "80"
+  
+	# skip this in a Github workflow
+	if ( $null -eq "$GITHUB_ACTIONS" ) {
+		check_system_deps
+  
+		__add_separator "80"
+
+		<# Write-Output "Would you like to check lunarvim's NodeJS dependencies?"
+		$answer = Read-Host "[y]es or [n]o (default: no) "
+		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+			install_nodejs_deps
+		} 
+  
+		Write-Output "Would you like to check lunarvim's Python dependencies?"
+		$answer = Read-Host "[y]es or [n]o (default: no) "
+		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+			install_python_deps
+		} 
+	    
+		Write-Output "Would you like to check lunarvim's Rust dependencies?"
+		$answer = Read-Host "[y]es or [n]o (default: no) "
+		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+			install_rust_deps
+		} 
+  
+		__add_separator "80"
+  
+		Write-Output "Backing up old LunarVim configuration"
+		backup_old_config
+  
+		__add_separator "80" #>
+  
+	}
+  
+	if ($cliargs.Contains("--overwrite")) {
+		Write-Output "!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag"
+		$answer = Read-Host "Would you like to continue? [y]es or [n]o "
+		if ("$answer" -ne "y" -and "$answer" -ne "Y") {
+			exit 1
+		} 
+		
+		foreach ($dir in $__lvim_dirs) {
+			if (Test-Path "$dir") {
+				Remove-Item -Force -Recurse "$dir"
+			}
+		}
+	}
+  
+	if (Test-Path "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim") {
+		Write-Output "Packer already installed"
+	}
+	else {
+		install_packer
+	}
+  
+	__add_separator "80"
+  
+	if (Test-Path "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" ) {
+		Write-Output "Updating LunarVim"
+		update_lvim
+	}
+	else {
+		if ($cliargs.Contains("--testing")) {
+			copy_local_lvim_repository
+		}
+		else {
+			clone_lvim
+		}
+		setup_lvim
+	}
+  
+	__add_separator "80"
+  
+}
+
+function print_missing_dep_msg($dep) {
+	Write-Output "[ERROR]: Unable to find dependency [$dep]"
+	Write-Output "Please install it first and re-run the installer. Try: $RECOMMEND_INSTALL $dep"
+}
+  
+
+function check_dep($dep) {
+	try { 
+		Get-Command -Name $dep -ErrorAction Stop | Out-Null 
+	}
+	catch { 
+		print_missing_dep_msg $dep
+		exit 1
+	}
+}
+
+function check_system_deps() {
+	check_dep "git"
+	check_dep "nvim"
+}
+
+function backup_old_config() {
+	foreach ($dir in $__lvim_dirs) {
+		# we create an empty folder for subsequent commands \
+		# that require an existing directory	  
+		New-Item "$dir.bak" -ItemType "directory"
+		Copy-Item -Recurse "$dir\*" "$dir.bak\."
+	}
+
+	Write-Output "Backup operation complete"
+}
+
+
+function install_packer() {
+	git clone --progress --depth 1 "https://github.com/wbthomason/packer.nvim" "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim"
+}
+  
+function copy_local_lvim_repository() {
+	Write-Output "Copy local LunarVim configuration"
+	Copy-Item -Path "$((Get-Item $PWD).Parent.Parent.FullName)" -Destination "$LUNARVIM_RUNTIME_DIR/lvim" -Recurse
+}
+
+function clone_lvim() {
+	Write-Output "Cloning LunarVim configuration"
+	try {
+		git clone --progress --branch "$LV_BRANCH" --depth 1 "https://github.com/${LV_REMOTE}" "$LUNARVIM_RUNTIME_DIR/lvim" 
+	}
+	catch {
+		Write-Output "Failed to clone repository. Installation failed."
+		exit 1		
+	}
+}
+
+function setup_shim() {
+	if ((Test-Path "$INSTALL_PREFIX\bin") -eq $false) {
+		New-Item "$INSTALL_PREFIX\bin" -ItemType "directory" | Out-Null
+	}
+
+	Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" -Value (`
+	"New-Variable -Name LUNARVIM_CONFIG_DIR -Value `"$LUNARVIM_CONFIG_DIR`"`n" +`
+	"New-Variable -Name LUNARVIM_RUNTIME_DIR -Value `"$LUNARVIM_RUNTIME_DIR`"`n`n" +`
+	"nvim -u `"$LUNARVIM_RUNTIME_DIR\lvim\init.lua`" " + '$args')
+}
+
+function setup_lvim() {
+	Write-Output "Installing LunarVim shim"
+  
+	setup_shim
+  
+	Write-Output "Preparing Packer setup"
+
+	if ((Test-Path "$LUNARVIM_CONFIG_DIR") -eq $false) {
+		New-Item "$LUNARVIM_CONFIG_DIR" -ItemType "directory"
+	}
+
+	Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example-no-ts.lua" `
+		"$LUNARVIM_CONFIG_DIR\config.lua"
+  
+	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerInstall
+	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerSync
+  
+	Write-Output "Packer setup complete"
+	
+	__add_separator "80"
+
+	Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example.lua" "$LUNARVIM_CONFIG_DIR\config.lua"
+  
+	$answer = Read-Host $(`
+	"Would you like to create an alias inside your Powershell profile?`n" +`
+	"(This enables you to start lvim with the command 'lvim') [y]es or [n]o (default: no)" )
+	if ("$answer" -eq "y" -and "$answer" -eq "Y") {
+		create_alias
+	} 
+
+	__add_separator "80"
+
+	Write-Output "Thank you for installing LunarVim!!"
+	Write-Output "You can start it by running: $INSTALL_PREFIX\bin\lvim.ps1"
+	Write-Output "Do not forget to use a font with glyphs (icons) support [https://github.com/ryanoasis/nerd-fonts]"
+}
+
+
+function update_lvim() {
+	try {
+		git -C "$LUNARVIM_RUNTIME_DIR/lvim" status -uno
+	}
+	catch {
+		git -C "$LUNARVIM_RUNTIME_DIR/lvim" pull --ff-only --progress -or
+		Write-Output "Unable to guarantee data integrity while updating. Please do that manually instead."
+		exit 1
+	}
+	Write-Output "Your LunarVim installation is now up to date!"
+}
+
+function __add_separator($div_width) {
+	"-" * $div_width
+	Write-Output ""
+}
+
+function create_alias {
+	if($null -eq $(Get-Alias | Select-String "lvim")){
+		Add-Content -Path $PROFILE -Value $(-join @('Set-Alias lvim "', "$INSTALL_PREFIX", '\bin\lvim.ps1"'))
+		
+		Write-Output ""
+		Write-Host 'To use the new alias in this window reload your profile with ". $PROFILE".' -ForegroundColor Yellow
+
+	}else {
+		Write-Output "Alias is already set and will not be reset."
+	}
+}
+
+main "$args"
+

--- a/utils/bin/lvim.ps1
+++ b/utils/bin/lvim.ps1
@@ -1,0 +1,9 @@
+$env:XDG_DATA_HOME = ($env:XDG_DATA_HOME, "$env:APPDATA", 1 -ne $null)[0]
+$env:XDG_CONFIG_HOME = ($env:XDG_CONFIG_HOME, "$LOCALAPPDATA", 1 -ne $null)[0]
+$env:XDG_CACHE_HOME = ($env:XDG_CACHE_HOME, "$TEMP", 1 -ne $null)[0]
+
+$env:LUNARVIM_RUNTIME_DIR = ($env:LUNARVIM_RUNTIME_DIR, "$env:XDG_DATA_HOME\lunarvim", 1 -ne $null)[0]
+$env:LUNARVIM_CONFIG_DIR = ($env:LUNARVIM_CONFIG_DIR, "$env:XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]
+$env:LUNARVIM_CACHE_DIR = ($env:LUNARVIM_CACHE_DIR, "$env:XDG_CACHE_HOME\lvim", 1 -ne $null)[0]
+
+nvim -u "$env:LUNARVIM_RUNTIME_DIR\lvim\init.lua"

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -16,22 +16,22 @@ $LUNARVIM_RUNTIME_DIR = ($LUNARVIM_RUNTIME_DIR, "$XDG_DATA_HOME\lunarvim", 1 -ne
 $LUNARVIM_CONFIG_DIR = ($LUNARVIM_CONFIG_DIR, "$XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]
 
 $__lvim_dirs = (
-	"$LUNARVIM_CONFIG_DIR",
-	"$LUNARVIM_RUNTIME_DIR",
-	"$NEOVIM_CACHE_DIR" # for now this is shared with neovim
+    "$LUNARVIM_CONFIG_DIR",
+    "$LUNARVIM_RUNTIME_DIR",
+    "$NEOVIM_CACHE_DIR" # for now this is shared with neovim
 )
 
 $__npm_deps = (
-	"neovim",
-	"tree-sitter-cli"
+    "neovim",
+    "tree-sitter-cli"
 )
 
 $__pip_deps = (
-	"pynvim"
+    "pynvim"
 )
 
 function main($cliargs) {
-	Write-Output "  
+    Write-Output "  
 
 		88\                                                   88\               
 		88 |                                                  \__|              
@@ -44,162 +44,205 @@ function main($cliargs) {
   
   "
   
-	__add_separator "80"
+    __add_separator "80"
   
-	# skip this in a Github workflow
-	if ( $null -eq "$GITHUB_ACTIONS" ) {
-		check_system_deps
-  
-		__add_separator "80"
+    # skip this in a Github workflow
+    if ( $null -eq "$GITHUB_ACTIONS" ) {
+        install_packer
+        setup_shim
+        exit
+    }
 
-		<# Write-Output "Would you like to check lunarvim's NodeJS dependencies?"
-		$answer = Read-Host "[y]es or [n]o (default: no) "
-		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
-			install_nodejs_deps
-		} 
+    __add_separator "80"
+
+    check_system_deps
+
+    Write-Output "Would you like to check lunarvim's NodeJS dependencies?"
+    $answer = Read-Host "[y]es or [n]o (default: no) "
+    if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+        install_nodejs_deps
+    } 
+
+    Write-Output "Would you like to check lunarvim's Python dependencies?"
+    $answer = Read-Host "[y]es or [n]o (default: no) "
+    if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+        install_python_deps
+    } 
+
+    __add_separator "80"
+
+    Write-Output "Backing up old LunarVim configuration"
+    backup_old_config
+
+    __add_separator "80" 
   
-		Write-Output "Would you like to check lunarvim's Python dependencies?"
-		$answer = Read-Host "[y]es or [n]o (default: no) "
-		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
-			install_python_deps
-		} 
-	    
-		Write-Output "Would you like to check lunarvim's Rust dependencies?"
-		$answer = Read-Host "[y]es or [n]o (default: no) "
-		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
-			install_rust_deps
-		} 
-  
-		__add_separator "80"
-  
-		Write-Output "Backing up old LunarVim configuration"
-		backup_old_config
-  
-		__add_separator "80" #>
-  
-	}
-  
-	if ($cliargs.Contains("--overwrite")) {
-		Write-Output "!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag"
-		$answer = Read-Host "Would you like to continue? [y]es or [n]o "
-		if ("$answer" -ne "y" -and "$answer" -ne "Y") {
-			exit 1
-		} 
+    if ($cliargs.Contains("--overwrite")) {
+        Write-Output "!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag"
+        $answer = Read-Host "Would you like to continue? [y]es or [n]o "
+        if ("$answer" -ne "y" -and "$answer" -ne "Y") {
+            exit 1
+        } 
 		
-		foreach ($dir in $__lvim_dirs) {
-			if (Test-Path "$dir") {
-				Remove-Item -Force -Recurse "$dir"
-			}
-		}
-	}
+        foreach ($dir in $__lvim_dirs) {
+            if (Test-Path "$dir") {
+                Remove-Item -Force -Recurse "$dir"
+            }
+        }
+    }
   
-	if (Test-Path "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim") {
-		Write-Output "Packer already installed"
-	}
-	else {
-		install_packer
-	}
+    if (Test-Path "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim") {
+        Write-Output "Packer already installed"
+    }
+    else {
+        install_packer
+    }
   
-	__add_separator "80"
+    __add_separator "80"
   
-	if (Test-Path "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" ) {
-		Write-Output "Updating LunarVim"
-		update_lvim
-	}
-	else {
-		if ($cliargs.Contains("--testing")) {
-			copy_local_lvim_repository
-		}
-		else {
-			clone_lvim
-		}
-		setup_lvim
-	}
+    if (Test-Path "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" ) {
+        Write-Output "Updating LunarVim"
+        update_lvim
+    }
+    else {
+        if ($cliargs.Contains("--testing")) {
+            copy_local_lvim_repository
+        }
+        else {
+            clone_lvim
+        }
+        setup_lvim
+    }
   
-	__add_separator "80"
-  
+    __add_separator "80"
 }
 
 function print_missing_dep_msg($dep) {
-	Write-Output "[ERROR]: Unable to find dependency [$dep]"
-	Write-Output "Please install it first and re-run the installer. Try: $RECOMMEND_INSTALL $dep"
+    Write-Output "[ERROR]: Unable to find dependency [$dep]"
+    Write-Output "Please install it first and re-run the installer. Try: $RECOMMEND_INSTALL $dep"
 }
-  
 
-function check_dep($dep) {
-	try { 
-		Get-Command -Name $dep -ErrorAction Stop | Out-Null 
-	}
-	catch { 
-		print_missing_dep_msg $dep
-		exit 1
-	}
+function install_system_package($dep) {
+    if (Get-Command -Name "winget" -ErrorAction SilentlyContinue) {
+        Write-Output "[INFO]: Attempting to install dependency [$dep] with winget"
+        $install_cmd = "winget install --interactive"
+    }
+    elseif (Get-Command -Name "scoop" -ErrorAction SilentlyContinue) {
+        Write-Output "[INFO]: Attempting to install dependency [$dep] with scoop"
+        # TODO: check if it's fine to not run it with --global
+        $install_cmd = "scoop install"
+    }
+    else {
+        print_missing_dep_msg "$dep"
+        exit 1
+    }
+
+    try {
+        Invoke-Command $install_cmd $dep -ErrorAction Stop
+    }
+    catch {
+        print_missing_dep_msg "$dep"
+        exit 1
+    }
+}
+
+function check_system_dep($dep) {
+    try { 
+        Get-Command -Name $dep -ErrorAction Stop | Out-Null 
+    }
+    catch { 
+        install_system_package "$dep"
+    }
 }
 
 function check_system_deps() {
-	check_dep "git"
-	check_dep "nvim"
+    Write-Output "[INFO]: Checking dependencies.."
+    check_system_dep "git"
+    check_system_dep "nvim"
+	
+}
+
+function install_nodejs_deps() {
+    try {
+        check_system_dep "node"
+        Invoke-Command npm install -g neovim tree-sitter-cli  -ErrorAction Break
+    }
+    catch {
+        print_missing_dep_msg "$dep"
+    }
+}
+
+function install_python_deps() {
+    try {
+        check_system_dep "pip"
+        Invoke-Command python -m pip install --user pynvim -ErrorAction Break
+    }
+    catch {
+        print_missing_dep_msg "$dep"
+    }
 }
 
 function backup_old_config() {
-	foreach ($dir in $__lvim_dirs) {
-		# we create an empty folder for subsequent commands \
-		# that require an existing directory	  
-		New-Item "$dir.bak" -ItemType "directory"
-		Copy-Item -Recurse "$dir\*" "$dir.bak\."
-	}
+    foreach ($dir in $__lvim_dirs) {
+        # we create an empty folder for subsequent commands \
+        # that require an existing directory	 
+        if ( Test-Path "$dir") {
+            New-Item "$dir.bak" -ItemType "directory"
+            Copy-Item -Recurse "$dir\*" "$dir.bak\." -
+        }
+    }
 
-	Write-Output "Backup operation complete"
+    Write-Output "Backup operation complete"
 }
 
 
 function install_packer() {
-	git clone --progress --depth 1 "https://github.com/wbthomason/packer.nvim" "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim"
+    Invoke-Command -ErrorAction Stop -ScriptBlock { git clone --progress --depth 1 "https://github.com/wbthomason/packer.nvim" "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim" }
 }
   
 function copy_local_lvim_repository() {
-	Write-Output "Copy local LunarVim configuration"
-	Copy-Item -Path "$((Get-Item $PWD).Parent.Parent.FullName)" -Destination "$LUNARVIM_RUNTIME_DIR/lvim" -Recurse
+    Write-Output "Copy local LunarVim configuration"
+    Copy-Item -Path "$((Get-Item $PWD).Parent.Parent.FullName)" -Destination "$LUNARVIM_RUNTIME_DIR/lvim" -Recurse
 }
 
 function clone_lvim() {
-	Write-Output "Cloning LunarVim configuration"
-	try {
-		git clone --progress --branch "$LV_BRANCH" --depth 1 "https://github.com/${LV_REMOTE}" "$LUNARVIM_RUNTIME_DIR/lvim" 
-	}
-	catch {
-		Write-Output "Failed to clone repository. Installation failed."
-		exit 1		
-	}
+    Write-Output "Cloning LunarVim configuration"
+    try {
+        Invoke-Command -ErrorAction Stop -ScriptBlock { git clone --progress --branch "$LV_BRANCH" --depth 1 "https://github.com/$LV_REMOTE" "$LUNARVIM_RUNTIME_DIR/lvim" } 
+    }
+    catch {
+        Write-Output "Failed to clone repository. Installation failed."
+        exit 1		
+    }
 }
 
 function setup_shim() {
-	if ((Test-Path "$INSTALL_PREFIX\bin") -eq $false) {
-		New-Item "$INSTALL_PREFIX\bin" -ItemType "directory" | Out-Null
-	}
+    if ((Test-Path "$INSTALL_PREFIX\bin") -eq $false) {
+        New-Item "$INSTALL_PREFIX\bin" -ItemType "directory"
+    }
 
-	Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" -Value (`
-	"New-Variable -Name LUNARVIM_CONFIG_DIR -Value `"$LUNARVIM_CONFIG_DIR`"`n" +`
-	"New-Variable -Name LUNARVIM_RUNTIME_DIR -Value `"$LUNARVIM_RUNTIME_DIR`"`n`n" +`
-	"nvim -u `"$LUNARVIM_RUNTIME_DIR\lvim\init.lua`" " + '$args')
+    Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" ("
+		New-Variable -Name LUNARVIM_CONFIG_DIR -Value '$LUNARVIM_CONFIG_DIR'
+		New-Variable -Name LUNARVIM_RUNTIME_DIR -Value '$LUNARVIM_RUNTIME_DIR'
+		
+		nvim -u '$LUNARVIM_RUNTIME_DIR\lvim\init.lua' ", '"', "$args", '"')
 }
 
 function setup_lvim() {
-	Write-Output "Installing LunarVim shim"
+    Write-Output "Installing LunarVim shim"
   
-	setup_shim
+    setup_shim
   
-	Write-Output "Preparing Packer setup"
+    Write-Output "Preparing Packer setup"
 
-	if ((Test-Path "$LUNARVIM_CONFIG_DIR") -eq $false) {
-		New-Item "$LUNARVIM_CONFIG_DIR" -ItemType "directory"
-	}
+    if ((Test-Path "$LUNARVIM_CONFIG_DIR") -eq $false) {
+        New-Item "$LUNARVIM_CONFIG_DIR" -ItemType "directory"
+    }
 
-	Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example-no-ts.lua" `
-		"$LUNARVIM_CONFIG_DIR\config.lua"
+    Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example-no-ts.lua" `
+        "$LUNARVIM_CONFIG_DIR\config.lua"
   
-	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerInstall
-	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerSync
+    nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerInstall
+    nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerSync
   
 	Write-Output "Packer setup complete"
 	
@@ -216,27 +259,27 @@ function setup_lvim() {
 
 	__add_separator "80"
 
-	Write-Output "Thank you for installing LunarVim!!"
-	Write-Output "You can start it by running: $INSTALL_PREFIX\bin\lvim.ps1"
-	Write-Output "Do not forget to use a font with glyphs (icons) support [https://github.com/ryanoasis/nerd-fonts]"
+    Write-Output "Thank you for installing LunarVim!!"
+    Write-Output "You can start it by running: $INSTALL_PREFIX\bin\lvim.ps1"
+    Write-Output "Do not forget to use a font with glyphs (icons) support [https://github.com/ryanoasis/nerd-fonts]"
 }
 
 
 function update_lvim() {
-	try {
-		git -C "$LUNARVIM_RUNTIME_DIR/lvim" status -uno
-	}
-	catch {
-		git -C "$LUNARVIM_RUNTIME_DIR/lvim" pull --ff-only --progress -or
-		Write-Output "Unable to guarantee data integrity while updating. Please do that manually instead."
-		exit 1
-	}
-	Write-Output "Your LunarVim installation is now up to date!"
+    try {
+        Invoke-Command git -C "$LUNARVIM_RUNTIME_DIR/lvim" status -uno
+    }
+    catch {
+        git -C "$LUNARVIM_RUNTIME_DIR/lvim" pull --ff-only --progress -or
+        Write-Output "Unable to guarantee data integrity while updating. Please do that manually instead."
+        exit 1
+    }
+    Write-Output "Your LunarVim installation is now up to date!"
 }
 
 function __add_separator($div_width) {
-	"-" * $div_width
-	Write-Output ""
+    "-" * $div_width
+    Write-Output ""
 }
 
 function create_alias {

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -1,0 +1,155 @@
+#Set Variable to master is not set differently
+if ($null -eq $LVBRANCH) {
+    $LVBRANCH = "master"
+}
+
+#set -o nounset # error when referencing undefined variable
+$ErrorActionPreference = "Stop" # exit when command fails
+
+function mkdirondemand($path) {
+	if ((Test-Path $path) -eq $false) {
+		mkdir $path
+	}
+}
+
+function commandinstalled($cmd){
+	try { Get-Command $cmd > $null }
+	catch { return $false }
+	return $true
+}
+
+function moveoldlvim {
+	Write-Output "Not installing LunarVim"
+	Write-Output "Please move your $HOME\.local\share\lunarvim folder before installing"
+	exit
+}
+
+function asktoinstallpip {
+	Write-Output "Please install pip3 before continuing with install"
+	exit
+}
+
+function installnode {
+	if ((commandinstalled("winget.exe")) -eq $false) {
+		Write-Output "winget is not installed, but is the only package manager currently supported."
+		Write-Output "node is not installed. Please install it manually"
+		exit
+	}
+	winget.exe install "OpenJS.NodeJSLTS"
+}
+
+function asktoinstallnode {
+	Write-Output "node not found"
+	$answer = Read-Host "Would you like to install node now (y/n)" -Confirm
+	if($answer.ToLower() -eq 'y') {
+		installnode
+	}
+}
+
+function installpynvim {
+	Write-Output "Installing pynvim..."
+	pip3.exe install pynvim --user
+}
+
+function installpacker {
+	git clone https://github.com/wbthomason/packer.nvim ${HOME}/.local/share/lunarvim/site/pack/packer/start/packer.nvim
+}
+
+function modifyhomevar($config) {
+	
+	Copy-Item $config $config".save"
+	(Get-Content -Path $config) |
+		ForEach-Object {$_ -Replace 'os.getenv "HOME"', 'os.getenv "HOMEDRIVE" .. os.getenv "HOMEPATH"'} |
+			Set-Content -Path $config
+}
+
+function cloneconfig($arg) {
+	Write-Output "Cloning LunarVim configuration"
+	mkdirondemand("$HOME/.local/share/lunarvim")
+	
+	if ($arg.Contains("--testing")) {
+		Copy-Item -Recurse "${pwd}" "$HOME/.local/share/lunarvim/lvim"
+	} else {
+		Write-Output "lvbranch=$LVBRANCH"
+		git clone --branch "$LVBRANCH" https://github.com/ChristianChiarulli/lunarvim.git "$HOME/.local/share/lunarvim/lvim"
+	}
+
+	mkdirondemand("$HOME/.config/lvim")
+	
+	if (($env:Path.Contains("$HOME/.local/share/lunarvim/lvim/utils/bin/")) -eq $false) {
+		$env:Path += ";$HOME/.local/share/lunarvim/lvim/utils/bin/"
+		[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User)
+	}
+	
+	# Hack because in rolling branch lv-config.lua is renamed to config.lua
+	if ($LVBRANCH -eq "rolling") {
+		Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/config.example-no-ts.lua" "$HOME/.config/lvim/config.lua"
+	} else {
+		Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/lv-config.example-no-ts.lua" "$HOME/.config/lvim/lv-config.lua"
+	}
+
+	modifyhomevar("$HOME/.local/share/lunarvim/lvim/lua/default-config.lua")
+	modifyhomevar("$HOME/.local/share/lunarvim/lvim/init.lua")
+
+	nvim -u $HOME/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=$HOME/.local/share/lunarvim/lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerInstall
+	nvim -u $HOME/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=$HOME/.local/share/lunarvim/lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerSync
+
+	Write-Output ""
+	Write-Output "Compile Complete"
+	Write-Output ""
+
+	if (Test-Path "$HOME/.local/share/lunarvim/lvim/init.lua" -PathType Any) {
+		Write-Output "lv-config already present"
+	} else {
+		if($LVBRANCH -eq "rolling") {
+			Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/config.example.lua" "$HOME/.config/lvim/config.lua"
+		} else {
+			Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/lv-config.example.lua" "$HOME/.config/lvim/lv-config.lua"
+		}
+	}
+}
+
+function rewritelvimforwindows {
+	Set-Content "$HOME/.local/share/lunarvim/lvim/utils/bin/lvim.ps1" 'nvim -u "$HOME/.local/share/lunarvim/lvim/init.lua" --cmd "set runtimepath+=$HOME/.local/share/lunarvim/lvim" "$args"'
+}
+
+# Welcome
+Write-Output 'Installing LunarVim'
+if ($args.Contains("--override")) {
+    Write-Output '!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag'
+	Remove-Item -Recurse -Force "$HOME/.local/share/lunarvim" -ErrorAction Ignore
+	Remove-Item -Recurse -Force "$HOME/.cache/nvim" -ErrorAction Ignore
+	Remove-Item -Recurse -Force "$HOME/.config/lvim" -ErrorAction Ignore
+}
+
+# move old lvim directory if it exists
+if (Test-Path -Path "$HOME/.local/share/lunarvim") { moveoldlvim }
+
+# install pip
+if (commandinstalled("pip3.exe")){ Write-Output "pip installed, moving on..." } 
+else { asktoinstallpip }
+
+# install node
+if (commandinstalled("node.exe")) { Write-Output "node installed, moving on..." }
+else { asktoinstallnode }
+
+# install pynvim
+if ($null -ne (pip3.exe list | Select-String "pynvim")) { Write-Output "pynvim installed, moving on..." }
+else { installpynvim }
+
+if ((Test-Path "$HOME/.local/share/lunarvim/site/pack/packer/start/packer.nvim" -PathType Any)) {
+	Write-Output "packer already installed"
+} else {
+	installpacker
+}
+
+if ((Test-Path "$HOME/.local/share/lunarvim/lvim/init.lua" -PathType Any)) {
+	Write-Output "LunarVim already installed"
+} else {
+	# clone config down
+	cloneconfig($args)
+}
+
+rewritelvimforwindows
+
+Write-Output "I recommend you also install and activate a font from here: https://github.com/ryanoasis/nerd-fonts"

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -226,9 +226,6 @@ function setup_lvim() {
     Copy-Item "$env:LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example-no-ts.lua" `
         "$env:LUNARVIM_CONFIG_DIR\config.lua"
   
-    nvim -u "$env:LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerInstall
-    nvim -u "$env:LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerSync
-  
 	Write-Output "Packer setup complete"
 	
 	__add_separator "80"

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -1,7 +1,8 @@
 $ErrorActionPreference = "Stop" # exit when command fails
 
 # set script variables
-$LV_BRANCH = ($LV_BRANCH, "rolling", 1 -ne $null)[0]
+# FIXME: temporarily set the branch to the new one
+$LV_BRANCH = ($LV_BRANCH, "lang-refactor", 1 -ne $null)[0]
 $LV_REMOTE = ($LV_REMOTE, "lunarvim/lunarvim.git", 1 -ne $null)[0]
 $INSTALL_PREFIX = ($INSTALL_PREFIX, "$HOME\.local", 1 -ne $null)[0]
 

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -71,7 +71,7 @@ function cloneconfig($arg) {
 		Copy-Item -Recurse "${pwd}" "$HOME/.local/share/lunarvim/lvim"
 	} else {
 		Write-Output "lvbranch=$LVBRANCH"
-		git clone --branch "$LVBRANCH" https://github.com/ChristianChiarulli/lunarvim.git "$HOME/.local/share/lunarvim/lvim"
+		git clone --branch "$LVBRANCH" https://github.com/LunarVim/LunarVim.git "$HOME/.local/share/lunarvim/lvim"
 	}
 
 	mkdirondemand("$HOME/.config/lvim")

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -202,7 +202,7 @@ function setup_lvim() {
 	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerSync
   
 	Write-Output "Packer setup complete"
-  
+	
 	__add_separator "80"
 
 	Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example.lua" "$LUNARVIM_CONFIG_DIR\config.lua"
@@ -242,7 +242,7 @@ function __add_separator($div_width) {
 function create_alias {
 	if($null -eq $(Get-Alias | Select-String "lvim")){
 		Add-Content -Path $PROFILE -Value $(-join @('Set-Alias lvim "', "$INSTALL_PREFIX", '\bin\lvim.ps1"'))
-
+		
 		Write-Output ""
 		Write-Host 'To use the new alias in this window reload your profile with ". $PROFILE".' -ForegroundColor Yellow
 
@@ -251,6 +251,5 @@ function create_alias {
 	}
 }
 
-append_to_path
-#main "$args"
+main "$args"
 

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -178,11 +178,10 @@ function setup_shim() {
 		New-Item "$INSTALL_PREFIX\bin" -ItemType "directory" | Out-Null
 	}
 
-	Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" ("
-		New-Variable -Name LUNARVIM_CONFIG_DIR -Value '$LUNARVIM_CONFIG_DIR'
-		New-Variable -Name LUNARVIM_RUNTIME_DIR -Value '$LUNARVIM_RUNTIME_DIR'
-		
-		nvim -u '$LUNARVIM_RUNTIME_DIR\lvim\init.lua' ", '"', "$args", '"')
+	Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" -Value (`
+	"New-Variable -Name LUNARVIM_CONFIG_DIR -Value `"$LUNARVIM_CONFIG_DIR`"`n" +`
+	"New-Variable -Name LUNARVIM_RUNTIME_DIR -Value `"$LUNARVIM_RUNTIME_DIR`"`n`n" +`
+	"nvim -u `"$LUNARVIM_RUNTIME_DIR\lvim\init.lua`" " + '$args')
 }
 
 function setup_lvim() {

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -175,7 +175,7 @@ function clone_lvim() {
 
 function setup_shim() {
 	if ((Test-Path "$INSTALL_PREFIX\bin") -eq $false) {
-		New-Item "$INSTALL_PREFIX\bin" -ItemType "directory"
+		New-Item "$INSTALL_PREFIX\bin" -ItemType "directory" | Out-Null
 	}
 
 	Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" ("

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -1,61 +1,42 @@
-#Set Variable to master is not set differently
+# set script variables
+$XDG_CONFIG_HOME="$HOME\.config"
+$XDG_DATA_HOME="$HOME\.local\share"
+$XDG_CACHE_HOME=$env:TEMP
+
+# Set Variable to master if not set differently
 if ($null -eq $LVBRANCH) {
     $LVBRANCH = "master"
 }
 
-#set -o nounset # error when referencing undefined variable
 $ErrorActionPreference = "Stop" # exit when command fails
 
-function mkdirondemand($path) {
+function mkdirOnDemand($path) {
 	if ((Test-Path $path) -eq $false) {
 		mkdir $path
 	}
 }
 
-function commandinstalled($cmd){
-	try { Get-Command $cmd > $null }
-	catch { return $false }
-	return $true
+function verifyInstalled($cmd){
+	try { Get-Command -Name $cmd -ErrorAction Stop | Out-Null }
+	catch { "Error! command [$cmd] is not found, please install and try again." }
 }
 
-function moveoldlvim {
+function moveOldLvim {
 	Write-Output "Not installing LunarVim"
-	Write-Output "Please move your $HOME\.local\share\lunarvim folder before installing"
+	Write-Output "Please move your $XDG_DATA_HOME\lunarvim folder before installing"
 	exit
 }
 
-function asktoinstallpip {
-	Write-Output "Please install pip3 before continuing with install"
-	exit
-}
-
-function installnode {
-	if ((commandinstalled("winget.exe")) -eq $false) {
-		Write-Output "winget is not installed, but is the only package manager currently supported."
-		Write-Output "node is not installed. Please install it manually"
-		exit
-	}
-	winget.exe install "OpenJS.NodeJSLTS"
-}
-
-function asktoinstallnode {
-	Write-Output "node not found"
-	$answer = Read-Host "Would you like to install node now (y/n)" -Confirm
-	if($answer.ToLower() -eq 'y') {
-		installnode
-	}
-}
-
-function installpynvim {
+function installPynvim {
 	Write-Output "Installing pynvim..."
 	pip3.exe install pynvim --user
 }
 
-function installpacker {
-	git clone https://github.com/wbthomason/packer.nvim ${HOME}/.local/share/lunarvim/site/pack/packer/start/packer.nvim
+function installPacker {
+	git clone "https://github.com/wbthomason/packer.nvim" "$XDG_DATA_HOME\lunarvim\site\pack\packer\start\packer.nvim"
 }
 
-function modifyhomevar($config) {
+function modifyHomeVar($config) {
 	
 	Copy-Item $config $config".save"
 	(Get-Content -Path $config) |
@@ -63,93 +44,93 @@ function modifyhomevar($config) {
 			Set-Content -Path $config
 }
 
-function cloneconfig($arg) {
+function cloneConfig($arg) {
 	Write-Output "Cloning LunarVim configuration"
-	mkdirondemand("$HOME/.local/share/lunarvim")
+	mkdirOnDemand("$XDG_DATA_HOME\lunarvim")
 	
 	if ($arg.Contains("--testing")) {
-		Copy-Item -Recurse "${pwd}" "$HOME/.local/share/lunarvim/lvim"
+		Copy-Item -Recurse "$pwd" "$XDG_DATA_HOME\lunarvim\lvim"
 	} else {
 		Write-Output "lvbranch=$LVBRANCH"
-		git clone --branch "$LVBRANCH" https://github.com/LunarVim/LunarVim.git "$HOME/.local/share/lunarvim/lvim"
+		git clone --branch "$LVBRANCH" "https://github.com/LunarVim/LunarVim.git" "$XDG_DATA_HOME\lunarvim\lvim"
 	}
 
-	mkdirondemand("$HOME/.config/lvim")
+	mkdirOnDemand("$XDG_CONFIG_HOME\lvim")
 	
-	if (($env:Path.Contains("$HOME/.local/share/lunarvim/lvim/utils/bin/")) -eq $false) {
-		$env:Path += ";$HOME/.local/share/lunarvim/lvim/utils/bin/"
+	if (($env:Path.Contains("$XDG_DATA_HOME\lunarvim\lvim\utils\bin\")) -eq $false) {
+		$env:Path += ";$XDG_DATA_HOME\lunarvim\lvim\utils\bin\"
 		[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User)
 	}
 	
 	# Hack because in rolling branch lv-config.lua is renamed to config.lua
 	if ($LVBRANCH -eq "rolling") {
-		Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/config.example-no-ts.lua" "$HOME/.config/lvim/config.lua"
+		Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\config.example-no-ts.lua" "$XDG_CONFIG_HOME\lvim\config.lua"
 	} else {
-		Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/lv-config.example-no-ts.lua" "$HOME/.config/lvim/lv-config.lua"
+		Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\lv-config.example-no-ts.lua" "$XDG_CONFIG_HOME\lvim\lv-config.lua"
 	}
 
-	modifyhomevar("$HOME/.local/share/lunarvim/lvim/lua/default-config.lua")
-	modifyhomevar("$HOME/.local/share/lunarvim/lvim/init.lua")
+	modifyHomeVar("$XDG_DATA_HOME\lunarvim\lvim\lua\default-config.lua")
+	modifyHomeVar("$XDG_DATA_HOME\lunarvim\lvim\init.lua")
 
-	nvim -u $HOME/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=$HOME/.local/share/lunarvim/lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerInstall
-	nvim -u $HOME/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=$HOME/.local/share/lunarvim/lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerSync
+	nvim -u $XDG_DATA_HOME\lunarvim\lvim\init.lua --cmd "set runtimepath+=$XDG_DATA_HOME\lunarvim\lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerInstall
+	nvim -u $XDG_DATA_HOME\lunarvim\lvim\init.lua --cmd "set runtimepath+=$XDG_DATA_HOME\lunarvim\lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerSync
 
 	Write-Output ""
 	Write-Output "Compile Complete"
 	Write-Output ""
 
-	if (Test-Path "$HOME/.local/share/lunarvim/lvim/init.lua" -PathType Any) {
+	if (Test-Path "$XDG_DATA_HOME\lunarvim\lvim\init.lua" -PathType Any) {
 		Write-Output "lv-config already present"
 	} else {
 		if($LVBRANCH -eq "rolling") {
-			Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/config.example.lua" "$HOME/.config/lvim/config.lua"
+			Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\config.example.lua" "$XDG_CONFIG_HOME\lvim\config.lua"
 		} else {
-			Copy-Item "$HOME/.local/share/lunarvim/lvim/utils/installer/lv-config.example.lua" "$HOME/.config/lvim/lv-config.lua"
+			Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\lv-config.example.lua" "$XDG_CONFIG_HOME\lvim\lv-config.lua"
 		}
 	}
 }
 
-function rewritelvimforwindows {
-	Set-Content "$HOME/.local/share/lunarvim/lvim/utils/bin/lvim.ps1" 'nvim -u "$HOME/.local/share/lunarvim/lvim/init.lua" --cmd "set runtimepath+=$HOME/.local/share/lunarvim/lvim" "$args"'
+function rewriteLvimForWindows {
+	Set-Content "$XDG_DATA_HOME\lunarvim\lvim\utils\bin\lvim.ps1" "nvim -u `"$XDG_DATA_HOME\lunarvim\lvim\init.lua`" --cmd `"set runtimepath+=$XDG_DATA_HOME\lunarvim\lvim`" `"$args`""
 }
 
 # Welcome
 Write-Output 'Installing LunarVim'
 if ($args.Contains("--override")) {
     Write-Output '!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag'
-	Remove-Item -Recurse -Force "$HOME/.local/share/lunarvim" -ErrorAction Ignore
-	Remove-Item -Recurse -Force "$HOME/.cache/nvim" -ErrorAction Ignore
-	Remove-Item -Recurse -Force "$HOME/.config/lvim" -ErrorAction Ignore
+	Remove-Item -Recurse -Force "$XDG_DATA_HOME\lunarvim" -ErrorAction Ignore
+	Remove-Item -Recurse -Force "$XDG_CACHE_HOME\nvim" -ErrorAction Ignore
+	Remove-Item -Recurse -Force "$XDG_CONFIG_HOME\lvim" -ErrorAction Ignore
 }
 
 # move old lvim directory if it exists
-if (Test-Path -Path "$HOME/.local/share/lunarvim") { moveoldlvim }
+if (Test-Path -Path "$XDG_DATA_HOME\lunarvim") { moveOldLvim }
 
 # install pip
-if (commandinstalled("pip3.exe")){ Write-Output "pip installed, moving on..." } 
-else { asktoinstallpip }
+verifyInstalled("pip3.exe")
+Write-Output "pip installed, moving on..."
 
 # install node
-if (commandinstalled("node.exe")) { Write-Output "node installed, moving on..." }
-else { asktoinstallnode }
+verifyInstalled("node.exe")
+Write-Output "node installed, moving on..."
 
 # install pynvim
 if ($null -ne (pip3.exe list | Select-String "pynvim")) { Write-Output "pynvim installed, moving on..." }
-else { installpynvim }
+else { installPynvim }
 
-if ((Test-Path "$HOME/.local/share/lunarvim/site/pack/packer/start/packer.nvim" -PathType Any)) {
+if ((Test-Path "$XDG_DATA_HOME\lunarvim\site\pack\packer\start\packer.nvim" -PathType Any)) {
 	Write-Output "packer already installed"
 } else {
-	installpacker
+	installPacker
 }
 
-if ((Test-Path "$HOME/.local/share/lunarvim/lvim/init.lua" -PathType Any)) {
+if ((Test-Path "$XDG_DATA_HOME\lunarvim\lvim\init.lua" -PathType Any)) {
 	Write-Output "LunarVim already installed"
 } else {
 	# clone config down
-	cloneconfig($args)
+	cloneConfig($args)
 }
 
-rewritelvimforwindows
+rewriteLvimForWindows
 
 Write-Output "I recommend you also install and activate a font from here: https://github.com/ryanoasis/nerd-fonts"

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -1,136 +1,275 @@
-# set script variables
-$XDG_CONFIG_HOME="$HOME\.config"
-$XDG_DATA_HOME="$HOME\.local\share"
-$XDG_CACHE_HOME=$env:TEMP
-
-# Set Variable to master if not set differently
-if ($null -eq $LVBRANCH) {
-    $LVBRANCH = "master"
-}
-
 $ErrorActionPreference = "Stop" # exit when command fails
 
-function mkdirOnDemand($path) {
-	if ((Test-Path $path) -eq $false) {
-		mkdir $path
+# set script variables
+$LV_BRANCH = ($LV_BRANCH, "rolling", 1 -ne $null)[0]
+$LV_REMOTE = ($LV_REMOTE, "lunarvim/lunarvim.git", 1 -ne $null)[0]
+$INSTALL_PREFIX = ($INSTALL_PREFIX, "$HOME\.local", 1 -ne $null)[0]
+
+$XDG_DATA_HOME = ($XDG_DATA_HOME, "$HOME\.local\share", 1 -ne $null)[0]
+$XDG_CACHE_HOME = ($XDG_CACHE_HOME, "$HOME\.cache", 1 -ne $null)[0]
+$XDG_CONFIG_HOME = ($XDG_CONFIG_HOME, "$HOME\.config", 1 -ne $null)[0]
+
+$NEOVIM_CACHE_DIR = "$XDG_CACHE_HOME\nvim"
+
+
+$LUNARVIM_RUNTIME_DIR = ($LUNARVIM_RUNTIME_DIR, "$XDG_DATA_HOME\lunarvim", 1 -ne $null)[0]
+$LUNARVIM_CONFIG_DIR = ($LUNARVIM_CONFIG_DIR, "$XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]
+
+$__lvim_dirs = (
+	"$LUNARVIM_CONFIG_DIR",
+	"$LUNARVIM_RUNTIME_DIR",
+	"$NEOVIM_CACHE_DIR" # for now this is shared with neovim
+)
+
+$__npm_deps = (
+	"neovim",
+	"tree-sitter-cli"
+)
+
+$__pip_deps = (
+	"pynvim"
+)
+
+function main($cliargs) {
+	Write-Output "  
+
+		88\                                                   88\               
+		88 |                                                  \__|              
+		88 |88\   88\ 888888$\   888888\   888888\ 88\    88\ 88\ 888888\8888\  
+		88 |88 |  88 |88  __88\  \____88\ 88  __88\\88\  88  |88 |88  _88  _88\ 
+		88 |88 |  88 |88 |  88 | 888888$ |88 |  \__|\88\88  / 88 |88 / 88 / 88 |
+		88 |88 |  88 |88 |  88 |88  __88 |88 |       \88$  /  88 |88 | 88 | 88 |
+		88 |\888888  |88 |  88 |\888888$ |88 |        \$  /   88 |88 | 88 | 88 |
+		\__| \______/ \__|  \__| \_______|\__|         \_/    \__|\__| \__| \__|
+  
+  "
+  
+	__add_separator "80"
+  
+	# skip this in a Github workflow
+	if ( $null -eq "$GITHUB_ACTIONS" ) {
+		check_system_deps
+  
+		__add_separator "80"
+
+		<# Write-Output "Would you like to check lunarvim's NodeJS dependencies?"
+		$answer = Read-Host "[y]es or [n]o (default: no) "
+		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+			install_nodejs_deps
+		} 
+  
+		Write-Output "Would you like to check lunarvim's Python dependencies?"
+		$answer = Read-Host "[y]es or [n]o (default: no) "
+		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+			install_python_deps
+		} 
+	    
+		Write-Output "Would you like to check lunarvim's Rust dependencies?"
+		$answer = Read-Host "[y]es or [n]o (default: no) "
+		if ("$answer" -eq "y" -or "$answer" -eq "Y") {
+			install_rust_deps
+		} 
+  
+		__add_separator "80"
+  
+		Write-Output "Backing up old LunarVim configuration"
+		backup_old_config
+  
+		__add_separator "80" #>
+  
 	}
-}
-
-function verifyInstalled($cmd){
-	try { Get-Command -Name $cmd -ErrorAction Stop | Out-Null }
-	catch { "Error! command [$cmd] is not found, please install and try again." }
-}
-
-function moveOldLvim {
-	Write-Output "Not installing LunarVim"
-	Write-Output "Please move your $XDG_DATA_HOME\lunarvim folder before installing"
-	exit
-}
-
-function installPynvim {
-	Write-Output "Installing pynvim..."
-	pip3.exe install pynvim --user
-}
-
-function installPacker {
-	git clone "https://github.com/wbthomason/packer.nvim" "$XDG_DATA_HOME\lunarvim\site\pack\packer\start\packer.nvim"
-}
-
-function modifyHomeVar($config) {
-	
-	Copy-Item $config $config".save"
-	(Get-Content -Path $config) |
-		ForEach-Object {$_ -Replace 'os.getenv "HOME"', 'os.getenv "HOMEDRIVE" .. os.getenv "HOMEPATH"'} |
-			Set-Content -Path $config
-}
-
-function cloneConfig($arg) {
-	Write-Output "Cloning LunarVim configuration"
-	mkdirOnDemand("$XDG_DATA_HOME\lunarvim")
-	
-	if ($arg.Contains("--testing")) {
-		Copy-Item -Recurse "$pwd" "$XDG_DATA_HOME\lunarvim\lvim"
-	} else {
-		Write-Output "lvbranch=$LVBRANCH"
-		git clone --branch "$LVBRANCH" "https://github.com/LunarVim/LunarVim.git" "$XDG_DATA_HOME\lunarvim\lvim"
-	}
-
-	mkdirOnDemand("$XDG_CONFIG_HOME\lvim")
-	
-	if (($env:Path.Contains("$XDG_DATA_HOME\lunarvim\lvim\utils\bin\")) -eq $false) {
-		$env:Path += ";$XDG_DATA_HOME\lunarvim\lvim\utils\bin\"
-		[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User)
-	}
-	
-	# Hack because in rolling branch lv-config.lua is renamed to config.lua
-	if ($LVBRANCH -eq "rolling") {
-		Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\config.example-no-ts.lua" "$XDG_CONFIG_HOME\lvim\config.lua"
-	} else {
-		Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\lv-config.example-no-ts.lua" "$XDG_CONFIG_HOME\lvim\lv-config.lua"
-	}
-
-	modifyHomeVar("$XDG_DATA_HOME\lunarvim\lvim\lua\default-config.lua")
-	modifyHomeVar("$XDG_DATA_HOME\lunarvim\lvim\init.lua")
-
-	nvim -u $XDG_DATA_HOME\lunarvim\lvim\init.lua --cmd "set runtimepath+=$XDG_DATA_HOME\lunarvim\lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerInstall
-	nvim -u $XDG_DATA_HOME\lunarvim\lvim\init.lua --cmd "set runtimepath+=$XDG_DATA_HOME\lunarvim\lvim" --headless +'autocmd User PackerComplete sleep 100m | qall' +PackerSync
-
-	Write-Output ""
-	Write-Output "Compile Complete"
-	Write-Output ""
-
-	if (Test-Path "$XDG_DATA_HOME\lunarvim\lvim\init.lua" -PathType Any) {
-		Write-Output "lv-config already present"
-	} else {
-		if($LVBRANCH -eq "rolling") {
-			Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\config.example.lua" "$XDG_CONFIG_HOME\lvim\config.lua"
-		} else {
-			Copy-Item "$XDG_DATA_HOME\lunarvim\lvim\utils\installer\lv-config.example.lua" "$XDG_CONFIG_HOME\lvim\lv-config.lua"
+  
+	if ($cliargs.Contains("--overwrite")) {
+		Write-Output "!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag"
+		$answer = Read-Host "Would you like to continue? [y]es or [n]o "
+		if ("$answer" -ne "y" -and "$answer" -ne "Y") {
+			exit 1
+		} 
+		
+		foreach ($dir in $__lvim_dirs) {
+			if (Test-Path "$dir") {
+				Remove-Item -Force -Recurse "$dir"
+			}
 		}
 	}
+  
+	if (Test-Path "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim") {
+		Write-Output "Packer already installed"
+	}
+	else {
+		install_packer
+	}
+  
+	__add_separator "80"
+  
+	if (Test-Path "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" ) {
+		Write-Output "Updating LunarVim"
+		update_lvim
+	}
+	else {
+		if ($cliargs.Contains("--testing")) {
+			copy_local_lvim_repository
+		}
+		else {
+			clone_lvim
+		}
+		setup_lvim
+	}
+  
+	__add_separator "80"
+  
 }
 
-function rewriteLvimForWindows {
-	Set-Content "$XDG_DATA_HOME\lunarvim\lvim\utils\bin\lvim.ps1" "nvim -u `"$XDG_DATA_HOME\lunarvim\lvim\init.lua`" --cmd `"set runtimepath+=$XDG_DATA_HOME\lunarvim\lvim`" `"$args`""
+function print_missing_dep_msg($dep) {
+	Write-Output "[ERROR]: Unable to find dependency [$dep]"
+	Write-Output "Please install it first and re-run the installer. Try: $RECOMMEND_INSTALL $dep"
+}
+  
+
+function check_dep($dep) {
+	try { 
+		Get-Command -Name $dep -ErrorAction Stop | Out-Null 
+	}
+	catch { 
+		print_missing_dep_msg $dep
+		exit 1
+	}
 }
 
-# Welcome
-Write-Output 'Installing LunarVim'
-if ($args.Contains("--override")) {
-    Write-Output '!!Warning!! -> Removing all lunarvim related config because of the --overwrite flag'
-	Remove-Item -Recurse -Force "$XDG_DATA_HOME\lunarvim" -ErrorAction Ignore
-	Remove-Item -Recurse -Force "$XDG_CACHE_HOME\nvim" -ErrorAction Ignore
-	Remove-Item -Recurse -Force "$XDG_CONFIG_HOME\lvim" -ErrorAction Ignore
+function check_system_deps() {
+	check_dep "git"
+	check_dep "nvim"
 }
 
-# move old lvim directory if it exists
-if (Test-Path -Path "$XDG_DATA_HOME\lunarvim") { moveOldLvim }
+function backup_old_config() {
+	foreach ($dir in $__lvim_dirs) {
+		# we create an empty folder for subsequent commands \
+		# that require an existing directory	  
+		New-Item "$dir.bak" -ItemType "directory"
+		Copy-Item -Recurse "$dir\*" "$dir.bak\."
+	}
 
-# install pip
-verifyInstalled("pip3.exe")
-Write-Output "pip installed, moving on..."
-
-# install node
-verifyInstalled("node.exe")
-Write-Output "node installed, moving on..."
-
-# install pynvim
-if ($null -ne (pip3.exe list | Select-String "pynvim")) { Write-Output "pynvim installed, moving on..." }
-else { installPynvim }
-
-if ((Test-Path "$XDG_DATA_HOME\lunarvim\site\pack\packer\start\packer.nvim" -PathType Any)) {
-	Write-Output "packer already installed"
-} else {
-	installPacker
+	Write-Output "Backup operation complete"
 }
 
-if ((Test-Path "$XDG_DATA_HOME\lunarvim\lvim\init.lua" -PathType Any)) {
-	Write-Output "LunarVim already installed"
-} else {
-	# clone config down
-	cloneConfig($args)
+
+function install_packer() {
+	git clone --progress --depth 1 "https://github.com/wbthomason/packer.nvim" "$LUNARVIM_RUNTIME_DIR\site\pack\packer\start\packer.nvim"
+}
+  
+function copy_local_lvim_repository() {
+	Write-Output "Copy local LunarVim configuration"
+	Copy-Item -Path "$((Get-Item $PWD).Parent.Parent.FullName)" -Destination "$LUNARVIM_RUNTIME_DIR/lvim" -Recurse
 }
 
-rewriteLvimForWindows
+function clone_lvim() {
+	Write-Output "Cloning LunarVim configuration"
+	try {
+		git clone --progress --branch "$LV_BRANCH" --depth 1 "https://github.com/${LV_REMOTE}" "$LUNARVIM_RUNTIME_DIR/lvim" 
+	}
+	catch {
+		Write-Output "Failed to clone repository. Installation failed."
+		exit 1		
+	}
+}
 
-Write-Output "I recommend you also install and activate a font from here: https://github.com/ryanoasis/nerd-fonts"
+function setup_shim() {
+	if ((Test-Path "$INSTALL_PREFIX\bin") -eq $false) {
+		New-Item "$INSTALL_PREFIX\bin" -ItemType "directory"
+	}
+
+	Set-Content -Path "$INSTALL_PREFIX\bin\lvim.ps1" ("
+		New-Variable -Name LUNARVIM_CONFIG_DIR -Value '$LUNARVIM_CONFIG_DIR'
+		New-Variable -Name LUNARVIM_RUNTIME_DIR -Value '$LUNARVIM_RUNTIME_DIR'
+		
+		nvim -u '$LUNARVIM_RUNTIME_DIR\lvim\init.lua' ", '"', "$args", '"')
+}
+
+function setup_lvim() {
+	Write-Output "Installing LunarVim shim"
+  
+	setup_shim
+  
+	Write-Output "Preparing Packer setup"
+
+	if ((Test-Path "$LUNARVIM_CONFIG_DIR") -eq $false) {
+		New-Item "$LUNARVIM_CONFIG_DIR" -ItemType "directory"
+	}
+
+	Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example-no-ts.lua" `
+		"$LUNARVIM_CONFIG_DIR\config.lua"
+  
+	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerInstall
+	nvim -u "$LUNARVIM_RUNTIME_DIR\lvim\init.lua" -c 'autocmd User PackerComplete sleep 100m | qall' -c PackerSync
+  
+	Write-Output "Packer setup complete"
+  
+	Copy-Item "$LUNARVIM_RUNTIME_DIR\lvim\utils\installer\config.example.lua" "$LUNARVIM_CONFIG_DIR\config.lua"
+  
+	$answer = Read-Host "Would you like to create a shortcut for $INSTALL_PREFIX\bin\lvim.ps1? [y]es or [n]o "
+	if ("$answer" -eq "y" -and "$answer" -eq "Y") {
+		create_shortcut
+	} 
+
+	#append_to_path
+
+	Write-Output "Thank you for installing LunarVim!!"
+	Write-Output "You can start it by running: $INSTALL_PREFIX\bin\lvim.ps1"
+	Write-Output "Do not forget to use a font with glyphs (icons) support [https://github.com/ryanoasis/nerd-fonts]"
+}
+
+
+function update_lvim() {
+	try {
+		git -C "$LUNARVIM_RUNTIME_DIR/lvim" status -uno
+	}
+	catch {
+		git -C "$LUNARVIM_RUNTIME_DIR/lvim" pull --ff-only --progress -or
+		Write-Output "Unable to guarantee data integrity while updating. Please do that manually instead."
+		exit 1
+	}
+	Write-Output "Your LunarVim installation is now up to date!"
+}
+
+function __add_separator($div_width) {
+	"-" * $div_width
+	Write-Output ""
+}
+
+function create_shortcut {
+	if(Test-Path "$INSTALL_PREFIX\bin\lvim") {
+		Remove-Item "$INSTALL_PREFIX\bin\lvim"
+	}
+	$WshShell = New-Object -comObject WScript.Shell
+	$Shortcut = $WshShell.CreateShortcut("$INSTALL_PREFIX\bin\lvim.lnk")
+	$Shortcut.TargetPath = "$INSTALL_PREFIX\bin\lvim.ps1"
+	$Shortcut.Save()
+	Move-Item "$INSTALL_PREFIX\bin\lvim.lnk" "$INSTALL_PREFIX\bin\lvim"
+}
+
+# TODO needs elevation
+function append_to_path {
+	$registryPath = 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment'
+	$path = (Get-ItemProperty -Path $registryPath -Name PATH).path
+	$list = [System.Collections.ArrayList]::new()
+	$list.AddRange(($path -split ";"))
+	$containsPathAlready = $false
+	foreach ($item in $list) {
+		if($item -eq "$INSTALL_PREFIX\bin\lvim"){
+			$containsPathAlready = $true
+			break
+		}
+	}
+
+	if (!$containsPathAlready) {
+		Write-Output "Add $INSTALL_PREFIX\bin\lvim to PATH variable"
+		$list.Add("$INSTALL_PREFIX\bin\lvim")
+		$newPath = ($list -join ";")
+		Set-ItemProperty -Path $registryPath -Name PATH -Value $newPath
+	}
+	
+}
+
+append_to_path
+#main "$args"
+

--- a/utils/installer/uninstall.ps1
+++ b/utils/installer/uninstall.ps1
@@ -1,0 +1,1 @@
+Remove-Item -Path "$HOME/.local/share/lunarvim" -Recurse -Force


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
This pull request adds a `install.ps1` for an easy installation on Windows, an `uninstall.ps1` for removing the lunarvim folder and adds a usage description in `README.md`.

This is basically a conversion from bash to powershell. To work on windows however two lua scripts are changed in the installation process.
- ~/.local/share/lunarvim/lvim/lua/default-config.lua
- ~/.local/share/lunarvim/lvim/init.lua

On both these files the string `os.getenv "HOME"` is replaced with `os.getenv "HOMEDRIVE" .. os.getenv "HOMEPATH"` because on windows a `HOME` environment variable does not exist.

Due to the lack of onboard package management of windows `winget` is used for installing dependencies. If `winget` is not installed the script stops but tells the user the reason.

Fixes #804 

## How Has This Been Tested?
- Powershell 5.1
- Windows 10 Pro (20H2) x64
- nvim 5.0
- Python 3.9.6 with pip 21.2.2
- winget 1.0.11692

The script was tested against both the master and rolling branches.