### PR TITLE
[Doc] Update README.md to delete old bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can find all of the documentation for Lunarvim at [lunarvim.org](https://www
 
 Make sure you have the release version of Neovim (0.5).
 
+If you have previously installed LunarVim, make sure to remove `/usr/local/bin/lvim`, as we've moved to `.local/bin/lvim`
+
 ``` bash
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
 ```


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

# Description

Previous versions of LunarVim had the bin located in `/usr/local/bin/lvim`.

Since the new one is at `.local/bin/lvim`, if $PATH has the previous bin location before the new one, new installations on systems that had already LunarVim installed in the past, will fail to work.

Hence, the old one should be removed.