### PR TITLE
watch_index is deprecated, use watch_gitdir instead

### DIFF
--- a/lua/core/gitsigns.lua
+++ b/lua/core/gitsigns.lua
@@ -44,7 +44,7 @@ M.config = function()
         noremap = true,
         buffer = true,
       },
-      watch_index = { interval = 1000 },
+      watch_gitdir = { interval = 1000 },
       sign_priority = 6,
       update_debounce = 200,
       status_formatter = nil, -- Use default


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Gitsigns has deprecated `watch_index` in favor of `watch_gitdir`
in this commit:
https://github.com/lewis6991/gitsigns.nvim/commit/489fe088c4bc7efa12ddcc47bcef915863e3b753
