### PR TITLE
[Bugfix] Fix loading cmp config after Packer install

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -38,6 +38,12 @@ return {
       "hrsh7th/cmp-path",
       "hrsh7th/cmp-nvim-lua",
     },
+    run = function()
+      -- cmp's config requires cmp to be installed to run the first time
+      if not lvim.builtin.cmp then
+        require("core.cmp").config()
+      end
+    end,
   },
   {
     "rafamadriz/friendly-snippets",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

For new installs, configuration will fail for cmp because `require('cmp')` fails. This configures `cmp` immediately after install only if it is not already configured.

## How Has This Been Tested?

Make a new install, check that cmp is configured after `PackerSync` by doing `:lua print(vim.inspect(lvim.builtin.cmp))`

Or checkout `rolling` before `cmp` was introduced, do a `PackerSync` then checkout `rolling` with the latest changes and `PackerSync` yet again.
