### PR TITLE
fix: do not overwrite plugins bindings in reload

### DIFF
--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -90,6 +90,7 @@ end
 function utils.reload_lv_config()
   vim.cmd "source ~/.local/share/lunarvim/lvim/lua/settings.lua"
   vim.cmd("source " .. USER_CONFIG_PATH)
+  require("keymappings").setup() -- this should be done before loading the plugins
   vim.cmd "source ~/.local/share/lunarvim/lvim/lua/plugins.lua"
   local plugins = require "plugins"
   local plugin_loader = require("plugin-loader").init()
@@ -97,7 +98,6 @@ function utils.reload_lv_config()
   plugin_loader:load { plugins, lvim.plugins }
   vim.cmd ":PackerCompile"
   vim.cmd ":PackerInstall"
-  require("keymappings").setup()
   -- vim.cmd ":PackerClean"
   Log:get_default().info "Reloaded configuration"
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

We should source the keybindings before loading the plugins, so that we don't overwrite any new ones.

## How Has This Been Tested?

Some plugins like "aserowy/tmux.nvim" uses C-hjkl for movement, and these should take effect now.

