### PR TITLE
Check if emmet is active.  Enable emmet completion if emmet language server is active

### DIFF
--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -83,9 +83,12 @@ M.setup = function()
   end
 
   local is_emmet_active = function()
-    local utils = require "lsp.utils"
-    if utils.is_client_active "emmet_ls" then
-      return true
+    local clients = vim.lsp.buf_get_clients()
+
+    for _, client in pairs(clients) do
+      if client.name == "emmet_ls" then
+        return true
+      end
     end
     return false
   end

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -98,10 +98,10 @@ M.setup = function()
       return t "<C-n>"
     elseif vim.fn.call("vsnip#jumpable", { 1 }) == 1 then
       return t "<Plug>(vsnip-jump-next)"
-    elseif is_emmet_active() then
-      return vim.fn["compe#complete"]()
     elseif check_back_space() then
       return t "<Tab>"
+    elseif is_emmet_active() then
+      return vim.fn["compe#complete"]()
     else
       return t "<Tab>"
     end

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -82,6 +82,14 @@ M.setup = function()
     end
   end
 
+  local is_emmet_active = function()
+    local utils = require "lsp.utils"
+    if utils.is_client_active "emmet_ls" then
+      return true
+    end
+    return false
+  end
+
   -- Use (s-)tab to:
   --- move to prev/next item in completion menuone
   --- jump to prev/next snippet's placeholder
@@ -90,10 +98,11 @@ M.setup = function()
       return t "<C-n>"
     elseif vim.fn.call("vsnip#jumpable", { 1 }) == 1 then
       return t "<Plug>(vsnip-jump-next)"
+    elseif is_emmet_active() then
+      return vim.fn["compe#complete"]()
     elseif check_back_space() then
       return t "<Tab>"
     else
-      -- return vim.fn["compe#complete"]() -- < use this if you want <tab> to always offer completion
       return t "<Tab>"
     end
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
Fixes #(issue)
Emmet completion does not work correctly.  An expression like `nav>ul>li` should produce
```html
<nav>
    <ul>
        <li></li>
    </ul>
</nav>
```

Instead, it just inserts a tab character.  

This pr adds a check to see if emmet_ls is active.  Enables emmet completion if emmet language server is active.   
```lua
    elseif is_emmet_active() then
      return vim.fn["compe#complete"]()
```
## How Has This Been Tested?
![emmet](https://user-images.githubusercontent.com/16025007/129571709-2052900b-4e5b-4ba3-8260-c334842c2e97.gif)


Please also list any relevant details for your test configuration.

To set up emmet-ls  add this to your plugins.  

```lua
lvim.plugins ={
		{
			"aca/emmet-ls",
			config = function()
				local lspconfig = require("lspconfig")
				local configs = require("lspconfig/configs")

				local capabilities = vim.lsp.protocol.make_client_capabilities()
				capabilities.textDocument.completion.completionItem.snippetSupport = true
				capabilities.textDocument.completion.completionItem.resolveSupport = {
					properties = {
						"documentation",
						"detail",
						"additionalTextEdits",
					},
				}

				if not lspconfig.emmet_ls then
					configs.emmet_ls = {
						default_config = {
							cmd = { "emmet-ls", "--stdio" },
							filetypes = {
								"html",
								"css",
								"javascript",
								"typescript",
								"eruby",
								"typescriptreact",
								"javascriptreact",
								"svelte",
								"vue",
							},
							root_dir = function(fname)
								return vim.loop.cwd()
							end,
							settings = {},
						},
					}
				end
				lspconfig.emmet_ls.setup({ capabilities = capabilities })
			end,
		},
}
```
