### PR TITLE
Fix commentstring for elixir files

### DIFF
--- a/ftplugin/elixir.lua
+++ b/ftplugin/elixir.lua
@@ -1,4 +1,5 @@
 require("lsp").setup "elixir"
+vim.api.nvim_buf_set_option(0, "commentstring", "# %s")
 
 -- TODO: do we need this?
 -- needed for the LSP to recognize elixir files (alternatively just use elixir-editors/vim-elixir)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Please include a summary of the change and which issue is fixed. \
List any dependencies that are required for this change.

Fixes #1308 

## How Has This Been Tested?

in elixir files instead of `/* stuff */` we'll get `# stuff`
