### PR TITLE
[Feature] Add command mode key mapping table

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -8,6 +8,7 @@ local generic_opts = {
   normal_mode = generic_opts_any,
   visual_mode = generic_opts_any,
   visual_block_mode = generic_opts_any,
+  command_mode = generic_opts_any,
   term_mode = { silent = true },
 }
 
@@ -17,6 +18,7 @@ local mode_adapters = {
   term_mode = "t",
   visual_mode = "v",
   visual_block_mode = "x",
+  command_mode = "c",
 }
 
 -- Append key mappings to lunarvim's defaults for a given mode
@@ -141,6 +143,14 @@ function M.config()
       -- Move current line / block with Alt-j/k ala vscode.
       ["<A-j>"] = ":m '>+1<CR>gv-gv",
       ["<A-k>"] = ":m '<-2<CR>gv-gv",
+    },
+
+    ---@usage change or add keymappings for command mode
+    command_mode = {
+      -- navigate tab completion with <c-j> and <c-k>
+      -- runs conditionally
+      ["<C-j>"] = { 'pumvisible() ? "\\<C-n>" : "\\<C-j>"', { expr = true, noremap = true } },
+      ["<C-k>"] = { 'pumvisible() ? "\\<C-p>" : "\\<C-k>"', { expr = true, noremap = true } },
     },
   }
 


### PR DESCRIPTION
# Description

Add the lvim.keys.command_mode table for configuring key bindings for
the command mode. Include bindings for <C-j> and <C-k> similar to the
ones available for insert mode.

## How Has This Been Tested?

For example, using:

```lua
local cmd_opts = { noremap=true, expr=true, silent=false }
lvim.keys.command_mode["<Up>"]    = { [[pumvisible() ? "\<Left>"  : "\<Up>"   ]], cmd_opts }
lvim.keys.command_mode["<Down>"]  = { [[pumvisible() ? "\<Right>" : "\<Down>" ]], cmd_opts }
lvim.keys.command_mode["<Left>"]  = { [[pumvisible() ? "\<Up>"    : "\<Left>" ]], cmd_opts }
lvim.keys.command_mode["<Right>"] = { [[pumvisible() ? "\<Down>"  : "\<Right>"]], cmd_opts }
```
in the `config.lua` file with the patch produces the same result as:

```lua
local cmd_opts = { noremap=true, expr=true, silent=false }
vim.api.nvim_set_keymap("c", "<Up>",    [[pumvisible() ? "\<Left>"  : "\<Up>"   ]], cmd_opts)
vim.api.nvim_set_keymap("c", "<Down>",  [[pumvisible() ? "\<Right>" : "\<Down>" ]], cmd_opts)
vim.api.nvim_set_keymap("c", "<Left>",  [[pumvisible() ? "\<Up>"    : "\<Left>" ]], cmd_opts)
vim.api.nvim_set_keymap("c", "<Right>", [[pumvisible() ? "\<Down>"  : "\<Right>"]], cmd_opts)
```

