### PR TITLE
[Bugfix]: change 'no highlight' behavior

### DIFF
--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -68,7 +68,7 @@ M.config = function()
       ["c"] = { "<cmd>BufferClose!<CR>", "Close Buffer" },
       ["e"] = { "<cmd>lua require'core.nvimtree'.toggle_tree()<CR>", "Explorer" },
       ["f"] = { "<cmd>Telescope find_files<CR>", "Find File" },
-      ["h"] = { '<cmd>let @/=""<CR>', "No Highlight" },
+      ["h"] = { '<cmd>nohlsearch', "No Highlight" },
       b = {
         name = "Buffers",
         j = { "<cmd>BufferPick<cr>", "jump to buffer" },


### PR DESCRIPTION
# Description

With `<cmd>let @/=""<CR>` its not possible to use `n`,`N` or stuff like `gcn` anymore because the last search is overwritten. With `:nohlsearch` this is not the case. The search keeps working only the highlight is removed.

Fixes an issue I didn't file

## How Has This Been Tested?
Tested manually after applying the change (using `<leader>h` after doing a search.