### PR TITLE
avoid using smart_cwd if root_dir is not found

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -51,6 +51,14 @@ local function add_lsp_buffer_keybindings(bufnr)
   wk.register(keys, { mode = "n", buffer = bufnr })
 end
 
+local function set_smart_cwd(client)
+  local proj_dir = client.config.root_dir
+  if lvim.lsp.smart_cwd and proj_dir ~= "/" then
+    vim.api.nvim_set_current_dir(proj_dir)
+    require("core.nvimtree").change_tree_dir(proj_dir)
+  end
+end
+
 function M.common_capabilities()
   local capabilities = vim.lsp.protocol.make_client_capabilities()
   capabilities.textDocument.completion.completionItem.snippetSupport = true
@@ -113,10 +121,7 @@ function M.common_on_attach(client, bufnr)
   end
   lsp_highlight_document(client)
   add_lsp_buffer_keybindings(bufnr)
-  if lvim.lsp.smart_cwd then
-    vim.api.nvim_set_current_dir(client.config.root_dir)
-    require("core.nvimtree").change_tree_dir(client.config.root_dir)
-  end
+  set_smart_cwd(client)
   require("lsp.null-ls").setup(vim.bo.filetype)
 end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Don't change the CWD if we get a "/" as the project directory result from the language-server.
