### PR TITLE
[Refactor]: consistent update of bufferline offset with nvim-tree

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -78,13 +78,21 @@ M.setup = function()
 
   lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 
-  vim.cmd "au FileType NvimTree lua require('core.nvimtree').on_type()"
-end
---
-M.on_type = function()
-  local buf = vim.fn.expand "<abuf>"
-  vim.cmd("au BufWinEnter <buffer=" .. buf .. "> lua require('core.nvimtree').on_open()")
-  vim.cmd("au WinClosed   <buffer=" .. buf .. "> lua require('core.nvimtree').on_close()")
+  -- Add nvim_tree open callback
+  on_open = require("nvim-tree.view").open
+  on_open_new = function()
+    M.on_open()
+    on_open()
+  end
+  require("nvim-tree.view").open = on_open_new
+
+  -- Add nvim_tree close callback
+  on_leave = require("nvim-tree").on_leave
+  on_leave_new = function()
+    M.on_close()
+    on_leave()
+  end
+  require("nvim-tree").on_leave = on_leave_new
 end
 --
 M.on_open = function()

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -1,6 +1,6 @@
 local M = {}
 local Log = require "core.log"
---
+
 M.config = function()
   lvim.builtin.nvimtree = {
     active = true,
@@ -47,7 +47,7 @@ M.config = function()
     },
   }
 end
---
+
 M.setup = function()
   local status_ok, nvim_tree_config = pcall(require, "nvim-tree.config")
   if not status_ok then
@@ -89,13 +89,13 @@ M.setup = function()
 
   vim.cmd "au WinClosed * lua require('core.nvimtree').on_close()"
 end
---
+
 M.on_open = function()
   if package.loaded["bufferline.state"] and lvim.builtin.nvimtree.side == "left" then
     require("bufferline.state").set_offset(lvim.builtin.nvimtree.width + 1, "")
   end
 end
---
+
 M.on_close = function()
   local buf = tonumber(vim.fn.expand "<abuf>")
   local ft = vim.api.nvim_buf_get_option(buf, "filetype")
@@ -103,12 +103,12 @@ M.on_close = function()
     require("bufferline.state").set_offset(0)
   end
 end
---
+
 function M.change_tree_dir(dir)
   local lib_status_ok, lib = pcall(require, "nvim-tree.lib")
   if lib_status_ok then
     lib.change_dir(dir)
   end
 end
---
+
 return M

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -96,7 +96,7 @@ M.on_open = function()
 end
 --
 M.on_close = function()
-  local buf = tonumber(vim.fn.expand("<abuf>"))
+  local buf = tonumber(vim.fn.expand "<abuf>")
   if vim.api.nvim_buf_get_option(buf, "filetype") == "NvimTree" then
     if package.loaded["bufferline.state"] then
       require("bufferline.state").set_offset(0)

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -76,6 +76,8 @@ M.setup = function()
     }
   end
 
+  lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
+
   vim.cmd "au FileType NvimTree lua require('core.nvimtree').on_type()"
 end
 --
@@ -94,41 +96,6 @@ end
 M.on_close = function()
   if package.loaded["bufferline.state"] then
     require("bufferline.state").set_offset(0)
-  end
-end
---
-M.focus_or_close = function()
-  local view_status_ok, view = pcall(require, "nvim-tree.view")
-  if not view_status_ok then
-    return
-  end
-  local a = vim.api
-
-  local curwin = a.nvim_get_current_win()
-  local curbuf = a.nvim_win_get_buf(curwin)
-  local bufnr = view.View.bufnr
-  local winnr = view.get_winnr()
-
-  if view.win_open() then
-    if curwin == winnr and curbuf == bufnr then
-      view.close()
-    else
-      view.focus()
-    end
-  else
-    view.open()
-  end
-end
---
-M.toggle_tree = function()
-  local view_status_ok, view = pcall(require, "nvim-tree.view")
-  if not view_status_ok then
-    return
-  end
-  if view.win_open() then
-    require("nvim-tree").close()
-  else
-    require("nvim-tree").toggle()
   end
 end
 --

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -86,13 +86,7 @@ M.setup = function()
   end
   require("nvim-tree.view").open = on_open_new
 
-  -- Add nvim_tree close callback
-  local on_leave = require("nvim-tree").on_leave
-  local on_leave_new = function()
-    M.on_close()
-    on_leave()
-  end
-  require("nvim-tree").on_leave = on_leave_new
+  vim.cmd "au WinClosed * lua require('core.nvimtree').on_close()"
 end
 --
 M.on_open = function()
@@ -102,6 +96,8 @@ M.on_open = function()
 end
 --
 M.on_close = function()
+  buf = tonumber(vim.fn.expand("<abuf>")) 
+  if vim.api.nvim_buf_get_option(buf, "filetype") ~= "NvimTree" then return end
   if package.loaded["bufferline.state"] then
     require("bufferline.state").set_offset(0)
   end

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -78,13 +78,14 @@ M.setup = function()
 
   lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 
+  local tree_view = require "nvim-tree.view"
+
   -- Add nvim_tree open callback
-  local on_open = require("nvim-tree.view").open
-  local on_open_new = function()
+  local open = tree_view.open
+  tree_view.open = function()
     M.on_open()
-    on_open()
+    open()
   end
-  require("nvim-tree.view").open = on_open_new
 
   vim.cmd "au WinClosed * lua require('core.nvimtree').on_close()"
 end
@@ -97,10 +98,9 @@ end
 --
 M.on_close = function()
   local buf = tonumber(vim.fn.expand "<abuf>")
-  if vim.api.nvim_buf_get_option(buf, "filetype") == "NvimTree" then
-    if package.loaded["bufferline.state"] then
-      require("bufferline.state").set_offset(0)
-    end
+  local ft = vim.api.nvim_buf_get_option(buf, "filetype")
+  if ft == "NvimTree" and package.loaded["bufferline.state"] then
+    require("bufferline.state").set_offset(0)
   end
 end
 --

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -79,16 +79,16 @@ M.setup = function()
   lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 
   -- Add nvim_tree open callback
-  on_open = require("nvim-tree.view").open
-  on_open_new = function()
+  local on_open = require("nvim-tree.view").open
+  local on_open_new = function()
     M.on_open()
     on_open()
   end
   require("nvim-tree.view").open = on_open_new
 
   -- Add nvim_tree close callback
-  on_leave = require("nvim-tree").on_leave
-  on_leave_new = function()
+  local on_leave = require("nvim-tree").on_leave
+  local on_leave_new = function()
     M.on_close()
     on_leave()
   end

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -96,10 +96,11 @@ M.on_open = function()
 end
 --
 M.on_close = function()
-  buf = tonumber(vim.fn.expand("<abuf>")) 
-  if vim.api.nvim_buf_get_option(buf, "filetype") ~= "NvimTree" then return end
-  if package.loaded["bufferline.state"] then
-    require("bufferline.state").set_offset(0)
+  local buf = tonumber(vim.fn.expand("<abuf>"))
+  if vim.api.nvim_buf_get_option(buf, "filetype") == "NvimTree" then
+    if package.loaded["bufferline.state"] then
+      require("bufferline.state").set_offset(0)
+    end
   end
 end
 --

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -76,16 +76,16 @@ M.setup = function()
     }
   end
 
-  vim.cmd("au FileType NvimTree lua require('core.nvimtree').on_type()")
+  vim.cmd "au FileType NvimTree lua require('core.nvimtree').on_type()"
 end
 --
-M.on_type = function ()
-  local buf = vim.fn.expand("<abuf>")
+M.on_type = function()
+  local buf = vim.fn.expand "<abuf>"
   vim.cmd("au BufWinEnter <buffer=" .. buf .. "> lua require('core.nvimtree').on_open()")
   vim.cmd("au WinClosed   <buffer=" .. buf .. "> lua require('core.nvimtree').on_close()")
 end
 --
-M.on_open = function ()
+M.on_open = function()
   if package.loaded["bufferline.state"] and lvim.builtin.nvimtree.side == "left" then
     require("bufferline.state").set_offset(lvim.builtin.nvimtree.width + 1, "")
   end

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -66,7 +66,6 @@ M.config = function()
       ["q"] = { "<cmd>q!<CR>", "Quit" },
       ["/"] = { "<cmd>CommentToggle<CR>", "Comment" },
       ["c"] = { "<cmd>BufferClose!<CR>", "Close Buffer" },
-      ["e"] = { "<cmd>lua require'core.nvimtree'.toggle_tree()<CR>", "Explorer" },
       ["f"] = { "<cmd>Telescope find_files<CR>", "Find File" },
       ["h"] = { "<cmd>nohlsearch<CR>", "No Highlight" },
       b = {


### PR DESCRIPTION
# Description

This adds buffer local autocmds to setup the bufferline offset which is
important since currently the bufferline doesn't get updated when someone does
`NvimTreeOpen` and co. Also important when someone does `:q`.

This also refactor the changedir function.

## How Has This Been Tested?

I opened and closed nvimtree
