### PR TITLE
[Bugfix] Pin astronauta.nvim on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,6 @@ To update plugins:
 To update LunarVim:
 
 ```bash
-# Master Branch
-cd ~/.config/nvim && git pull
-:PackerSync  
-
-# Rolling Branch
 cd ~/.local/share/lunarvim/lvim && git pull
 :PackerSync
 ```

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -18,7 +18,7 @@ return {
 
   { "nvim-lua/popup.nvim" },
   { "nvim-lua/plenary.nvim" },
-  { "tjdevries/astronauta.nvim" },
+  { "tjdevries/astronauta.nvim", commit = "e69d7bdc4183047c4700427922c4a3cc1e3258c6" },
 
   -- Telescope
   {


### PR DESCRIPTION
# Description

astronauta.nvim has removed some of the functionality as they have been moved to neovim. LunarVim master branch still uses the removed astronauta.nvim functions/modeules.

Fixes

`ftplugin/*.lua` files are not triggered after astronauta.nvim plugin update.