### PR TITLE
Add exclude_dirs as a configuration option

### DIFF
--- a/lua/core/project.lua
+++ b/lua/core/project.lua
@@ -20,6 +20,10 @@ function M.config()
     --- can also delete or rearangne the detection methods.
     detection_methods = { "lsp", "pattern" },
 
+    ---@usage Methods of detecting patterns for excluding from the project list
+    --- Ex: { "~/.cargo/*", ... }
+    exclude_dirs = {},
+
     ---@usage patterns used to detect root dir, when **"pattern"** is in detection_methods
     patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
 


### PR DESCRIPTION
  Add exclude_dirs to lvim.builtin.project to allow the user to exclude folders from the project list
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

A new configuration option was provided by the developer of the package project.nvim through the commit https://github.com/ahmedkhalf/project.nvim/commit/21986b90407064d3f20daff3ec241bb8790c8565
and this PR adds this configuration option to the project.

## How Has This Been Tested?

Tested locally with the config `lvim.builtin.project.exclude_dirs = { "~/Archive/*" }` and projects that before where being listed disappeared. 
Removing the configuration above, reintroduced projects under the folder as projects again.


