### PR TITLE
fix(installer): fix ARGS_LOCAL condition

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -135,7 +135,7 @@ EOF
     echo "Updating LunarVim"
     update_lvim
   else
-    if [ -n "$ARGS_LOCAL" ]; then
+    if [ "$ARGS_LOCAL" -eq 1 ]; then
       link_local_lvim
     else
       clone_lvim


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`install.sh` doesn't work properly. It always link local lvim regardless of the `ARGS_LOCAL` value. 

This PR fixes the if-else condition to correctly check `ARGS_LOCAL`.

## How Has This Been Tested?

- Uninstall lvim 
- Run the installer

Uninstall lvim
```
$ rm -rf ~/.local/share/lunarvim

$ sudo rm /usr/local/bin/lvim

$ rm ~/.local/bin/lvim

$ rm -rf ~/.local/share/applications/lvim.desktop
```

Run the installer
```
$ ./utils/installer/install.sh
```