### PR TITLE
[Feature] Allow cmp confirm options to be configured and jump after confirm if available

### DIFF
--- a/lua/core/cmp.lua
+++ b/lua/core/cmp.lua
@@ -30,6 +30,10 @@ M.config = function()
     return
   end
   lvim.builtin.cmp = {
+    confirm_opts = {
+      behavior = cmp.ConfirmBehavior.Replace,
+      select = true,
+    },
     formatting = {
       format = function(entry, vim_item)
         local icons = require("lsp.kind").icons
@@ -107,10 +111,15 @@ M.config = function()
 
       ["<C-Space>"] = cmp.mapping.complete(),
       ["<C-e>"] = cmp.mapping.close(),
-      ["<CR>"] = cmp.mapping.confirm {
-        behavior = cmp.ConfirmBehavior.Replace,
-        select = true,
-      },
+      ["<CR>"] = cmp.mapping(function(fallback)
+        if not require("cmp").confirm(lvim.builtin.cmp.confirm_opts) then
+          if luasnip.jumpable() then
+            vim.fn.feedkeys(T "<Plug>luasnip-jump-next", "")
+          else
+            fallback()
+          end
+        end
+      end),
     },
   }
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This allows users to change the options of the complete action' mapped to `<CR>` for cmp.
For example, I prefer it not to `select`, so I would add `lvim.builtin.cmp.confirm_opts.select = false` to my `config.lua`

This also make it so that if there is a snippet currently in place, it completes the current completion and then jumps instead of falling back to inserting a newline.

## How Has This Been Tested?
- Add `lvim.builtin.cmp.confirm_opts.select = false` to `config.lua`, enter a snippet and press `<CR>`