### PR TITLE
use `<leader>gd` to see git diff with previous head

### DIFF
--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -130,6 +130,10 @@ M.config = function()
           "<cmd>Telescope git_bcommits<cr>",
           "Checkout commit(for current file)",
         },
+        d = {
+          "<cmd>Gitsigns diffthis HEAD<cr>",
+          "Git Diff",
+        },
       },
 
       l = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add a simple git diff with prev header

Fixes #1363

## How Has This Been Tested?

open a file and use `<leader>gd` to see diff with `HEAD~1`
