### PR TITLE
[Bugfix] ignore jdtls to fix `CI`

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -40,5 +40,5 @@ jobs:
       # https://google.github.io/styleguide/shellguide.html
       - name: Check formatting
         run: |
-          shfmt -i 2 -ci -l -d .
+          shfmt -f . | grep -v jdtls | xargs shfmt -i 2 -ci -l -d
     

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,3 +32,4 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
        scandir: './utils'
+       ignore: 'bin'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ repos:
         name: shfmt
         minimum_pre_commit_version: 2.4.0
         language: system
-        entry: shfmt
-        args: [-i=2, -ci, -w]
         types: [shell]
+        entry: bash
+        args: [-c, "shfmt -f $(git rev-parse --show-toplevel) | grep -v jdtls | xargs shfmt -i=2 -ci -w"]
       - id: shellcheck
         name: shellcheck
         language: system
         types: [shell]
         entry: bash
         args:
-          [-c, "shfmt -f $(git rev-parse --show-toplevel) | xargs shellcheck"]
+          [-c, "shfmt -f $(git rev-parse --show-toplevel) | grep -v jdtls | xargs shellcheck"]
       - id: stylua
         name: StyLua
         language: rust


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`jdtls` is causing the `CI` to throw errors, we should ignore that file till we find the root cause
