### PR TITLE
[Bugfix]: key mappings of nvim-cmp doesn't work

### DIFF
--- a/lua/core/cmp.lua
+++ b/lua/core/cmp.lua
@@ -73,10 +73,10 @@ M.config = function()
       { name = "crates" },
     },
     mapping = {
-      ["<C-d>"] = cmp.mapping.scroll_docs(-4),
-      ["<C-f>"] = cmp.mapping.scroll_docs(4),
+      ["<C-D>"] = cmp.mapping.scroll_docs(-4),
+      ["<C-F>"] = cmp.mapping.scroll_docs(4),
       -- TODO: potentially fix emmet nonsense
-      ["<Tab>"] = cmp.mapping(function()
+      ["<TAB>"] = cmp.mapping(function()
         if vim.fn.pumvisible() == 1 then
           vim.fn.feedkeys(T "<down>", "n")
         elseif luasnip.expand_or_jumpable() then
@@ -92,7 +92,7 @@ M.config = function()
         "i",
         "s",
       }),
-      ["<S-Tab>"] = cmp.mapping(function(fallback)
+      ["<S-TAB>"] = cmp.mapping(function(fallback)
         if vim.fn.pumvisible() == 1 then
           vim.fn.feedkeys(T "<up>", "n")
         elseif luasnip.jumpable(-1) then
@@ -105,8 +105,8 @@ M.config = function()
         "s",
       }),
 
-      ["<C-Space>"] = cmp.mapping.complete(),
-      ["<C-e>"] = cmp.mapping.close(),
+      ["<C-SPACE>"] = cmp.mapping.complete(),
+      ["<C-E>"] = cmp.mapping.close(),
       ["<CR>"] = cmp.mapping.confirm {
         behavior = cmp.ConfirmBehavior.Replace,
         select = true,


### PR DESCRIPTION
Relate to: https://github.com/hrsh7th/nvim-cmp/issues/221

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Because of this https://github.com/hrsh7th/nvim-cmp/commit/7c8876330df6e11cf91ca42ab6e52f37d81cc003, mappings of nvim-cmp's configuration need updating to all caps.

## How Has This Been Tested?

- Use `lvim` to edit a file. e.g. `test.js`
- Check `<Tab>` and `<S-Tab>` can work as expect when completion menu is visible.

