### PR TITLE
fix: limit shfmt scope to utils to avoid surprises

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ repos:
         language: system
         types: [shell]
         entry: bash
-        args: [-c, "shfmt -f $(git rev-parse --show-toplevel) | grep -v jdtls | xargs shfmt -i=2 -ci -w"]
+        args: [-c, "shfmt -f \"$(git rev-parse --show-toplevel)\"/utils | grep -v jdtls | xargs shfmt -i=2 -ci -w"]
       - id: shellcheck
         name: shellcheck
         language: system
         types: [shell]
         entry: bash
         args:
-          [-c, "shfmt -f $(git rev-parse --show-toplevel) | grep -v jdtls | xargs shellcheck"]
+          [-c, "shfmt -f \"$(git rev-parse --show-toplevel)\"/utils | grep -v jdtls | xargs shellcheck"]
       - id: stylua
         name: StyLua
         language: rust


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Limit `shfmt` scope to `./utils` because it was somehow wanting to run on `lunarvim/site`


## How Has This Been Tested?

`pre-commit run shfmt`
