### PR TITLE
[Refactor]: Disable sumneko_lua telemetry by default

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -652,6 +652,7 @@ lvim.lang = {
               maxPreload = 100000,
               preloadFileSize = 1000,
             },
+            telemetry = { enable = false },
           },
         },
       },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Disable's telemetry from sumneko lua lsp by default.

## How Has This Been Tested?

N/A, but this setting is also in folke/luadev so it must work.

