### PR TITLE
[Bugfix]: use correct filetype name for docker

### DIFF
--- a/ftplugin/dockerfile.lua
+++ b/ftplugin/dockerfile.lua
@@ -1,1 +1,1 @@
-require("lsp").setup "docker"
+require("lsp").setup "dockerfile"

--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -348,7 +348,7 @@ lvim.lang = {
       },
     },
   },
-  docker = {
+  dockerfile = {
     formatters = {},
     linters = {},
     lsp = {


### PR DESCRIPTION
# Description
[Screen Recording 2021-09-06 at 11.04.40.mov.zip](https://github.com/LunarVim/LunarVim/files/7113232/Screen.Recording.2021-09-06.at.11.04.40.mov.zip)
![Screen Recording 2021-09-06 at 11 04 40 2021-09-06 11_16_18](https://user-images.githubusercontent.com/15828926/132159901-aafd8ff7-7285-4303-9ae7-2ac961405bda.gif)

When adding a builtin null-ls linter or formatter to docker, they wont get applied. 
Reproduction:

```lua
lvim.lang.docker.linters = { { exe = "hadolint" } }
```

The output of:
```
:LvimInfo
```

is empty
and the dockerfile is not getting linted by hadolint

This behaviour is from  https://github.com/LunarVim/LunarVim/blob/9eeb4f23da3967c1b01e26853163b47f5dcbdc2e/lua/lsp/init.lua#L122
where we set up null-ls with vim filetype, not Lvim global object and
its 'lang' keys.

Therefore, inside this function https://github.com/LunarVim/LunarVim/blob/9eeb4f23da3967c1b01e26853163b47f5dcbdc2e/lua/lsp/null-ls/linters.lua#L65
, for example, lvim lang dockerfile does not exist, leading to setting
linters and formatters not being in effect.

I am not sure if this is the right approach. The same problem could
happen for another language where filetype that null-ls uses and lvim.lang keys doesnt
match. If it occurs more than once then probably a high level fix is
necessary where we have to do mappings between the language and its
filetype to ensure consistency


