### PR TITLE
[Bugfix] Fix cp cannot stat error during installation

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -214,7 +214,7 @@ function backup_old_config() {
       rsync --archive -hh --partial --progress --cvs-exclude \
         --modify-window=1 "$dir"/ "$dir.bak"
     else
-      cp -R "$dir/*" "$dir.bak/."
+      cp -R "$dir/"* "$dir.bak/."
     fi
   done
   echo "Backup operation complete"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

During installation, this error aries.
```
Would you like to check lunarvim's NodeJS dependencies?
[y]es or [n]o (default: no) :
Would you like to check lunarvim's Python dependencies?
[y]es or [n]o (default: no) :
Would you like to check lunarvim's Rust dependencies?
[y]es or [n]o (default: no) :
--------------------------------------------------------------------------------
Backing up old LunarVim configuration
cp: cannot stat '/home/user/.config/lvim/*': No such file or directory
```
The * should outside the quotes in `cp -R "$dir/*" "$dir.bak/."`

FYI, https://stackoverflow.com/questions/34254164/what-is-cp-cannot-stat-error-in-unix-i-get-this-error-when-trying-to-copy-thin/51239548

## How Has This Been Tested?

Reinstalling LunarVim. It worked.

