### PR TITLE
[Bugfix] string cannot contain newlines error while showing diagnostics

### DIFF
--- a/lua/lsp/handlers.lua
+++ b/lua/lsp/handlers.lua
@@ -89,7 +89,8 @@ function M.show_line_diagnostics()
   vim.api.nvim_win_set_option(winnr, "winblend", 0)
   vim.api.nvim_buf_set_var(bufnr, "lsp_floating_window", winnr)
   for i, diag in ipairs(diags) do
-    vim.api.nvim_buf_set_lines(bufnr, i - 1, i - 1, 0, { diag.message })
+    local message = diag.message:gsub("[\n\r]", " ")
+    vim.api.nvim_buf_set_lines(bufnr, i - 1, i - 1, 0, { message })
     vim.api.nvim_buf_add_highlight(
       bufnr,
       -1,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

when showing diagnostics in a floating window, trim lines

Fixes #1480 

## How Has This Been Tested?

- add `lvim.lsp.diagnostics.virtual_text = false` to your `config.lua`
- try viewing a diagnostics using `gl`

