### PR TITLE
fix: remove wrongful log entry from null-ls setup

### DIFF
--- a/lua/lsp/null-ls/services.lua
+++ b/lua/lsp/null-ls/services.lua
@@ -13,11 +13,9 @@ local function find_root_dir()
 end
 
 local function from_node_modules(command)
-  local logger = require("core.log"):get_default()
   local root_dir = find_root_dir()
 
   if not root_dir then
-    logger.error(string.format("Unable to find the [%s] node module.", command))
     return nil
   end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

There shouldn't be an error log entry when the provider hasn't be checked if it's on path.

