### PR TITLE
[Feature]: Change whickey background color

### DIFF
--- a/lua/onedarker/Whichkey.lua
+++ b/lua/onedarker/Whichkey.lua
@@ -3,7 +3,7 @@ local Whichkey = {
   WhichKeySeperator = { fg = C.green },
   WhichKeyGroup = { fg = C.cyan },
   WhichKeyDesc = { fg = C.blue },
-  WhichKeyFloat = { bg = C.dark },
+  WhichKeyFloat = { bg = C.bg },
 }
 
 return Whichkey


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Changed Whickey background color from `#282c34` (dark) to `#1f2227` (bg) for smoother look .

Before:
<img width="1440" alt="Screen Shot 2021-08-31 at 19 26 44" src="https://user-images.githubusercontent.com/5767281/131542750-dba8fc9f-f838-452c-9d8b-449c114122e7.png">
(Notice how `#282c34` is looking like a secondary border here)

After:
<img width="1436" alt="Screen Shot 2021-08-31 at 19 27 18" src="https://user-images.githubusercontent.com/5767281/131542779-1ef832fa-a545-4b97-b694-690dd6a3b3dc.png">

## How Has This Been Tested?

No need for testing.
