### PR TITLE
[Feature]: Add signs for DAP

### DIFF
--- a/lua/core/dap.lua
+++ b/lua/core/dap.lua
@@ -10,6 +10,18 @@ M.config = function()
       linehl = "",
       numhl = "",
     },
+    breakpoint_rejected = {
+      text = "",
+      texthl = "LspDiagnosticsSignHint",
+      linehl = "",
+      numhl = "",
+    },
+    stopped = {
+      text = "",
+      texthl = "LspDiagnosticsSignInformation",
+      linehl = "DiagnosticUnderlineInfo",
+      numhl = "LspDiagnosticsSignInformation",
+    },
   }
 end
 
@@ -17,6 +29,9 @@ M.setup = function()
   local dap = require "dap"
 
   vim.fn.sign_define("DapBreakpoint", lvim.builtin.dap.breakpoint)
+  vim.fn.sign_define("DapBreakpointRejected", lvim.builtin.dap.breakpoint_rejected)
+  vim.fn.sign_define("DapStopped", lvim.builtin.dap.stopped)
+
   dap.defaults.fallback.terminal_win_cmd = "50vsplit new"
 
   lvim.builtin.which_key.mappings["d"] = {


### PR DESCRIPTION
## Description

Defining signs for `DapBreakpointRejected` and `DapStopped`. These would earlier fallback to the defaults and as a result were not formatted well on the default theme.


## How Has This Been Tested?

This has been tested on DAP and the `lldb-vscode` adapter. 