### PR TITLE
[Bugfix]: load nvim_comment setup from core module

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -116,7 +116,7 @@ return {
     "terrortylor/nvim-comment",
     event = "BufRead",
     config = function()
-      require("nvim_comment").setup()
+      require("core.comment").setup()
     end,
     disable = not lvim.builtin.comment.active,
   },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Load nvim_comment's setup from module `core.comment`

## How Has This Been Tested?

Try overriding some nvim_comment configs via `lvim.builtin.comment` and it works

For example
```
lvim.builtin.comment.line_mapping = "<leader>cl"
lvim.builtin.comment.hook = function()
	require("ts_context_commentstring.internal").update_commentstring()
end
```
