### PR TITLE
[Bugfix] Pin astronauta.nvim on master

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -18,7 +18,7 @@ return {
 
   { "nvim-lua/popup.nvim" },
   { "nvim-lua/plenary.nvim" },
-  { "tjdevries/astronauta.nvim" },
+  { "tjdevries/astronauta.nvim", commit = "e69d7bdc4183047c4700427922c4a3cc1e3258c6" },
 
   -- Telescope
   {


### PR DESCRIPTION
## Description

astronauta.nvim has removed some of the functionality as they have been moved to neovim. LunarVim master branch still uses the removed astronauta.nvim functions/modules.

### Fixes

ftplugin/*.lua files are not triggered after astronauta.nvim plugin update.
