### PR TITLE
Show treesitter icon only with supported filetype

### DIFF
--- a/lua/core/lualine/components.lua
+++ b/lua/core/lualine/components.lua
@@ -71,7 +71,8 @@ return {
   },
   treesitter = {
     function()
-      if next(vim.treesitter.highlighter.active) then
+      local b = vim.api.nvim_get_current_buf()
+      if next(vim.treesitter.highlighter.active[b]) then
         return "  "
       end
       return ""


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I noticed the treesitter symbol in the statusline is always visible, even when the current buffer has an unsupported filetype. While taking a look at the existing code, I saw the logic for toggling the icon already exists, but apparently it doesn’t work. This is a quick one liner to fix it. 

## How Has This Been Tested?

Opened a bunch of buffers with different filetypes and the treesitter symbol is either visible or hidden, depending on filetype. Seems to work fine, at least on my end. But please take a look and decide for yourself.
