### PR TITLE
[Bugfix] common capabilities returning nothing if no cmp_nvim_lsp

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -67,10 +67,10 @@ function M.common_capabilities()
   }
 
   local status_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
-  if not status_ok then
-    return
+  if status_ok then
+    capabilities = cmp_nvim_lsp.update_capabilities(capabilities)
   end
-  capabilities = cmp_nvim_lsp.update_capabilities(capabilities)
+
   return capabilities
 end
 


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

While we heavily depend on nvim-cmp for completion with lsp, it should not block other capabilities of the lsp.

Given a use case when user tries to unload or opt for an alternative to nvim-cmp-lsp, the line of code that I fixed will return basic capabilities instead of nothing at all (no capabilities for ls)



