### PR TITLE
refactor: use more flexible paths

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -4,9 +4,6 @@ stds.nvim = {
   globals = {
     "lvim",
     vim = { fields = { "g" } },
-    "CONFIG_PATH",
-    "CACHE_PATH",
-    "DATA_PATH",
     "TERMINAL",
     "USER",
     "C",
@@ -21,6 +18,10 @@ stds.nvim = {
     "jit",
     "os",
     "vim",
+    "join_paths",
+    "get_runtime_dir",
+    "get_config_dir",
+    "get_cache_dir",
     -- vim = { fields = { "cmd", "api", "fn", "o" } },
   },
 }

--- a/init.lua
+++ b/init.lua
@@ -1,60 +1,27 @@
--- {{{ Bootstrap
-local home_dir = vim.loop.os_homedir()
+if os.getenv "LUNARVIM_RUNTIME_DIR" then
+  local path_sep = vim.loop.os_uname().version:match "Windows" and "\\" or "/"
+  vim.opt.rtp:append(os.getenv "LUNARVIM_RUNTIME_DIR" .. path_sep .. "lvim")
+end
 
-vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/lvim")
-
-vim.opt.rtp:remove(home_dir .. "/.local/share/nvim/site")
-vim.opt.rtp:remove(home_dir .. "/.local/share/nvim/site/after")
-vim.opt.rtp:prepend(home_dir .. "/.local/share/lunarvim/site")
-vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/site/after")
-
-vim.opt.rtp:remove(home_dir .. "/.config/nvim")
-vim.opt.rtp:remove(home_dir .. "/.config/nvim/after")
-vim.opt.rtp:prepend(home_dir .. "/.config/lvim")
-vim.opt.rtp:append(home_dir .. "/.config/lvim/after")
-
--- TODO: we need something like this: vim.opt.packpath = vim.opt.rtp
-vim.cmd [[let &packpath = &runtimepath]]
--- }}}
-
-_G.PLENARY_DEBUG = false -- Plenary destroys cache with this undocumented flag set to true by default
-require("impatient").setup {
-  path = vim.fn.stdpath "cache" .. "/lvim_cache",
-  enable_profiling = true,
-}
+require("bootstrap"):init()
 
 local config = require "config"
-config:init()
+-- config:init()
 config:load()
 
 local plugins = require "plugins"
-local plugin_loader = require("plugin-loader").init()
-plugin_loader:load { plugins, lvim.plugins }
+require("plugin-loader"):load { plugins, lvim.plugins }
 
 local Log = require "core.log"
-Log:info "Starting LunarVim"
+Log:debug "Starting LunarVim"
 
 vim.g.colors_name = lvim.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
 vim.cmd("colorscheme " .. lvim.colorscheme)
 
-local utils = require "utils"
-utils.toggle_autoformat()
+require("utils").toggle_autoformat()
 local commands = require "core.commands"
 commands.load(commands.defaults)
 
-require("lsp").config()
-
-local null_status_ok, null_ls = pcall(require, "null-ls")
-if null_status_ok then
-  null_ls.config {}
-  require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
-end
-
-local lsp_settings_status_ok, lsp_settings = pcall(require, "nlspsettings")
-if lsp_settings_status_ok then
-  lsp_settings.setup {
-    config_home = home_dir .. "/.config/lvim/lsp-settings",
-  }
-end
+require("lsp").global_setup()
 
 require("keymappings").setup()

--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -1,0 +1,82 @@
+local M = {}
+-- It's not safe to require 'utils' without adjusting the runtimepath
+function _G.join_paths(...)
+  local uv = vim.loop
+  local path_sep = uv.os_uname().version:match "Windows" and "\\" or "/"
+  local result = table.concat({ ... }, path_sep)
+  return result
+end
+
+function _G.get_runtime_dir()
+  local lvim_runtime_dir = os.getenv "LUNARVIM_RUNTIME_DIR"
+  if not lvim_runtime_dir then
+    -- when nvim is used directly
+    return vim.fn.stdpath "config"
+  end
+  return lvim_runtime_dir
+end
+
+function _G.get_config_dir()
+  local lvim_config_dir = os.getenv "LUNARVIM_CONFIG_DIR"
+  if not lvim_config_dir then
+    return vim.fn.stdpath "config"
+  end
+  return lvim_config_dir
+end
+
+function _G.get_cache_dir()
+  local lvim_cache_dir = os.getenv "LUNARVIM_CACHE_DIR"
+  if not lvim_cache_dir then
+    return vim.fn.stdpath "cache"
+  end
+  return lvim_cache_dir
+end
+
+function M:init()
+  self.runtime_dir = get_runtime_dir()
+  self.config_dir = get_config_dir()
+  self.cache_path = get_cache_dir()
+
+  self.pack_dir = join_paths(self.runtime_dir, "site", "pack")
+
+  if os.getenv "LUNARVIM_RUNTIME_DIR" then
+    vim.opt.rtp:remove(join_paths(vim.fn.stdpath "data", "site"))
+    vim.opt.rtp:remove(join_paths(vim.fn.stdpath "data", "site", "after"))
+    vim.opt.rtp:prepend(join_paths(self.runtime_dir, "site"))
+    vim.opt.rtp:append(join_paths(self.runtime_dir, "site", "after"))
+
+    vim.opt.rtp:remove(vim.fn.stdpath "config")
+    vim.opt.rtp:remove(join_paths(vim.fn.stdpath "config", "after"))
+    vim.opt.rtp:prepend(self.config_dir)
+    vim.opt.rtp:append(join_paths(self.config_dir, "after"))
+    -- TODO: we need something like this: vim.opt.packpath = vim.opt.rtp
+
+    vim.cmd [[let &packpath = &runtimepath]]
+    vim.cmd("set spellfile=" .. join_paths(self.config_dir, "spell", "en.utf-8.add"))
+  end
+
+  -- FIXME: currently unreliable in unit-tests
+  if not os.getenv "LVIM_TEST_ENV" then
+    require("impatient").setup {
+      path = vim.fn.stdpath "cache" .. "/lvim_cache",
+      enable_profiling = true,
+    }
+  end
+
+  local config = require "config"
+  config:init {
+    path = join_paths(self.config_dir, "config.lua"),
+  }
+
+  require("plugin-loader"):init {
+    cache_path = self.cache_path,
+    runtime_dir = self.runtime_dir,
+    config_dir = self.config_dir,
+    package_root = join_paths(self.runtime_dir, "site", "pack"),
+    compile_path = join_paths(self.config_dir, "plugin", "packer_compiled.lua"),
+  }
+
+  return self
+end
+
+return M

--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -1,8 +1,7 @@
 local home_dir = vim.loop.os_homedir()
-CONFIG_PATH = home_dir .. "/.local/share/lunarvim/lvim"
-DATA_PATH = vim.fn.stdpath "data"
-CACHE_PATH = vim.fn.stdpath "cache"
-vim.cmd [[ set spellfile=~/.config/lvim/spell/en.utf-8.add ]]
+local utils = require "utils"
+-- FIXME: stop using hard-coded paths for LspInstall
+local ls_install_prefix = vim.fn.stdpath "data" .. "/lspinstall"
 
 lvim = {
   leader = "space",
@@ -10,8 +9,8 @@ lvim = {
   line_wrap_cursor_movement = true,
   transparent_window = false,
   format_on_save = true,
-  vsnip_dir = home_dir .. "/.config/snippets",
-  database = { save_location = "~/.config/lunarvim_db", auto_execute = 1 },
+  vsnip_dir = utils.join_paths(home_dir, ".config", "snippets"),
+  database = { save_location = utils.join_paths(home_dir, ".config", "lunarvim_db"), auto_execute = 1 },
   keys = {},
 
   builtin = {},
@@ -140,7 +139,7 @@ lvim.lang = {
       setup = {
         cmd = {
           "dotnet",
-          DATA_PATH .. "/lspinstall/bicep/Bicep.LangServer.dll",
+          ls_install_prefix .. "/bicep/Bicep.LangServer.dll",
         },
         filetypes = { "bicep" },
       },
@@ -162,7 +161,7 @@ lvim.lang = {
       provider = "clangd",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/cpp/clangd/bin/clangd",
+          ls_install_prefix .. "/cpp/clangd/bin/clangd",
           "--background-index",
           "--header-insertion=never",
           "--cross-file-rename",
@@ -188,7 +187,7 @@ lvim.lang = {
       provider = "clangd",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/cpp/clangd/bin/clangd",
+          ls_install_prefix .. "/cpp/clangd/bin/clangd",
           "--background-index",
           "--header-insertion=never",
           "--cross-file-rename",
@@ -229,7 +228,7 @@ lvim.lang = {
       provider = "omnisharp",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/csharp/omnisharp/run",
+          ls_install_prefix .. "/csharp/omnisharp/run",
           "--languageserver",
           "--hostPID",
           tostring(vim.fn.getpid()),
@@ -249,7 +248,7 @@ lvim.lang = {
       provider = "cmake",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/cmake/venv/bin/cmake-language-server",
+          ls_install_prefix .. "/cmake/venv/bin/cmake-language-server",
         },
       },
     },
@@ -261,7 +260,7 @@ lvim.lang = {
       provider = "clojure_lsp",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/clojure/clojure-lsp",
+          ls_install_prefix .. "/clojure/clojure-lsp",
         },
       },
     },
@@ -283,7 +282,7 @@ lvim.lang = {
       setup = {
         cmd = {
           "node",
-          DATA_PATH .. "/lspinstall/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
+          ls_install_prefix .. "/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
           "--stdio",
         },
       },
@@ -306,7 +305,7 @@ lvim.lang = {
       setup = {
         cmd = {
           "node",
-          DATA_PATH .. "/lspinstall/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
+          ls_install_prefix .. "/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
           "--stdio",
         },
       },
@@ -353,7 +352,7 @@ lvim.lang = {
       provider = "dockerls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/dockerfile/node_modules/.bin/docker-langserver",
+          ls_install_prefix .. "/dockerfile/node_modules/.bin/docker-langserver",
           "--stdio",
         },
       },
@@ -371,7 +370,7 @@ lvim.lang = {
       provider = "elixirls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/elixir/elixir-ls/language_server.sh",
+          ls_install_prefix .. "/elixir/elixir-ls/language_server.sh",
         },
       },
     },
@@ -388,13 +387,13 @@ lvim.lang = {
       provider = "elmls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/elm/node_modules/.bin/elm-language-server",
+          ls_install_prefix .. "/elm/node_modules/.bin/elm-language-server",
         },
         -- init_options = {
         -- elmAnalyseTrigger = "change",
-        -- elmFormatPath = DATA_PATH .. "/lspinstall/elm/node_modules/.bin/elm-format",
-        -- elmPath = DATA_PATH .. "/lspinstall/elm/node_modules/.bin/",
-        -- elmTestPath = DATA_PATH .. "/lspinstall/elm/node_modules/.bin/elm-test",
+        -- elmFormatPath = ls_install_prefix .. "/elm/node_modules/.bin/elm-format",
+        -- elmPath = ls_install_prefix .. "/elm/node_modules/.bin/",
+        -- elmTestPath = ls_install_prefix .. "/elm/node_modules/.bin/elm-test",
         -- },
       },
     },
@@ -437,7 +436,7 @@ lvim.lang = {
       provider = "fortls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/fortran/venv/bin/fortls",
+          ls_install_prefix .. "/fortran/venv/bin/fortls",
         },
       },
     },
@@ -462,7 +461,7 @@ lvim.lang = {
       provider = "gopls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/go/gopls",
+          ls_install_prefix .. "/go/gopls",
         },
       },
     },
@@ -488,7 +487,7 @@ lvim.lang = {
     lsp = {
       provider = "hls",
       setup = {
-        cmd = { DATA_PATH .. "/lspinstall/haskell/hls" },
+        cmd = { ls_install_prefix .. "/haskell/hls" },
       },
     },
   },
@@ -509,7 +508,7 @@ lvim.lang = {
       setup = {
         cmd = {
           "node",
-          DATA_PATH .. "/lspinstall/html/vscode-html/html-language-features/server/dist/node/htmlServerMain.js",
+          ls_install_prefix .. "/html/vscode-html/html-language-features/server/dist/node/htmlServerMain.js",
           "--stdio",
         },
       },
@@ -530,7 +529,7 @@ lvim.lang = {
     lsp = {
       provider = "jdtls",
       setup = {
-        cmd = { DATA_PATH .. "/lspinstall/java/jdtls.sh" },
+        cmd = { ls_install_prefix .. "/java/jdtls.sh" },
       },
     },
   },
@@ -555,7 +554,7 @@ lvim.lang = {
       setup = {
         cmd = {
           "node",
-          DATA_PATH .. "/lspinstall/json/vscode-json/json-language-features/server/dist/node/jsonServerMain.js",
+          ls_install_prefix .. "/json/vscode-json/json-language-features/server/dist/node/jsonServerMain.js",
           "--stdio",
         },
         settings = {
@@ -589,8 +588,7 @@ lvim.lang = {
           "julia",
           "--startup-file=no",
           "--history-file=no",
-          -- vim.fn.expand "~/.config/nvim/lua/lsp/julia/run.jl",
-          CONFIG_PATH .. "/utils/julia/run.jl",
+          -- self.runtime_dir .. "lvim/utils/julia/run.jl",
         },
       },
     },
@@ -602,7 +600,7 @@ lvim.lang = {
       provider = "kotlin_language_server",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/kotlin/server/bin/kotlin-language-server",
+          ls_install_prefix .. "/kotlin/server/bin/kotlin-language-server",
         },
         root_dir = function(fname)
           local util = require "lspconfig/util"
@@ -639,9 +637,9 @@ lvim.lang = {
       provider = "sumneko_lua",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/lua/sumneko-lua-language-server",
+          ls_install_prefix .. "/lua/sumneko-lua-language-server",
           "-E",
-          DATA_PATH .. "/lspinstall/lua/main.lua",
+          ls_install_prefix .. "/lua/main.lua",
         },
         settings = {
           Lua = {
@@ -658,7 +656,7 @@ lvim.lang = {
             workspace = {
               -- Make the server aware of Neovim runtime files
               library = {
-                [vim.fn.expand "~/.local/share/lunarvim/lvim/lua"] = true,
+                [require("utils").join_paths(get_runtime_dir(), "lvim", "lua")] = true,
                 [vim.fn.expand "$VIMRUNTIME/lua"] = true,
                 [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
               },
@@ -733,7 +731,7 @@ lvim.lang = {
       provider = "intelephense",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/php/node_modules/.bin/intelephense",
+          ls_install_prefix .. "/php/node_modules/.bin/intelephense",
           "--stdio",
         },
         filetypes = { "php", "phtml" },
@@ -754,7 +752,7 @@ lvim.lang = {
       provider = "puppet",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/puppet/puppet-editor-services/puppet-languageserver",
+          ls_install_prefix .. "/puppet/puppet-editor-services/puppet-languageserver",
           "--stdio",
         },
       },
@@ -782,7 +780,7 @@ lvim.lang = {
       setup = {
         cmd = {
           -- TODO:
-          DATA_PATH .. "/lspinstall/typescript/node_modules/.bin/typescript-language-server",
+          ls_install_prefix .. "/typescript/node_modules/.bin/typescript-language-server",
           "--stdio",
         },
       },
@@ -809,7 +807,7 @@ lvim.lang = {
       setup = {
         cmd = {
           -- TODO:
-          DATA_PATH .. "/lspinstall/typescript/node_modules/.bin/typescript-language-server",
+          ls_install_prefix .. "/typescript/node_modules/.bin/typescript-language-server",
           "--stdio",
         },
       },
@@ -831,7 +829,7 @@ lvim.lang = {
       provider = "pyright",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/python/node_modules/.bin/pyright-langserver",
+          ls_install_prefix .. "/python/node_modules/.bin/pyright-langserver",
           "--stdio",
         },
       },
@@ -871,7 +869,7 @@ lvim.lang = {
       provider = "solargraph",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/ruby/solargraph/solargraph",
+          ls_install_prefix .. "/ruby/solargraph/solargraph",
           "stdio",
         },
         filetypes = { "ruby" },
@@ -902,7 +900,7 @@ lvim.lang = {
       provider = "rust_analyzer",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/rust/rust-analyzer",
+          ls_install_prefix .. "/rust/rust-analyzer",
         },
       },
     },
@@ -932,7 +930,7 @@ lvim.lang = {
       provider = "bashls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server",
+          ls_install_prefix .. "/bash/node_modules/.bin/bash-language-server",
           "start",
         },
       },
@@ -945,7 +943,7 @@ lvim.lang = {
       provider = "svelte",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/svelte/node_modules/.bin/svelteserver",
+          ls_install_prefix .. "/svelte/node_modules/.bin/svelteserver",
           "--stdio",
         },
       },
@@ -975,7 +973,7 @@ lvim.lang = {
       provider = "tailwindcss",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/tailwindcss/node_modules/.bin/tailwindcss-language-server",
+          ls_install_prefix .. "/tailwindcss/node_modules/.bin/tailwindcss-language-server",
           "--stdio",
         },
       },
@@ -993,7 +991,7 @@ lvim.lang = {
       provider = "terraformls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/terraform/terraform-ls",
+          ls_install_prefix .. "/terraform/terraform-ls",
           "serve",
         },
       },
@@ -1005,7 +1003,7 @@ lvim.lang = {
     lsp = {
       provider = "texlab",
       setup = {
-        cmd = { DATA_PATH .. "/lspinstall/latex/texlab" },
+        cmd = { ls_install_prefix .. "/latex/texlab" },
       },
     },
   },
@@ -1030,7 +1028,7 @@ lvim.lang = {
       setup = {
         cmd = {
           -- TODO:
-          DATA_PATH .. "/lspinstall/typescript/node_modules/.bin/typescript-language-server",
+          ls_install_prefix .. "/typescript/node_modules/.bin/typescript-language-server",
           "--stdio",
         },
       },
@@ -1058,7 +1056,7 @@ lvim.lang = {
       setup = {
         cmd = {
           -- TODO:
-          DATA_PATH .. "/lspinstall/typescript/node_modules/.bin/typescript-language-server",
+          ls_install_prefix .. "/typescript/node_modules/.bin/typescript-language-server",
           "--stdio",
         },
       },
@@ -1071,7 +1069,7 @@ lvim.lang = {
       provider = "vimls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/vim/node_modules/.bin/vim-language-server",
+          ls_install_prefix .. "/vim/node_modules/.bin/vim-language-server",
           "--stdio",
         },
       },
@@ -1097,7 +1095,7 @@ lvim.lang = {
       provider = "vuels",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/vue/node_modules/.bin/vls",
+          ls_install_prefix .. "/vue/node_modules/.bin/vls",
         },
         root_dir = function(fname)
           local util = require "lspconfig/util"
@@ -1139,7 +1137,7 @@ lvim.lang = {
       provider = "yamlls",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/yaml/node_modules/.bin/yaml-language-server",
+          ls_install_prefix .. "/yaml/node_modules/.bin/yaml-language-server",
           "--stdio",
         },
       },

--- a/lua/config/init.lua
+++ b/lua/config/init.lua
@@ -1,20 +1,13 @@
-local home_dir = vim.loop.os_homedir()
-local M = {
-  path = string.format("%s/.config/lvim/config.lua", home_dir),
-}
+local M = {}
 
 --- Initialize lvim default configuration
 -- Define lvim global variable
-function M:init()
+function M:init(opts)
+  opts = opts or {}
+  self.path = opts.path
   local utils = require "utils"
 
   require "config.defaults"
-
-  local builtins = require "core.builtins"
-  builtins.config(self)
-
-  local settings = require "config.settings"
-  settings.load_options()
 
   -- Fallback config.lua to lv-config.lua
   if not utils.is_file(self.path) then
@@ -23,6 +16,12 @@ function M:init()
 
     self.path = lv_config
   end
+
+  local builtins = require "core.builtins"
+  builtins.config(self)
+
+  local settings = require "config.settings"
+  settings.load_options()
 end
 
 --- Override the configuration with a user provided one

--- a/lua/config/settings.lua
+++ b/lua/config/settings.lua
@@ -1,5 +1,5 @@
 local M = {}
-
+local utils = require "utils"
 M.load_options = function()
   local default_options = {
     backup = false, -- creates a backup file
@@ -28,7 +28,7 @@ M.load_options = function()
     timeoutlen = 100, -- time to wait for a mapped sequence to complete (in milliseconds)
     title = true, -- set the title of window to the value of the titlestring
     -- opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
-    undodir = CACHE_PATH .. "/undo", -- set an undo directory
+    undodir = utils.join_paths(get_cache_dir(), "undo"), -- set an undo directory
     undofile = true, -- enable persistent undo
     updatetime = 300, -- faster completion
     writebackup = false, -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -1,5 +1,5 @@
 local M = {}
-local home_dir = vim.loop.os_homedir()
+local utils = require "utils"
 
 M.config = function(config)
   lvim.builtin.dashboard = {
@@ -7,7 +7,7 @@ M.config = function(config)
     on_config_done = nil,
     search_handler = "telescope",
     disable_at_vim_enter = 0,
-    session_directory = home_dir .. "/.cache/lvim/sessions",
+    session_directory = utils.join_paths(get_cache_dir(), "sessions"),
     custom_header = {
       "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⣀⣀⣀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
       "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣤⣶⣾⠿⠿⠟⠛⠛⠛⠛⠿⠿⣿⣷⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
@@ -68,15 +68,6 @@ M.setup = function()
   lvim.builtin.which_key.mappings[";"] = { "<cmd>Dashboard<CR>", "Dashboard" }
 
   vim.g.dashboard_session_directory = lvim.builtin.dashboard.session_directory
-
-  vim.cmd "let packages = len(globpath('~/.local/share/lunarvim/site/pack/packer/start', '*', 0, 1))"
-
-  vim.api.nvim_exec(
-    [[
-    let g:dashboard_custom_footer = ['LunarVim loaded '..packages..' plugins  ']
-]],
-    false
-  )
 
   require("core.autocmds").define_augroups {
     _dashboard = {

--- a/lua/core/project.lua
+++ b/lua/core/project.lua
@@ -35,7 +35,7 @@ function M.config()
 
     ---@type string
     ---@usage path to store the project history for use in telescope
-    datapath = CACHE_PATH,
+    datapath = get_cache_dir(),
   }
 end
 

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local utils = require "utils"
+
 function M.config()
   -- Define this minimal config so that it's available if telescope is not yet available.
   lvim.builtin.telescope = {
@@ -96,7 +98,7 @@ function M.find_lunarvim_files(opts)
     },
     prompt = ">> ",
     prompt_title = "~ LunarVim files ~",
-    cwd = CONFIG_PATH,
+    cwd = utils.join_paths(get_runtime_dir(), "lvim"),
     find_command = { "git", "ls-files" },
   }
   opts = vim.tbl_deep_extend("force", theme_opts, opts)
@@ -111,7 +113,7 @@ function M.grep_lunarvim_files(opts)
     layout_strategy = "bottom_pane",
     prompt = ">> ",
     prompt_title = "~ search LunarVim ~",
-    cwd = CONFIG_PATH,
+    cwd = utils.join_paths(get_runtime_dir(), "lvim"),
   }
   opts = vim.tbl_deep_extend("force", theme_opts, opts)
   require("telescope.builtin").live_grep(opts)

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -95,7 +95,7 @@ local function get_log_path(name)
   local logger = require "core.log"
   local file
   if name == "nvim" then
-    file = CACHE_PATH .. "/log"
+    file = utils.join_paths(get_cache_dir(), "log")
   else
     file = logger:new({ plugin = name }):get_path()
   end

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -176,7 +176,7 @@ M.config = function()
       L = {
         name = "+LunarVim",
         c = {
-          "<cmd>edit ~/.config/lvim/config.lua<cr>",
+          "<cmd>edit" .. get_config_dir() .. "/config.lua<cr>",
           "Edit config.lua",
         },
         f = {

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -1,16 +1,6 @@
 local M = {}
 local Log = require "core.log"
 
-function M.config()
-  vim.lsp.protocol.CompletionItemKind = lvim.lsp.completion.item_kind
-
-  for _, sign in ipairs(lvim.lsp.diagnostics.signs.values) do
-    vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })
-  end
-
-  require("lsp.handlers").setup()
-end
-
 local function lsp_highlight_document(client)
   if lvim.lsp.document_highlight == false then
     return -- we don't need further
@@ -156,6 +146,31 @@ function M.setup(lang)
     end
 
     lspconfig[lsp.provider].setup(lsp.setup)
+  end
+end
+
+function M.global_setup()
+  vim.lsp.protocol.CompletionItemKind = lvim.lsp.completion.item_kind
+
+  for _, sign in ipairs(lvim.lsp.diagnostics.signs.values) do
+    vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })
+  end
+
+  require("lsp.handlers").setup()
+
+  local null_status_ok, null_ls = pcall(require, "null-ls")
+  if null_status_ok then
+    null_ls.config()
+    require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
+  end
+
+  local utils = require "utils"
+
+  local lsp_settings_status_ok, lsp_settings = pcall(require, "nlspsettings")
+  if lsp_settings_status_ok then
+    lsp_settings.setup {
+      config_home = utils.join_paths(get_config_dir(), "lsp-settings"),
+    }
   end
 end
 

--- a/lua/plugin-loader.lua
+++ b/lua/plugin-loader.lua
@@ -1,9 +1,13 @@
 local plugin_loader = {}
 
-function plugin_loader:init()
-  local install_path = "~/.local/share/lunarvim/site/pack/packer/start/packer.nvim"
-  if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
-    vim.fn.system { "git", "clone", "https://github.com/wbthomason/packer.nvim", install_path }
+function plugin_loader:init(opts)
+  opts = opts or {}
+
+  local package_root = opts.package_root or vim.fn.stdpath "data" .. "/site/pack"
+  local compile_path = opts.compile_path or vim.fn.stdpath "config" .. "/plugin/packer_compile.lua"
+
+  if vim.fn.empty(vim.fn.glob(package_root)) > 0 then
+    vim.fn.system { "git", "clone", "--depth", "1", "https://github.com/wbthomason/packer.nvim", package_root }
     vim.cmd "packadd packer.nvim"
   end
 
@@ -12,15 +16,13 @@ function plugin_loader:init()
     return
   end
 
-  local util = require "packer.util"
-
   packer.init {
-    package_root = util.join_paths "~/.local/share/lunarvim/site/pack/",
-    compile_path = util.join_paths("~/.config/lvim", "plugin", "packer_compiled.lua"),
+    package_root = package_root,
+    compile_path = compile_path,
     git = { clone_timeout = 300 },
     display = {
       open_fn = function()
-        return util.float { border = "rounded" }
+        return require("packer.util").float { border = "rounded" }
       end,
     },
   }
@@ -39,8 +41,4 @@ function plugin_loader:load(configurations)
   end)
 end
 
-return {
-  init = function()
-    return plugin_loader:init()
-  end,
-}
+return plugin_loader

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -90,7 +90,7 @@ function utils.reload_lv_config()
   config:load()
 
   require("keymappings").setup() -- this should be done before loading the plugins
-  vim.cmd "source ~/.local/share/lunarvim/lvim/lua/plugins.lua"
+  vim.cmd("source " .. utils.join_paths(get_runtime_dir(), "lvim", "lua", "plugins.lua"))
   local plugins = require "plugins"
   local plugin_loader = require("plugin-loader").init()
   utils.toggle_autoformat()
@@ -125,6 +125,12 @@ end
 function utils.is_file(filename)
   local stat = uv.fs_stat(filename)
   return stat and stat.type == "file" or false
+end
+
+function utils.join_paths(...)
+  local path_sep = vim.loop.os_uname().version:match "Windows" and "\\" or "/"
+  local result = table.concat(vim.tbl_flatten { ... }, path_sep):gsub(path_sep .. "+", path_sep)
+  return result
 end
 
 return utils

--- a/tests/bootstrap_spec.lua
+++ b/tests/bootstrap_spec.lua
@@ -3,9 +3,13 @@ local a = require "plenary.async_lib.tests"
 a.describe("initial start", function()
   local uv = vim.loop
   local home_dir = uv.os_homedir()
-  -- TODO: update once #1381 is merged
-  local lvim_config_path = home_dir .. "/.config/lvim"
-  local lvim_runtime_path = home_dir .. "/.local/share/lunarvim/lvim"
+  local lvim_config_path = get_config_dir() or home_dir .. "/.config/lvim"
+  local lvim_runtime_path = get_runtime_dir() or home_dir .. "/.local/share/lunarvim"
+
+  a.it("shoud be able to detect test environment", function()
+    assert.truthy(os.getenv "LVIM_TEST_ENV")
+    assert.falsy(package.loaded["impatient"])
+  end)
 
   a.it("should not be reading default neovim directories in the home directoies", function()
     local rtp_list = vim.opt.rtp:get()
@@ -14,7 +18,7 @@ a.describe("initial start", function()
 
   a.it("should be able to read lunarvim directories", function()
     local rtp_list = vim.opt.rtp:get()
-    assert.truthy(vim.tbl_contains(rtp_list, lvim_runtime_path))
+    assert.truthy(vim.tbl_contains(rtp_list, lvim_runtime_path .. "/lvim"))
     assert.truthy(vim.tbl_contains(rtp_list, lvim_config_path))
   end)
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Remove most of the hard-coded paths that can lead to trouble on other platforms. 

NOTE: We are not able to `require` any modules before adjusting the `&rtp`. So any utility functions that are to be used need to be manually defined in `init.lua`.

TODO: 
[ ] make it work on the CI
[ ] fix `runtimepath` for windows, possible use it unmodified

## How Has This Been Tested?

It should start as normal.

