### PR TITLE
[Feature]: Add new which-key command for switching to the last buffer

### DIFF
--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -72,26 +72,26 @@ M.config = function()
       ["h"] = { "<cmd>nohlsearch<CR>", "No Highlight" },
       b = {
         name = "Buffers",
-        j = { "<cmd>BufferPick<cr>", "jump to buffer" },
-        f = { "<cmd>Telescope buffers<cr>", "Find buffer" },
-        b = { ":b#<cr>", "go back to previous buffer" },
-        w = { "<cmd>BufferWipeout<cr>", "wipeout buffer" },
+        j = { "<cmd>BufferPick<cr>", "Jump" },
+        f = { "<cmd>Telescope buffers<cr>", "Find" },
+        b = { "<cmd>b#<cr>", "Previous" },
+        w = { "<cmd>BufferWipeout<cr>", "Wipeout" },
         e = {
           "<cmd>BufferCloseAllButCurrent<cr>",
-          "close all but current buffer",
+          "Close all but current",
         },
-        h = { "<cmd>BufferCloseBuffersLeft<cr>", "close all buffers to the left" },
-        l = {
+        l = { "<cmd>BufferCloseBuffersLeft<cr>", "Close all - left" },
+        r = {
           "<cmd>BufferCloseBuffersRight<cr>",
-          "close all BufferLines to the right",
+          "Close all - right",
         },
         D = {
           "<cmd>BufferOrderByDirectory<cr>",
-          "sort BufferLines automatically by directory",
+          "Sort by directory",
         },
         L = {
           "<cmd>BufferOrderByLanguage<cr>",
-          "sort BufferLines automatically by language",
+          "Sort by language",
         },
       },
       p = {

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -74,6 +74,7 @@ M.config = function()
         name = "Buffers",
         j = { "<cmd>BufferPick<cr>", "jump to buffer" },
         f = { "<cmd>Telescope buffers<cr>", "Find buffer" },
+        b = { ":b#<cr>", "go back to previous buffer" },
         w = { "<cmd>BufferWipeout<cr>", "wipeout buffer" },
         e = {
           "<cmd>BufferCloseAllButCurrent<cr>",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adds ability to switch back to the previous buffer (like alt+tab in windows). Which-key command is `<leader> -> b -> b`

https://user-images.githubusercontent.com/5767281/131635300-ea41deb7-3af2-4ccc-829c-57f62d913da6.mp4



## How Has This Been Tested?

No need for testing, it's just a new which-key command.

