### PR TITLE
fix: errors caused by deprecated options in lualine config.

### DIFF
--- a/lua/core/lualine/components.lua
+++ b/lua/core/lualine/components.lua
@@ -17,31 +17,33 @@ return {
     function()
       return " "
     end,
-    left_padding = 0,
-    right_padding = 0,
+    padding = { left = 0 },
+    padding = { right = 0 },
     color = {},
-    condition = nil,
+    cond = nil,
   },
   branch = {
     "b:gitsigns_head",
     icon = " ",
     color = { gui = "bold" },
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
   },
   filename = {
     "filename",
     color = {},
-    condition = nil,
+    cond = nil,
   },
   diff = {
     "diff",
     source = diff_source,
     symbols = { added = "  ", modified = "柳", removed = " " },
-    color_added = { fg = colors.green },
-    color_modified = { fg = colors.yellow },
-    color_removed = { fg = colors.red },
+    diff_color = {
+      added = colors.green,
+      modified = colors.yellow,
+      removed = colors.red,
+    },
     color = {},
-    condition = nil,
+    cond = nil,
   },
   python_env = {
     function()
@@ -60,14 +62,14 @@ return {
       return ""
     end,
     color = { fg = colors.green },
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
   },
   diagnostics = {
     "diagnostics",
     sources = { "nvim_lsp" },
     symbols = { error = " ", warn = " ", info = " ", hint = " " },
     color = {},
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
   },
   treesitter = {
     function()
@@ -78,7 +80,7 @@ return {
       return ""
     end,
     color = { fg = colors.green },
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
   },
   lsp = {
     function(msg)
@@ -118,10 +120,10 @@ return {
     end,
     icon = " ",
     color = { gui = "bold" },
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
   },
-  location = { "location", condition = conditions.hide_in_width, color = {} },
-  progress = { "progress", condition = conditions.hide_in_width, color = {} },
+  location = { "location", cond = conditions.hide_in_width, color = {} },
+  progress = { "progress", cond = conditions.hide_in_width, color = {} },
   spaces = {
     function()
       local label = "Spaces: "
@@ -130,16 +132,16 @@ return {
       end
       return label .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
     end,
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
     color = {},
   },
   encoding = {
     "o:encoding",
     upper = true,
     color = {},
-    condition = conditions.hide_in_width,
+    cond = conditions.hide_in_width,
   },
-  filetype = { "filetype", condition = conditions.hide_in_width, color = {} },
+  filetype = { "filetype", cond = conditions.hide_in_width, color = {} },
   scrollbar = {
     function()
       local current_line = vim.fn.line "."
@@ -149,9 +151,9 @@ return {
       local index = math.ceil(line_ratio * #chars)
       return chars[index]
     end,
-    left_padding = 0,
-    right_padding = 0,
+    padding = { left = 0 },
+    padding = { right = 0 },
     color = { fg = colors.yellow, bg = colors.bg },
-    condition = nil,
+    cond = nil,
   },
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This fixes errors caused by use of deprecated settings in lualine config file.

When LunarVim starts, the following error appears:
```
lualine: There are some issues with your config. Run :LualineNotices for details
```

Errors reported when executing `:LualineNotices`:
```
### option.left_padding

Option `left_padding` has been deprecated.
Please use `padding` option to set left/right padding.

You have some thing like this in your config:

'''lua
  left_padding = 0,
'''

You'll have to change it to this to retain old behavior:

'''lua
  padding = { left = 0 }
'''
if you've set both left_padding and right_padding for a component
you'll need to have something like
'''lua
  padding = { left = x, right = y }
'''
When you set `padding = x` it's same as `padding = {left = x, right = x}`

### option.left_padding

Option `left_padding` has been deprecated.
Please use `padding` option to set left/right padding.

You have some thing like this in your config:

'''lua
  left_padding = 0,
'''

You'll have to change it to this to retain old behavior:

'''lua
  padding = { left = 0 }
'''
if you've set both left_padding and right_padding for a component
you'll need to have something like
'''lua
  padding = { left = x, right = y }
'''
When you set `padding = x` it's same as `padding = {left = x, right = x}`

### option.condition
condition option has been renamed to `cond`. Please use `cond` instead in your config
for diagnostics component.

### option.condition
condition option has been renamed to `cond`. Please use `cond` instead in your config
for function component.

### option.condition
condition option has been renamed to `cond`. Please use `cond` instead in your config
for function component.

### option.condition
condition option has been renamed to `cond`. Please use `cond` instead in your config
for filetype component.

### diff.options.colors
Previously colors in diff section was set with color_added, color_modified..
separate options . They've been unified under diff_color option.
Now it should be something like:
'''lua
{ 'diff',
  diff_color = {
    added = color_added,
    modified = color_modified,
    removed = color_removed,
  }
}
'''

### option.condition
condition option has been renamed to `cond`. Please use `cond` instead in your config
for function component.

### option.condition
condition option has been renamed to `cond`. Please use `cond` instead in your config
for function component.
```

Fixes #(issue)

## How Has This Been Tested?

Once the fixes are applied, lualine complains no more.