### PR TITLE
[Bugfix]: fixes invalid toggleterm plugin name

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -183,7 +183,7 @@ return {
 
   -- Terminal
   {
-    "akinsho/nvim-toggleterm.lua",
+    "akinsho/toggleterm.nvim",
     event = "BufWinEnter",
     config = function()
       require("core.terminal").setup()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The current fix has a typo, it should be `toggleterm.nvim`

Fixes #1489

## How Has This Been Tested?

`:PackerSync` doesn't fail

