### PR TITLE
[Feature]: Add snippets navigation with c-j / c-k

### DIFF
--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -113,6 +113,11 @@ M.setup = function()
   vim.api.nvim_set_keymap("s", "<Tab>", "v:lua.tab_complete()", { expr = true })
   vim.api.nvim_set_keymap("i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
   vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
+
+  vim.api.nvim_set_keymap("i", "<C-j>", "v:lua.tab_complete()", { expr = true })
+  vim.api.nvim_set_keymap("s", "<C-j>", "v:lua.tab_complete()", { expr = true })
+  vim.api.nvim_set_keymap("i", "<C-k>", "v:lua.s_tab_complete()", { expr = true })
+  vim.api.nvim_set_keymap("s", "<C-k>", "v:lua.s_tab_complete()", { expr = true })
 end
 
 return M

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -78,10 +78,6 @@ function M.config()
       ["<A-Down>"] = "<C-\\><C-N><C-w>j",
       ["<A-Left>"] = "<C-\\><C-N><C-w>h",
       ["<A-Right>"] = "<C-\\><C-N><C-w>l",
-      -- navigate tab completion with <c-j> and <c-k>
-      -- runs conditionally
-      ["<C-j>"] = { 'pumvisible() ? "\\<C-n>" : "\\<C-j>"', { expr = true, noremap = true } },
-      ["<C-k>"] = { 'pumvisible() ? "\\<C-p>" : "\\<C-k>"', { expr = true, noremap = true } },
     },
 
     ---@usage change or add keymappings for normal mode


### PR DESCRIPTION
# Description

Allow to cycle through snippets placeholders with `<C-j>` and `<C-k>`, the same way `<Tab>` / `<S-Tab>` works.
Navigation in completion menu still works the same (down and up selection) with those keymaps.

## How Has This Been Tested?

With python and c snippets.
