### PR TITLE
Correct path of uninstall script.

### DIFF
--- a/utils/installer/uninstall.sh
+++ b/utils/installer/uninstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-USER_BIN_DIR="/usr/local/bin"
+USER_BIN_DIR="$HOME/.local/bin"
 if [ -d "/data/data/com.termux" ]; then
   sudo() {
     eval "$@"


### PR DESCRIPTION
The uninstaller still had the old path set.  

This updates the path to `~/.local/bin`