### PR TITLE
[Bugfix]: Fix nvimtree quit to update bufferline

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -66,6 +66,7 @@ M.setup = function()
       { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
       { key = "h", cb = tree_cb "close_node" },
       { key = "v", cb = tree_cb "vsplit" },
+      { key = "q", cb = ":lua require('core.nvimtree').toggle_tree()<cr>" },
     }
   end
 end


### PR DESCRIPTION
# Description

Updates the bufferline when pressing q in nvimtree. Previous behavior would not update the bufferline.

## How Has This Been Tested?

I pressed q