### PR TITLE
[Bugfix] Use correct highlight group with LvimInfo

### DIFF
--- a/lua/core/info.lua
+++ b/lua/core/info.lua
@@ -204,8 +204,8 @@ function M.toggle_popup(ft)
   local function set_syntax_hl()
     vim.cmd [[highlight LvimInfoIdentifier gui=bold]]
     vim.cmd [[highlight link LvimInfoHeader Type]]
-    vim.cmd [[let m=matchadd("DashboardHeader", "Language Server Protocol (LSP) info")]]
-    vim.cmd [[let m=matchadd("DashboardHeader", "Formatters and linters")]]
+    vim.cmd [[let m=matchadd("LvimInfoHeader", "Language Server Protocol (LSP) info")]]
+    vim.cmd [[let m=matchadd("LvimInfoHeader", "Formatters and linters")]]
     vim.cmd('let m=matchadd("LvimInfoIdentifier", " ' .. ft .. '$")')
     vim.cmd 'let m=matchadd("string", "true")'
     vim.cmd 'let m=matchadd("error", "false")'


### PR DESCRIPTION
# Description

In LvimInfo implementation `info.lua` a `DashboardHeader` highlight group was mistakenly used as the header highlight. This PR fixes the implementation to use the correct `LvimInfoHeader` highlight group.

## How Has This Been Tested?

- Run command `:LvimInfo`
- Check, that `Language Server Protocol (LSP) info` and `Formatters and linters` have a different syntax highlight compared to other text. 
- Check with e.g. `:Telescope highlights` that highlight group `LvimInfoHeader` exists.

