### PR TITLE
[Bug]: fix runtime path order

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,15 +3,15 @@ local home_dir = vim.loop.os_homedir()
 
 vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/lvim")
 
-vim.opt.rtp:remove(home_dir .. "/.config/nvim")
-vim.opt.rtp:remove(home_dir .. "/.config/nvim/after")
-vim.opt.rtp:append(home_dir .. "/.config/lvim")
-vim.opt.rtp:append(home_dir .. "/.config/lvim/after")
-
 vim.opt.rtp:remove(home_dir .. "/.local/share/nvim/site")
 vim.opt.rtp:remove(home_dir .. "/.local/share/nvim/site/after")
-vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/site")
+vim.opt.rtp:prepend(home_dir .. "/.local/share/lunarvim/site")
 vim.opt.rtp:append(home_dir .. "/.local/share/lunarvim/site/after")
+
+vim.opt.rtp:remove(home_dir .. "/.config/nvim")
+vim.opt.rtp:remove(home_dir .. "/.config/nvim/after")
+vim.opt.rtp:prepend(home_dir .. "/.config/lvim")
+vim.opt.rtp:append(home_dir .. "/.config/lvim/after")
 
 -- TODO: we need something like this: vim.opt.packpath = vim.opt.rtp
 vim.cmd [[let &packpath = &runtimepath]]


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Please include a summary of the change and which issue is fixed. \
List any dependencies that are required for this change.

Fixes #1442

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. \
Provide instructions so we can reproduce. \
Please also list any relevant details for your test configuration.

- Run command `set rtp?` and `set packpath?`
- Results shows that */after paths indeed comes after paths without.
- Testing on a user plugin "vimtex" now loads correctly.

