### PR TITLE
[Bugfix] Use vim.lsp.buf.formatting instead of vim.lsp.buf.formatting_sync

### DIFF
--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -64,7 +64,7 @@ function utils.toggle_autoformat()
         {
           "BufWritePre",
           "*",
-          ":silent lua vim.lsp.buf.formatting_sync()",
+          ":silent lua vim.lsp.buf.formatting()",
         },
       },
     }


### PR DESCRIPTION
I don't know why yet, but it lets us use multiple formatters.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Self-explanatory title. While reviewing [sequential formatting](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/93) from null-ls, I observed that using `vim.lsp.buf.formatting_sync` did only run `black`, (if `isort` runs, the buffer is not updated).
I don't understand yet the rationale, so let's discuss the change before merging it. Maybe @jose-elias-alvarez could give us a hand.

## How Has This Been Tested?

``` lua
lvim.lang.python.formatters = {
  {
    exe = "black",
  },
  {
    exe = "isort",
  },
}

```

