### PR TITLE
[Hotfix] update tailwindcss cmd path to match lspinstall

### DIFF
--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -953,7 +953,7 @@ lvim.lang = {
       provider = "tailwindcss",
       setup = {
         cmd = {
-          DATA_PATH .. "/lspinstall/tailwindcss/tailwindcss-intellisense.sh",
+          DATA_PATH .. "/lspinstall/tailwindcss/node_modules/.bin/tailwindcss-language-server",
           "--stdio",
         },
       },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix tailwindcss address bcz of [this commit](https://github.com/kabouzeid/nvim-lspinstall/commit/bd3adbb94f07ee12f7a721ec45a94e7825c32c66#diff-2f2bb4dfdb18304474c7e8e159b5d96ba5dacca10502f99c8c93e92959ed6f9b)

## How Has This Been Tested?

open a sample file that uses tailwindcss and observer that it works!