### PR TITLE
fix(dashboard): hide version when no tag found

### DIFF
--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -33,7 +33,11 @@ function _G.get_cache_dir()
 end
 
 function _G.get_version(type)
-  local lvim_full_ver = vim.fn.system("git -C " .. get_runtime_dir() .. "/lvim describe --tag")
+  local lvim_full_ver = vim.fn.system("git -C " .. get_runtime_dir() .. "/lvim describe --tags")
+
+  if string.match(lvim_full_ver, "%d") == nil then
+    return nil
+  end
   if type == "short" then
     return vim.fn.split(lvim_full_ver, "-")[1]
   else

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -73,14 +73,19 @@ M.setup = function()
   local lvim_version = get_version "short"
   local num_plugins_loaded = #vim.fn.globpath(get_runtime_dir() .. "/site/pack/packer/start", "*", 0, 1)
 
-  local text = require "interface.text"
-  vim.g.dashboard_custom_footer = text.align_center({ width = 0 }, {
+  local footer = {
     "LunarVim loaded " .. num_plugins_loaded .. " plugins ",
     "",
-    "v" .. lvim_version,
-    "",
     lvim_site,
-  }, 0.49) -- Use 0.49 as  counts for 2 characters
+  }
+
+  if lvim_version then
+    table.insert(footer, 2, "")
+    table.insert(footer, 3, "v" .. lvim_version)
+  end
+
+  local text = require "interface.text"
+  vim.g.dashboard_custom_footer = text.align_center({ width = 0 }, footer, 0.49) -- Use 0.49 as  counts for 2 characters
 
   require("core.autocmds").define_augroups {
     _dashboard = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Display LunarVim version on dashboard only when a git tag is found.
This is a temporary fix until we come up with a better way to retrieve the latest version.


