### PR TITLE
[Feature] switched os.getenv('HOME') to a basepath variable for better cross platform support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,7 +22,8 @@ local function file_exists(name)
   end
 end
 
-local lvim_path = os.getenv "HOME" .. "/.config/lvim/"
+BASE_PATH = os.getenv "HOME" or os.getenv "HOMEDRIVE" .. os.getenv "HOMEPATH"
+local lvim_path = BASE_PATH .. "/.config/lvim/"
 USER_CONFIG_PATH = lvim_path .. "config.lua"
 local config_exist = file_exists(USER_CONFIG_PATH)
 if not config_exist then
@@ -64,7 +65,7 @@ end
 local lsp_settings_status_ok, lsp_settings = pcall(require, "nlspsettings")
 if lsp_settings_status_ok then
   lsp_settings.setup {
-    config_home = os.getenv "HOME" .. "/.config/lvim/lsp-settings",
+    config_home = BASE_PATH .. "/.config/lvim/lsp-settings",
   }
 end
 

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1,4 +1,5 @@
-CONFIG_PATH = os.getenv "HOME" .. "/.local/share/lunarvim/lvim"
+BASE_PATH = os.getenv "HOME" or os.getenv "HOMEDRIVE" .. os.getenv "HOMEPATH"
+CONFIG_PATH = BASE_PATH .. "/.local/share/lunarvim/lvim"
 DATA_PATH = vim.fn.stdpath "data"
 CACHE_PATH = vim.fn.stdpath "cache"
 TERMINAL = vim.fn.expand "$TERMINAL"
@@ -11,7 +12,7 @@ lvim = {
   line_wrap_cursor_movement = true,
   transparent_window = false,
   format_on_save = true,
-  vsnip_dir = os.getenv "HOME" .. "/.config/snippets",
+  vsnip_dir = BASE_PATH .. "/.config/snippets",
   database = { save_location = "~/.config/lunarvim_db", auto_execute = 1 },
   keys = {},
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The current method of using `os.env("home")` for a basepath doesn't work on windows. The install script in #1261 works around this by creating a backup file of `init.lua` and `default-config.lua` and replacing all occurrences with a windows alternative. Using this instead sets a `BASE_PATH` variable to `os.getenv("HOME")`, or if it doesn't exist (meaning the OS being used is windows) sets it to `os.getenv "HOMEDRIVE" .. os.getenv "HOMEPATH"`.

Improves situation with #1271 

## How Has This Been Tested?
- Replace files with modified files
- See if lvim opens
### This has only been tested on windows, but I see no reason why this shouldn't work on Linux. I don't have access to linux atm, if needed could someone else test it?
