### PR TITLE
fix: can't open lvim log file cause by `lvim.log.viewer.cmd`

### DIFF
--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -20,7 +20,7 @@ lvim = {
     level = "warn",
     viewer = {
       ---@usage this will fallback on "less +F" if not found
-      cmd = "less +F",
+      cmd = "lnav",
       layout_config = {
         ---@usage direction = 'vertical' | 'horizontal' | 'window' | 'float',
         direction = "horizontal",

--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -20,7 +20,7 @@ lvim = {
     level = "warn",
     viewer = {
       ---@usage this will fallback on "less +F" if not found
-      cmd = "less",
+      cmd = "less +F",
       layout_config = {
         ---@usage direction = 'vertical' | 'horizontal' | 'window' | 'float',
         direction = "horizontal",

--- a/lua/config/defaults.lua
+++ b/lua/config/defaults.lua
@@ -20,7 +20,7 @@ lvim = {
     level = "warn",
     viewer = {
       ---@usage this will fallback on "less +F" if not found
-      cmd = "lnav",
+      cmd = "less",
       layout_config = {
         ---@usage direction = 'vertical' | 'horizontal' | 'window' | 'float',
         direction = "horizontal",

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -112,8 +112,14 @@ M.toggle_log_view = function(name)
   if not logfile then
     return
   end
+
+  local log_viewer = lvim.log.viewer.cmd
+  if vim.fn.executable(log_viewer) ~= 1 then
+    log_viewer = "less +F"
+  end
+  log_viewer = log_viewer .. " " .. logfile
   local term_opts = vim.tbl_deep_extend("force", lvim.builtin.terminal, {
-    cmd = lvim.log.viewer.cmd .. " " .. logfile,
+    cmd = log_viewer,
     open_mapping = lvim.log.viewer.layout_config.open_mapping,
     direction = lvim.log.viewer.layout_config.direction,
     -- TODO: this might not be working as expected


### PR DESCRIPTION
When I try to open log file by pressing `<leader>Lld`, nothing happens.

I found it was caused by this line:

https://github.com/LunarVim/LunarVim/blob/238bbf18ac4e35152be06736c75e94a81e3382e8/lua/config/defaults.lua#L23

`lvim.log.viewer.cmd` is not executable in this case. Use `less` instead of `lnav` will solve it



