### PR TITLE
[Feature] Add LvimInfo command

### DIFF
--- a/lua/core/commands.lua
+++ b/lua/core/commands.lua
@@ -10,6 +10,8 @@ M.defaults = {
     endif
   endfunction
   ]],
+  -- :LvimInfo
+  [[command! LvimInfo lua require('core.info').toggle_popup(vim.bo.filetype)]],
 }
 
 M.load = function(commands)

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -73,7 +73,6 @@ M.load_commands = function()
     cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
     cmd "let &fcs='eob: '"
   end
-  vim.cmd [[command! LvimInfo lua require('core.info').toggle_popup(vim.bo.filetype)]]
 end
 
 return M

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -73,6 +73,7 @@ M.load_commands = function()
     cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
     cmd "let &fcs='eob: '"
   end
+  vim.cmd [[command! LvimInfo lua require('core.info').toggle_popup(vim.bo.filetype)]]
 end
 
 return M


### PR DESCRIPTION
# Description

Add command `:LvimInfo` to toggle/show LunarVim info panel (in addition to `<leader>Li`). 

## How Has This Been Tested?

- Open a file(type) for which you want to check LSP, formatter and/or linter info.
- Run command `:LvimInfo`

