### PR TITLE
[Fix] missing default configuration for update_in_insert

### DIFF
--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -78,6 +78,7 @@ lvim = {
         prefix = "",
         spacing = 0,
       },
+      update_in_insert = false,
       underline = true,
       severity_sort = true,
     },


### PR DESCRIPTION


<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

For some reasons this field is missing from the default configuration. Therefore, when accessing this key inside lsp handlers, it will return nil. For now we are lucky that there are some internal handling within the lsp that convert nil to false or disable the feature. However, this pull request propose that we define a default value for this configuration  


Concern: I dont know where and how to update the documentation (if there is any)
