### PR TITLE
[Refactor]: Remove vim-rooter dependency

### DIFF
--- a/lua/lsp/null-ls/services.lua
+++ b/lua/lsp/null-ls/services.lua
@@ -4,12 +4,12 @@ local function find_root_dir()
   local util = require "lspconfig/util"
   local lsp_utils = require "lsp.utils"
 
-  local ts_client = lsp_utils.get_active_client_by_ft "typescript"
-  if not ts_client then
-    local dirname = vim.fn.expand "%:p:h"
-    return util.root_pattern "package.json"(dirname)
+  local status_ok, ts_client = lsp_utils.is_client_active "typescript"
+  if status_ok then
+    return ts_client.config.root_dir
   end
-  return ts_client.config.root_dir
+  local dirname = vim.fn.expand "%:p:h"
+  return util.root_pattern "package.json"(dirname)
 end
 
 local function from_node_modules(command)

--- a/lua/lsp/utils.lua
+++ b/lua/lsp/utils.lua
@@ -4,12 +4,13 @@ function M.is_client_active(name)
   local clients = vim.lsp.get_active_clients()
   for _, client in pairs(clients) do
     if client.name == name then
-      return true
+      return true, client
     end
   end
   return false
 end
 
+-- FIXME: this should return a list instead
 function M.get_active_client_by_ft(filetype)
   if not lvim.lang[filetype] or not lvim.lang[filetype].lsp then
     return nil


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Remove vim-rooter dependency when configuring null-ls local providers

## How Has This Been Tested?

Install prettier locally and test that it still works with yaml files for example.

