### PR TITLE
[Bugfix] LvimInfo highlight match fix

### DIFF
--- a/lua/core/info.lua
+++ b/lua/core/info.lua
@@ -124,7 +124,7 @@ local function tbl_set_highlight(terms, highlight_group)
   end
 
   for _, v in pairs(terms) do
-    vim.cmd('let m=matchadd("' .. highlight_group .. '", "' .. v .. '")')
+    vim.cmd('let m=matchadd("' .. highlight_group .. '", "' .. v .. "[ ,│']\")")
   end
 end
 


### PR DESCRIPTION
# Description

Improve highlight matching of formatting and linting providers.

## Before

![CleanShot 2021-08-14 at 14 35 33@2x](https://user-images.githubusercontent.com/2576369/129445092-6afd75ef-eb8c-417d-a1af-6b13b2aded57.png)

## After

![CleanShot 2021-08-14 at 14 37 19@2x](https://user-images.githubusercontent.com/2576369/129445118-bcbbc50e-b2b6-44cf-aff3-6a001c679f1a.png)

