### PR TITLE
[Bugfix]$LUNARVIM_CONFIG_DIR doesn't exist on install.sh

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -258,7 +258,6 @@ function setup_lvim() {
   
     
   if [ ! -d "$LUNARVIM_CONFIG_DIR" ]; then
-   echo "$LUNARVIM_CONFIG_DIR not found"
    mkdir -p $LUNARVIM_CONFIG_DIR
   fi
   

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -256,12 +256,13 @@ function setup_lvim() {
 
   echo "Preparing Packer setup"
   
+    
   if [ ! -d "$LUNARVIM_CONFIG_DIR" ]; then
-    mkdir -p "$LUNARVIM_CONFIG_DIR"
+   echo "$LUNARVIM_CONFIG_DIR not found"
+   mkdir -p $LUNARVIM_CONFIG_DIR
   fi
-
-  cp "$LUNARVIM_RUNTIME_DIR/lvim/utils/installer/config.example-no-ts.lua" \
-    "$LUNARVIM_CONFIG_DIR/config.lua"
+  
+  cp -i $LUNARVIM_RUNTIME_DIR/lvim/utils/installer/config.example-no-ts.lua $LUNARVIM_CONFIG_DIR/config.lua
 
   nvim -u "$LUNARVIM_RUNTIME_DIR/lvim/init.lua" --headless \
     -c 'autocmd User PackerComplete quitall' \


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

fix $LUNARVIM_CONFIG_DIR doesn't exist on install.sh
when you use install script with overwrite params :
curl -LSs https://raw.githubusercontent.com/lunarvim/lunarvim/rolling/utils/installer/install.sh --output install.sh                                                                                                                     ─╯
LVBRANCH=rolling bash install.sh --overwrite

Fixes #(issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. \
Provide instructions so we can reproduce. \
Please also list any relevant details for your test configuration.

- Run command `:mycommand`
- Check logs
- ...

