### PR TITLE
[BUGFIX] don't show table address in lualine

### DIFF
--- a/lua/core/lualine/components.lua
+++ b/lua/core/lualine/components.lua
@@ -84,6 +84,9 @@ return {
       msg = msg or "LSP Inactive"
       local buf_clients = vim.lsp.buf_get_clients()
       if next(buf_clients) == nil then
+        if #msg == 0 then
+          return ""
+        end
         return msg
       end
       local buf_ft = vim.bo.filetype

--- a/lua/core/lualine/components.lua
+++ b/lua/core/lualine/components.lua
@@ -81,11 +81,11 @@ return {
   },
   lsp = {
     function(msg)
-      msg = msg or "LSP Inactive"
+      msg = msg or "LS Inactive"
       local buf_clients = vim.lsp.buf_get_clients()
       if next(buf_clients) == nil then
         if #msg == 0 then
-          return ""
+          return "LS Inactive"
         end
         return msg
       end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

If the file has no buffer type, just don't show anything in the lsp section of lualine
right now it shows the table address

just open a file using `lvim test`