### PR TITLE
fix: adjust layout after a regression in telescope

### DIFF
--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -89,13 +89,8 @@ function M.find_lunarvim_files(opts)
   opts = opts or {}
   local themes = require "telescope.themes"
   local theme_opts = themes.get_ivy {
-    previewer = false,
     sorting_strategy = "ascending",
     layout_strategy = "bottom_pane",
-    layout_config = {
-      height = 5,
-      width = 0.5,
-    },
     prompt = ">> ",
     prompt_title = "~ LunarVim files ~",
     cwd = utils.join_paths(get_runtime_dir(), "lvim"),


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adjust the menu height for `find_lunarvim_files()` that got too short after a regression in Telescope.
