### PR TITLE
[Feature] Make peek function work in neovim head and 0.5

### DIFF
--- a/lua/lsp/peek.lua
+++ b/lua/lsp/peek.lua
@@ -54,9 +54,8 @@ local function create_floating_file(location, opts)
   return bufnr, winnr
 end
 
-local function preview_location_callback(_, method, result)
+local function preview_location_callback(result)
   if result == nil or vim.tbl_isempty(result) then
-    print("peek: No location found: " .. method)
     return nil
   end
 
@@ -72,6 +71,14 @@ local function preview_location_callback(_, method, result)
     M.prev_result = result
     M.floating_buf, M.floating_win = create_floating_file(result, opts)
   end
+end
+
+local function preview_location_callback_old_signature(_, _, result)
+  return preview_location_callback(result)
+end
+
+local function preview_location_callback_new_signature(_, result)
+  return preview_location_callback(result)
 end
 
 function M.open_file()
@@ -129,7 +136,11 @@ function M.Peek(what)
   else
     -- Make a new request and then create the new window in the callback
     local params = vim.lsp.util.make_position_params()
-    local success, _ = pcall(vim.lsp.buf_request, 0, "textDocument/" .. what, params, preview_location_callback)
+    local preview_callback = preview_location_callback_old_signature
+    if vim.fn.has "nvim-0.5.1" > 0 then
+      preview_callback = preview_location_callback_new_signature
+    end
+    local success, _ = pcall(vim.lsp.buf_request, 0, "textDocument/" .. what, params, preview_callback)
     if not success then
       print(
         'peek: Error calling LSP method "textDocument/' .. what .. '". The current language lsp might not support it.'


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Noevim 0.6 has a different signature, so we need to support both in order for peek functions to work