### PR TITLE
feat: use telescope to quickly open lunarvim files

### DIFF
--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -1,6 +1,6 @@
 local M = {}
 local Log = require "core.log"
-M.config = function()
+function M.config()
   local status_ok, actions = pcall(require, "telescope.actions")
   if not status_ok then
     return
@@ -77,7 +77,41 @@ M.config = function()
   }
 end
 
-M.setup = function()
+function M.find_lunarvim_files(opts)
+  opts = opts or {}
+  local themes = require "telescope.themes"
+  local theme_opts = themes.get_ivy {
+    previewer = false,
+    sorting_strategy = "ascending",
+    layout_strategy = "bottom_pane",
+    layout_config = {
+      height = 5,
+      width = 0.5,
+    },
+    prompt = ">> ",
+    prompt_title = "~ LunarVim files ~",
+    cwd = CONFIG_PATH,
+    find_command = { "git", "ls-files" },
+  }
+  opts = vim.tbl_deep_extend("force", theme_opts, opts)
+  require("telescope.builtin").find_files(opts)
+end
+
+function M.grep_lunarvim_files(opts)
+  opts = opts or {}
+  local themes = require "telescope.themes"
+  local theme_opts = themes.get_ivy {
+    sorting_strategy = "ascending",
+    layout_strategy = "bottom_pane",
+    prompt = ">> ",
+    prompt_title = "~ search LunarVim ~",
+    cwd = CONFIG_PATH,
+  }
+  opts = vim.tbl_deep_extend("force", theme_opts, opts)
+  require("telescope.builtin").live_grep(opts)
+end
+
+function M.setup()
   local status_ok, telescope = pcall(require, "telescope")
   if not status_ok then
     Log:get_default().error "Failed to load telescope"

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -169,6 +169,18 @@ M.config = function()
       },
       L = {
         name = "+LunarVim",
+        c = {
+          "<cmd>edit ~/.config/lvim/config.lua<cr>",
+          "Edit config.lua",
+        },
+        f = {
+          "<cmd>lua require('core.telescope').find_lunarvim_files()<cr>",
+          "Find LunarVim files",
+        },
+        g = {
+          "<cmd>lua require('core.telescope').grep_lunarvim_files()<cr>",
+          "Grep LunarVim files",
+        },
         k = { "<cmd>lua require('keymappings').print()<cr>", "View LunarVim's default keymappings" },
         i = {
           "<cmd>lua require('core.info').toggle_popup(vim.bo.filetype)<cr>",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add two simple functions that allow opening and grepping LunarVim Files from anywhere.

## How Has This Been Tested?

Use `<leader>L` to see the new options.

