### PR TITLE
[Feature] Expose null ls setup to user config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -58,7 +58,7 @@ require("lsp").config()
 local null_status_ok, null_ls = pcall(require, "null-ls")
 if null_status_ok then
   null_ls.config {}
-  require("lspconfig")["null-ls"].setup {}
+  require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
 end
 
 local lsp_settings_status_ok, lsp_settings = pcall(require, "nlspsettings")

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -104,6 +104,9 @@ lvim = {
     on_init_callback = nil,
     ---@usage query the project directory from the language server and use it to set the CWD
     smart_cwd = true,
+    null_ls = {
+      setup = {}
+    }
   },
 
   plugins = {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -105,8 +105,8 @@ lvim = {
     ---@usage query the project directory from the language server and use it to set the CWD
     smart_cwd = true,
     null_ls = {
-      setup = {}
-    }
+      setup = {},
+    },
   },
 
   plugins = {

--- a/utils/installer/config.example-no-ts.lua
+++ b/utils/installer/config.example-no-ts.lua
@@ -73,7 +73,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 --   elseif vim.bo.filetype == "php" then
 --     return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
 --   else
---     return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
+--     return require("lspconfig/util").root_pattern("Makefile", ".git")(fname) or require("lspconfig/util").path.dirname(fname)
 --   end
 -- end
 

--- a/utils/installer/config.example-no-ts.lua
+++ b/utils/installer/config.example-no-ts.lua
@@ -63,18 +63,18 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- end
 -- you can overwrite the null_ls setup table (useful for setting the root_dir function)
 -- lvim.lsp.null_ls.setup = {
---   root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules")
+--   root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules"),
 -- }
 -- or if you need something more advanced
 -- lvim.lsp.null_ls.setup.root_dir = function(fname)
--- 	if vim.bo.filetype == "javascript" then
--- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "node_modules")(fname)
--- 			or require("lspconfig/util").path.dirname(fname)
--- 	elseif vim.bo.filetype == "php" then
--- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
--- 	else
--- 		return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
--- 	end
+--   if vim.bo.filetype == "javascript" then
+--     return require("lspconfig/util").root_pattern("Makefile", ".git", "node_modules")(fname)
+--       or require("lspconfig/util").path.dirname(fname)
+--   elseif vim.bo.filetype == "php" then
+--     return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
+--   else
+--     return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
+--   end
 -- end
 
 -- set a formatter if you want to override the default lsp one (if it exists)

--- a/utils/installer/config.example-no-ts.lua
+++ b/utils/installer/config.example-no-ts.lua
@@ -61,6 +61,21 @@ lvim.builtin.treesitter.highlight.enabled = true
 --   --Enable completion triggered by <c-x><c-o>
 --   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
 -- end
+-- you can overwrite the null_ls setup table (useful for setting the root_dir function)
+-- lvim.lsp.null_ls.setup = {
+--   root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules")
+-- }
+-- or if you need something more advanced
+-- lvim.lsp.null_ls.setup.root_dir = function(fname)
+-- 	if vim.bo.filetype == "javascript" then
+-- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "node_modules")(fname)
+-- 			or require("lspconfig/util").path.dirname(fname)
+-- 	elseif vim.bo.filetype == "php" then
+-- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
+-- 	else
+-- 		return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
+-- 	end
+-- end
 
 -- set a formatter if you want to override the default lsp one (if it exists)
 -- lvim.lang.python.formatters = {

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -82,7 +82,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 --   elseif vim.bo.filetype == "php" then
 --     return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
 --   else
---     return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
+--     return require("lspconfig/util").root_pattern("Makefile", ".git")(fname) or require("lspconfig/util").path.dirname(fname)
 --   end
 -- end
 

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -70,6 +70,21 @@ lvim.builtin.treesitter.highlight.enabled = true
 --   --Enable completion triggered by <c-x><c-o>
 --   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
 -- end
+-- you can overwrite the null_ls setup table (useful for setting the root_dir function)
+-- lvim.lsp.null_ls.setup = {
+--   root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules")
+-- }
+-- or if you need something more advanced
+-- lvim.lsp.null_ls.setup.root_dir = function(fname)
+-- 	if vim.bo.filetype == "javascript" then
+-- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "node_modules")(fname)
+-- 			or require("lspconfig/util").path.dirname(fname)
+-- 	elseif vim.bo.filetype == "php" then
+-- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
+-- 	else
+-- 		return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
+-- 	end
+-- end
 
 -- set a formatter if you want to override the default lsp one (if it exists)
 -- lvim.lang.python.formatters = {

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -72,18 +72,18 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- end
 -- you can overwrite the null_ls setup table (useful for setting the root_dir function)
 -- lvim.lsp.null_ls.setup = {
---   root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules")
+--   root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules"),
 -- }
 -- or if you need something more advanced
 -- lvim.lsp.null_ls.setup.root_dir = function(fname)
--- 	if vim.bo.filetype == "javascript" then
--- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "node_modules")(fname)
--- 			or require("lspconfig/util").path.dirname(fname)
--- 	elseif vim.bo.filetype == "php" then
--- 		return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
--- 	else
--- 		return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
--- 	end
+--   if vim.bo.filetype == "javascript" then
+--     return require("lspconfig/util").root_pattern("Makefile", ".git", "node_modules")(fname)
+--       or require("lspconfig/util").path.dirname(fname)
+--   elseif vim.bo.filetype == "php" then
+--     return require("lspconfig/util").root_pattern("Makefile", ".git", "composer.json")(fname) or vim.fn.getcwd()
+--   else
+--     return require("lspconfig/util").root_pattern("Makefile", ".git")(fname)
+--   end
 -- end
 
 -- set a formatter if you want to override the default lsp one (if it exists)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This feature allows user to pass a custom table to null_ls setup function.

## How Has This Been Tested?

I have tested this with `root_dir` overwrite.
Example config: 
```
lvim.lsp.null_ls.setup.root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules")
```

With this I can see null_ls root set to the `app` folder when opening a file in a project with structure like this
```
repo/
├── .git/
└── app/
    ├── node_modules/
    ├── App.js
    ├── package.json
    └── yarn.lock
```

## Why is this useful?

Eslint and babel sometimes have weird interactions, where if you're running eslint or eslint_d from repo root and not `app` folder (see project structure above), you might run into errors where eslint can't find your babel config because it either looks for it from cwd and upwards or only cwd.

Making sure `null_ls` root is set correctly is the easiest workaround for my case (if you don't want to add random empty makefiles around the projects you work on).