### PR TITLE
[Feature]: Add show_hidden option to project module

### DIFF
--- a/lua/core/project.lua
+++ b/lua/core/project.lua
@@ -20,6 +20,9 @@ function M.config()
     -- detection_methods
     patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
 
+    -- Show hidden files in telescope
+    show_hidden = false,
+
     -- When set to false, you will get a message when project.nvim changes your
     -- directory.
     silent_chdir = true,


### PR DESCRIPTION
# Description

Adds the `show_hidden` option to show hidden files in project module telescope.

## How Has This Been Tested?

By adding the option to my config.lua

