### PR TITLE
[Feature]: Join lines improvement

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -109,6 +109,9 @@ function M.config()
       ["<A-j>"] = ":m .+1<CR>==",
       ["<A-k>"] = ":m .-2<CR>==",
 
+      -- Join lines, keeping the cursor position
+      ["<S-j>"] = "mzJ`z",
+
       -- QuickFix
       ["]q"] = ":cnext<CR>",
       ["[q"] = ":cprev<CR>",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Join line

This commit change the default behavior of jump the cursor to the first word from joined line.
Now the cursor keeps your position.
