### PR TITLE
append_to_default bug

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -25,9 +25,7 @@ local mode_adapters = {
 -- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
 function M.append_to_defaults(keymaps)
   for mode, mappings in pairs(keymaps) do
-    for k, v in ipairs(mappings) do
-      lvim.keys[mode][k] = v
-    end
+     M.load_mode(mode, mappings)
   end
 end
 

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -25,7 +25,7 @@ local mode_adapters = {
 -- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
 function M.append_to_defaults(keymaps)
   for mode, mappings in pairs(keymaps) do
-     M.load_mode(mode, mappings)
+    M.load_mode(mode, mappings)
   end
 end
 


### PR DESCRIPTION
When I check bufferline config, I found some keymaps:
[bufferline.lua](https://github.com/LunarVim/LunarVim/blob/8c83b403ef833101a93b53cc232368424b3dff9b/lua/core/bufferline.lua#L7)
```vim
    keymap = {
      normal_mode = {
        ["<S-l>"] = ":BufferNext<CR>",
        ["<S-h>"] = ":BufferPrevious<CR>",
      },
    },
```
But they did not work.
So I did some fix on [keymappings.lua](https://github.com/LunarVim/LunarVim/blob/8c83b403ef833101a93b53cc232368424b3dff9b/lua/keymappings.lua#L28)

ipairs did not work, 
ipairs -> pairs did not work either, it seems `lvim.builtin.bufferline.setup()` runs after `require("keymappings").setup().
`
```vim
function M.append_to_defaults(keymaps)
  for mode, mappings in pairs(keymaps) do
     for k, v in pairs(mappings) do
       lvim.keys[mode][k] = v
     end
  end
end
```
Finally, I used `M.load_mode` instead.
```vim
function M.append_to_defaults(keymaps)
  for mode, mappings in pairs(keymaps) do
    M.load_mode(mode, mappings)
  end
end
```