### PR TITLE
fix(lualine): pin version to avoid breaking config

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -131,6 +131,7 @@ return {
     -- "hoob3rt/lualine.nvim",
     "shadmansaleh/lualine.nvim",
     -- "Lunarvim/lualine.nvim",
+    commit = "62bfe80fb6e0cd51cec6fc9df9e1768f7d37d299",
     config = function()
       require("core.lualine").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Lualine has breaking changes in its configuration. 
See this [PR](https://github.com/shadmansaleh/lualine.nvim/pull/24#event-5300370888)

This will break LunarVim's and users' lualine config. 

Therefore, pinning Lualine's [the latest commit before the PR](https://github.com/shadmansaleh/lualine.nvim/commit/62bfe80fb6e0cd51cec6fc9df9e1768f7d37d299)


