### PR TITLE
[Bugfix] Support extending null builtin args

### DIFF
--- a/lua/lsp/null-ls/formatters.lua
+++ b/lua/lsp/null-ls/formatters.lua
@@ -59,7 +59,7 @@ function M.list_configured(formatter_configs)
         errors[fmt_config.exe] = {} -- Add data here when necessary
       else
         logger.info("Using formatter:", formatter_cmd)
-        formatters[fmt_config.exe] = formatter.with { command = formatter_cmd, args = fmt_config.args }
+        formatters[fmt_config.exe] = formatter.with { command = formatter_cmd, extra_args = fmt_config.args }
       end
     end
   end

--- a/lua/lsp/null-ls/formatters.lua
+++ b/lua/lsp/null-ls/formatters.lua
@@ -7,14 +7,9 @@ local logger = require("core.log"):get_default()
 
 local function list_names(formatters, options)
   options = options or {}
-  local names = {}
-
   local filter = options.filter or "supported"
-  for name, _ in pairs(formatters[filter]) do
-    table.insert(names, name)
-  end
 
-  return names
+  return vim.tbl_keys(formatters[filter])
 end
 
 function M.list_supported_names(filetype)

--- a/lua/lsp/null-ls/linters.lua
+++ b/lua/lsp/null-ls/linters.lua
@@ -7,14 +7,9 @@ local logger = require("core.log"):get_default()
 
 local function list_names(linters, options)
   options = options or {}
-  local names = {}
-
   local filter = options.filter or "supported"
-  for name, _ in pairs(linters[filter]) do
-    table.insert(names, name)
-  end
 
-  return names
+  return vim.tbl_keys(linters[filter])
 end
 
 function M.list_supported_names(filetype)

--- a/lua/lsp/null-ls/linters.lua
+++ b/lua/lsp/null-ls/linters.lua
@@ -59,7 +59,7 @@ function M.list_configured(linter_configs)
         errors[lnt_config.exe] = {} -- Add data here when necessary
       else
         logger.info("Using linter:", linter_cmd)
-        linters[lnt_config.exe] = linter.with { command = linter_cmd, args = lnt_config.args }
+        linters[lnt_config.exe] = linter.with { command = linter_cmd, extra_args = lnt_config.args }
       end
     end
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Support [has been added](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/106) to null-ls for extending builtins args :tada: 

## How Has This Been Tested?

``` lua
lvim.lang.sh.formatters = {
  {
    exe = "shfmt",
    args = { "-i", "2", "-ci" },
  },
}
```


