### PR TITLE
[Bugfix] fix formatter/linter nil issue

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1189,7 +1189,7 @@ lvim.lang = {
   },
   vim = {
     formatters = {},
-    linters = { "" },
+    linters = {},
     lsp = {
       provider = "vimls",
       setup = {

--- a/lua/lsp/null-ls/formatters.lua
+++ b/lua/lsp/null-ls/formatters.lua
@@ -63,7 +63,7 @@ function M.list_configured(formatter_configs)
 end
 
 function M.setup(filetype, options)
-  if formatters_by_ft[filetype] and not options.force_reload then
+  if (formatters_by_ft[filetype] and not options.force_reload) or not lvim.lang[filetype] then
     return
   end
 

--- a/lua/lsp/null-ls/formatters.lua
+++ b/lua/lsp/null-ls/formatters.lua
@@ -63,7 +63,7 @@ function M.list_configured(formatter_configs)
 end
 
 function M.setup(filetype, options)
-  if (formatters_by_ft[filetype] and not options.force_reload) or not lvim.lang[filetype] then
+  if not lvim.lang[filetype] or (formatters_by_ft[filetype] and not options.force_reload) then
     return
   end
 

--- a/lua/lsp/null-ls/linters.lua
+++ b/lua/lsp/null-ls/linters.lua
@@ -63,7 +63,7 @@ function M.list_configured(linter_configs)
 end
 
 function M.setup(filetype, options)
-  if (linters_by_ft[filetype] and not options.force_reload) or not lvim.lang[filetype] then
+  if not lvim.lang[filetype] or (linters_by_ft[filetype] and not options.force_reload) then
     return
   end
 

--- a/lua/lsp/null-ls/linters.lua
+++ b/lua/lsp/null-ls/linters.lua
@@ -63,7 +63,7 @@ function M.list_configured(linter_configs)
 end
 
 function M.setup(filetype, options)
-  if linters_by_ft[filetype] and not options.force_reload then
+  if (linters_by_ft[filetype] and not options.force_reload) or not lvim.lang[filetype] then
     return
   end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes two issues

1. linters for `vim` files was set to `{""} ` in `default-config.lua` which is wrong.
<img width="1015" alt="Screen Shot 2021-08-19 at 6 16 32 PM" src="https://user-images.githubusercontent.com/10992695/130079698-78ee695e-2a4c-4ad5-b259-67c427a3e53f.png">

2. we didn't check for the existence of `lvim.lang[filetype]` before using it, which cause this error
<img width="1107" alt="Screen Shot 2021-08-19 at 6 17 52 PM" src="https://user-images.githubusercontent.com/10992695/130079899-60bc8b45-91f6-48d4-ba17-15a841028b65.png">


## How Has This Been Tested?

opened a sample `.vim` file and a sample `.rmd` file without any errors
