### PR TITLE
fix: set runtime directories correctly

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,24 +1,21 @@
---    __                          _    ___
---   / /   __  ______  ____ _____| |  / (_)___ ___
---  / /   / / / / __ \/ __ `/ ___/ | / / / __ `__ \
--- / /___/ /_/ / / / / /_/ / /   | |/ / / / / / / /
---/_____/\__,_/_/ /_/\__,_/_/    |___/_/_/ /_/ /_/
+-- {{{ Bootstrap
+local home_dir = vim.loop.os_homedir()
 
---- Bootstrap
-vim.opt.rtp:append(os.getenv "HOME" .. "/.local/share/lunarvim/lvim")
+vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/lvim")
 
-vim.opt.rtp:remove(os.getenv "HOME" .. "/.config/nvim")
-vim.opt.rtp:remove(os.getenv "HOME" .. "/.config/nvim/after")
-vim.opt.rtp:append(os.getenv "HOME" .. "/.config/lvim")
-vim.opt.rtp:append(os.getenv "HOME" .. "/.config/lvim/after")
+vim.opt.rtp:remove(home_dir .. "/.config/nvim")
+vim.opt.rtp:remove(home_dir .. "/.config/nvim/after")
+vim.opt.rtp:append(home_dir .. "/.config/lvim")
+vim.opt.rtp:append(home_dir .. "/.config/lvim/after")
 
-vim.opt.rtp:remove(os.getenv "HOME" .. "/.local/share/nvim/site")
-vim.opt.rtp:remove(os.getenv "HOME" .. "/.local/share/nvim/site/after")
-vim.opt.rtp:append(os.getenv "HOME" .. "/.local/share/lunarvim/site")
-vim.opt.rtp:append(os.getenv "HOME" .. "/.local/share/lunarvim/site/after")
+vim.opt.rtp:remove(home_dir .. "/.local/share/nvim/site")
+vim.opt.rtp:remove(home_dir .. "/.local/share/nvim/site/after")
+vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/site")
+vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/site/after")
 
 -- TODO: we need something like this: vim.opt.packpath = vim.opt.rtp
 vim.cmd [[let &packpath = &runtimepath]]
+-- }}}
 
 local function file_exists(name)
   local f = io.open(name, "r")

--- a/init.lua
+++ b/init.lua
@@ -1,16 +1,24 @@
-vim.cmd [[
-  set packpath-=~/.config/nvim
-  set packpath-=~/.config/nvim/after
-  set packpath-=~/.local/share/nvim/site
-  set packpath^=~/.local/share/lunarvim/site
-  set packpath^=~/.config/lvim
+--    __                          _    ___
+--   / /   __  ______  ____ _____| |  / (_)___ ___
+--  / /   / / / / __ \/ __ `/ ___/ | / / / __ `__ \
+-- / /___/ /_/ / / / / /_/ / /   | |/ / / / / / / /
+--/_____/\__,_/_/ /_/\__,_/_/    |___/_/_/ /_/ /_/
 
-  set runtimepath-=~/.config/nvim
-  set runtimepath-=~/.config/nvim/after
-  set runtimepath+=~/.config/lvim
-  set runtimepath^=~/.local/share/lunarvim/lvim/after
-]]
--- vim.opt.rtp:append() instead of vim.cmd ?
+--- Bootstrap
+vim.opt.rtp:append(os.getenv "HOME" .. "/.local/share/lunarvim/lvim")
+
+vim.opt.rtp:remove(os.getenv "HOME" .. "/.config/nvim")
+vim.opt.rtp:remove(os.getenv "HOME" .. "/.config/nvim/after")
+vim.opt.rtp:append(os.getenv "HOME" .. "/.config/lvim")
+vim.opt.rtp:append(os.getenv "HOME" .. "/.config/lvim/after")
+
+vim.opt.rtp:remove(os.getenv "HOME" .. "/.local/share/nvim/site")
+vim.opt.rtp:remove(os.getenv "HOME" .. "/.local/share/nvim/site/after")
+vim.opt.rtp:append(os.getenv "HOME" .. "/.local/share/lunarvim/site")
+vim.opt.rtp:append(os.getenv "HOME" .. "/.local/share/lunarvim/site/after")
+
+-- TODO: we need something like this: vim.opt.packpath = vim.opt.rtp
+vim.cmd [[let &packpath = &runtimepath]]
 
 local function file_exists(name)
   local f = io.open(name, "r")

--- a/utils/bin/lvim
+++ b/utils/bin/lvim
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-exec nvim -u ~/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=~/.local/share/lunarvim/lvim" "$@"
+LUNARVIM_RUNTIME_DIR=${LUNARVIM_RUNTIME_DIR:-"$HOME/.local/share/lunarvim"}
+
+exec nvim -u "$LUNARVIM_RUNTIME_DIR"/lvim/init.lua "$@"


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This also simplifies the way to invoke LunarVim to just be:
`nvim -u "$LUNARVIM_RUNTIME_DIR/lvim/init.lua"`

Fixes #1352

## How Has This Been Tested?

Add this to test the rtp variable more easily

```lua
print("-- rtp list: ")
local rtp_list = vim.opt.rtp:get()
local user_rtp_list = {}
for _, path in pairs(rtp_list) do
    if vim.startswith(path, "/home") and not path:match(".*packer.*") then
        table.insert(user_rtp_list, path)
        print(vim.inspect(path))
    end
end

print("-- pack list: ")
local pack_list = vim.opt.packpath:get()
local user_pack_list = {}
for _, path in pairs(pack_list) do
    if vim.startswith(path, "/home") and not path:match(".*packer.*") then
        table.insert(user_pack_list, path)
        print(vim.inspect(path))
    end
end
```

You can now start LunarVim by just using `nvim -u "$LUNARVIM_RUNTIME_DIR/lvim/init.lua"` :)
