### PR TITLE
[Feature] Add a new option to show the mode name in galaxyline

### DIFF
--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -18,6 +18,20 @@ local condition = require "galaxyline.condition"
 local gls = gl.section
 gl.short_line_list = { "NvimTree", "vista", "dbui", "packer" }
 
+local function get_mode_name()
+  local names = {
+    n = "NORMAL",
+    i = "INSERT",
+    c = "COMMAND",
+    v = "VISUAL",
+    V = "VISUAL LINE",
+    t = "TERMINAL",
+    R = "REPLACE",
+    [""] = "VISUAL BLOCK",
+  }
+  return names[vim.fn.mode()]
+end
+
 table.insert(gls.left, {
   ViMode = {
     provider = function()
@@ -44,6 +58,16 @@ table.insert(gls.left, {
         ["!"] = colors.blue,
         t = colors.blue,
       }
+      if lvim.builtin.galaxyline.show_mode then
+        local name = get_mode_name()
+        -- Fall back to the default behavior is a name is not defined
+        if name ~= nil then
+          vim.api.nvim_command("hi GalaxyViMode guibg=" .. mode_color[vim.fn.mode()])
+          vim.api.nvim_command("hi GalaxyViMode guifg=" .. colors.alt_bg)
+          return "  " .. name .. " "
+        end
+      end
+      vim.api.nvim_command("hi GalaxyViMode guibg=" .. colors.alt_bg)
       vim.api.nvim_command("hi GalaxyViMode guifg=" .. mode_color[vim.fn.mode()])
       return "▊"
     end,

--- a/lua/core/status_colors.lua
+++ b/lua/core/status_colors.lua
@@ -1,5 +1,6 @@
 lvim.builtin.galaxyline = {
   active = true,
+  show_mode = false,
   colors = {
     alt_bg = "#2E2E2E",
     grey = "#858585",


### PR DESCRIPTION
# Description

Add the new config variable "lvim.builtin.galaxyline.show_mode" to
control if the mode name should be shown in the galaxyline. The option
defaults to false to preserve the current behavior.

## How Has This Been Tested?

Tested with `lvim.builtin.galaxyline.show_mode = false`, `lvim.builtin.galaxyline.show_mode = true` and without `lvim.builtin.galaxyline.show_mode` in the `config.lua`

