### PR TITLE
[Bugfix]: Add `Diff*` colors to onedarker

### DIFF
--- a/lua/onedarker/diff.lua
+++ b/lua/onedarker/diff.lua
@@ -1,0 +1,12 @@
+local diff = {
+  DiffAdd = { fg = C.none, bg = C.diff_add },
+  DiffDelete = { fg = C.none, bg = C.diff_delete },
+  DiffChange = { fg = C.none, bg = C.diff_change, style = "bold" },
+  DiffText = { fg = C.none, bg = C.diff_text },
+  DiffAdded = { fg = C.green },
+  DiffRemoved = { fg = C.red },
+  DiffFile = { fg = C.cyan },
+  DiffIndexLine = { fg = C.gray },
+}
+
+return diff

--- a/lua/onedarker/init.lua
+++ b/lua/onedarker/init.lua
@@ -15,6 +15,7 @@ local markdown = require "onedarker.markdown"
 local Whichkey = require "onedarker.Whichkey"
 local Git = require "onedarker.Git"
 local LSP = require "onedarker.LSP"
+local diff = require "onedarker.diff"
 
 local skeletons = {
   highlights,
@@ -23,6 +24,7 @@ local skeletons = {
   Whichkey,
   Git,
   LSP,
+  diff,
 }
 
 for _, skeleton in ipairs(skeletons) do

--- a/lua/onedarker/palette.lua
+++ b/lua/onedarker/palette.lua
@@ -1,4 +1,5 @@
 local colors = {
+  none = "NONE",
   fg = "#abb2bf",
   bg = "#1f2227",
   alt_bg = "#282c34",
@@ -34,6 +35,10 @@ local colors = {
   purple_test = "#ff007c",
   cyan_test = "#00dfff",
   ui_blue = "#264F78",
+  diff_add = "#303d27",
+  diff_delete = "#6e3b40",
+  diff_change = "#18344c",
+  diff_text = "#265478",
 }
 
 return colors


### PR DESCRIPTION
## Description

This PR adds highlight colors to the `Diff*` highlight groups and makes diff. Significantly improves readability of diff output over the default scheme.

The colors are taken from [navarasu/onedark.nvim](https://github.com/navarasu/onedark.nvim)

Fixes #1576 

## How Has This Been Tested?

The colors are subjective. Diff can be tested using
```
lvim -d <file 1> <file 2?
```
