### PR TITLE
[fix]: don't overwrite dashboard config

### DIFF
--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -31,7 +31,10 @@ M.config = function()
         description = { "  Find File          " },
         command = "Telescope find_files",
       },
-      -- b is reserved for the core.project module
+      b = {
+        description = { "  Recent Projects    " },
+        command = "Telescope projects",
+      },
       c = {
         description = { "  Recently Used Files" },
         command = "Telescope oldfiles",

--- a/lua/core/project.lua
+++ b/lua/core/project.lua
@@ -2,50 +2,43 @@ local M = {}
 --
 function M.config()
   lvim.builtin.project = {
-    --- This is on by default since it's currently the expected behavior.
     ---@usage set to false to disable project.nvim.
+    --- This is on by default since it's currently the expected behavior.
     active = true,
 
-    -- Manual mode doesn't automatically change your root directory, so you have
-    -- the option to manually do so using `:ProjectRoot` command.
+    ---@usage set to true to disable setting the current-woriking directory
+    --- Manual mode doesn't automatically change your root directory, so you have
+    --- the option to manually do so using `:ProjectRoot` command.
     manual_mode = false,
 
-    -- Methods of detecting the root directory. **"lsp"** uses the native neovim
-    -- lsp, while **"pattern"** uses vim-rooter like glob pattern matching. Here
-    -- order matters: if one is not detected, the other is used as fallback. You
-    -- can also delete or rearangne the detection methods.
+    ---@usage Methods of detecting the root directory
+    --- Allowed values: **"lsp"** uses the native neovim lsp
+    --- **"pattern"** uses vim-rooter like glob pattern matching. Here
+    --- order matters: if one is not detected, the other is used as fallback. You
+    --- can also delete or rearangne the detection methods.
     detection_methods = { "lsp", "pattern" },
 
-    -- All the patterns used to detect root dir, when **"pattern"** is in
-    -- detection_methods
+    ---@usage patterns used to detect root dir, when **"pattern"** is in detection_methods
     patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
 
-    -- Show hidden files in telescope
+    ---@ Show hidden files in telescope when searching for files in a project
     show_hidden = false,
 
-    -- When set to false, you will get a message when project.nvim changes your
-    -- directory.
+    ---@usage When set to false, you will get a message when project.nvim changes your directory.
+    -- When set to false, you will get a message when project.nvim changes your directory.
     silent_chdir = true,
+
+    ---@usage list of lsp client names to ignore when using **lsp** detection. eg: { "efm", ... }
+    ignore_lsp = {},
+
+    ---@type string
+    ---@usage path to store the project history for use in telescope
+    datapath = CACHE_PATH,
   }
 end
 --
 function M.setup()
-  local settings = lvim.builtin.project
-
-  -- Table of lsp clients to ignore by name
-  -- eg: { "efm", ... }
-  settings["ignore_lsp"] = {}
-
-  -- Path where project.nvim will store the project history for use in
-  -- telescope
-  settings["datapath"] = CACHE_PATH
-
-  require("project_nvim").setup(settings)
-
-  lvim.builtin.dashboard.custom_section["b"] = {
-    description = { "  Recent Projects    " },
-    command = "Telescope projects",
-  }
+  require("project_nvim").setup(lvim.builtin.project)
 end
 --
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Don't overwrite dashboard config from the project setup function. Also, allow the rest of the settings to be configurable.

## How Has This Been Tested?

It was always setting the second slot in the dashboard to be "Recent Projects", that is not the case anymore.

