### PR TITLE
fix telescope.project call in sample config (without ts)

### DIFF
--- a/utils/installer/config.example-no-ts.lua
+++ b/utils/installer/config.example-no-ts.lua
@@ -28,7 +28,7 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- end
 
 -- Use which-key to add extra bindings with the leader-key prefix
--- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }
+-- lvim.builtin.which_key.mappings["P"] = { "<cmd>Telescope projects<CR>", "Projects" }
 -- lvim.builtin.which_key.mappings["t"] = {
 --   name = "+Trouble",
 --   r = { "<cmd>Trouble lsp_references<cr>", "References" },


### PR DESCRIPTION
# Description

One sample config fixed call to telescope project. Another sample config got outdated instruction, this commit is updating that one too.
