### PR TITLE
Show correct inline diagnostics in neovim 0.6

### DIFF
--- a/lua/lsp/handlers.lua
+++ b/lua/lsp/handlers.lua
@@ -3,12 +3,6 @@
 local M = {}
 
 function M.setup()
-  vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
-    virtual_text = lvim.lsp.diagnostics.virtual_text,
-    signs = lvim.lsp.diagnostics.signs.active,
-    underline = lvim.lsp.document_highlight,
-  })
-
   local config = { -- your config
     virtual_text = lvim.lsp.diagnostics.virtual_text,
     signs = lvim.lsp.diagnostics.signs,
@@ -19,13 +13,13 @@ function M.setup()
   if vim.fn.has "nvim-0.5.1" > 0 then
     vim.lsp.handlers["textDocument/publishDiagnostics"] = function(_, result, ctx, _)
       local uri = result.uri
-      local bufnr = ctx.bufnr
+      local bufnr = vim.uri_to_bufnr(uri)
       if not bufnr then
         return
       end
 
       local diagnostics = result.diagnostics
-      vim.lsp.diagnostic.save(diagnostics, ctx.bufnr, ctx.client_id)
+      vim.lsp.diagnostic.save(diagnostics, bufnr, ctx.client_id)
       if not vim.api.nvim_buf_is_loaded(bufnr) then
         return
       end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

in neovim 0.6 diagnostics didn't show up in some lang servers
which would get fixed by this