### PR TITLE
rename settings to configuration in dashboard

### DIFF
--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -41,7 +41,7 @@ M.config = function()
         command = "Telescope live_grep",
       },
       e = {
-        description = { "  Settings           " },
+        description = { "  Configuration      " },
         command = ":e " .. USER_CONFIG_PATH,
       },
     },


### PR DESCRIPTION
Rename `Settings` to `Configuration` in dashboard. To decrease confusion, for new comers.