### PR TITLE
[Bugfix] Fixes indexing args when formatter is not set

### DIFF
--- a/lua/lsp/null-ls.lua
+++ b/lua/lsp/null-ls.lua
@@ -97,10 +97,10 @@ function M.setup(filetype)
     local builtin_formatter = null_ls.builtins.formatting[formatter.exe]
     if not vim.tbl_contains(M.requested_providers, builtin_formatter) then
       -- FIXME: why doesn't this work?
-      builtin_formatter._opts.args = formatter.args or builtin_formatter._opts.args
       -- builtin_formatter._opts.to_stdin = formatter.stdin or builtin_formatter._opts.to_stdin
       local resolved_path = validate_provider_request(builtin_formatter)
       if resolved_path then
+        builtin_formatter._opts.args = formatter.args or builtin_formatter._opts.args
         builtin_formatter._opts.command = resolved_path
         table.insert(M.requested_providers, builtin_formatter)
         Log:get_default().info("Using format provider", builtin_formatter.name)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Formatter args were being indexed when no formatter was set. This just moves the setting of the args after validating the formatter.

Fixes #1307 

## How Has This Been Tested?

Open a lua file with no formatter optins in `config.lua` and verify that neovim doesn't complain. Tested on few other filetypes like cpp as well.
