### PR TITLE
fix: add missing lsp.log entry in log_viewer

### DIFF
--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -1,5 +1,4 @@
 local M = {}
-local utils = require "utils"
 local Log = require "core.log"
 
 M.config = function()
@@ -90,29 +89,9 @@ M._exec_toggle = function(exec)
   exec_term:toggle()
 end
 
-local function get_log_path(name)
-  --handle custom paths not managed by Plenary.log
-  local file
-  if name == "nvim" then
-    file = utils.join_paths(vim.fn.stdpath "cache", "log")
-  elseif name == "packer.nvim" then
-    file = utils.join_paths(vim.fn.stdpath "cache", "packer.nvim.log")
-  else
-    file = Log:get_path()
-  end
-  if utils.is_file(file) then
-    return file
-  end
-end
-
 ---Toggles a log viewer according to log.viewer.layout_config
----@param name can be the name of any of the managed logs, e,g. "lunarvim" or the default ones {"nvim", "lsp", "packer.nvim"}
-M.toggle_log_view = function(name)
-  local logfile = get_log_path(name)
-  if not logfile then
-    return
-  end
-
+---@param logfile string the fullpath to the logfile
+M.toggle_log_view = function(logfile)
   local log_viewer = lvim.log.viewer.cmd
   if vim.fn.executable(log_viewer) ~= 1 then
     log_viewer = "less +F"
@@ -129,7 +108,6 @@ M.toggle_log_view = function(name)
 
   local Terminal = require("toggleterm.terminal").Terminal
   local log_view = Terminal:new(term_opts)
-  -- require("core.log"):debug("term", vim.inspect(term_opts))
   log_view:toggle()
 end
 

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -199,14 +199,17 @@ M.config = function()
         l = {
           name = "+logs",
           d = {
-            "<cmd>lua require('core.terminal').toggle_log_view('lunarvim')<cr>",
+            "<cmd>lua require('core.terminal').toggle_log_view(require('core.log').get_path())<cr>",
             "view default log",
           },
-          D = { "<cmd>exe 'edit '.stdpath('cache').'/lunarvim.log'<cr>", "Open the default logfile" },
-          n = { "<cmd>lua require('core.terminal').toggle_log_view('lsp')<cr>", "view lsp log" },
+          D = { "<cmd>lua vim.fn.execute('edit ' .. require('core.log').get_path())<cr>", "Open the default logfile" },
+          l = { "<cmd>lua require('core.terminal').toggle_log_view(vim.lsp.get_log_path())<cr>", "view lsp log" },
+          L = { "<cmd>lua vim.fn.execute('edit ' .. vim.lsp.get_log_path())<cr>", "Open the LSP logfile" },
+          n = {
+            "<cmd>lua require('core.terminal').toggle_log_view(os.getenv('NVIM_LOG_FILE'))<cr>",
+            "view neovim log",
+          },
           N = { "<cmd>edit $NVIM_LOG_FILE<cr>", "Open the Neovim logfile" },
-          l = { "<cmd>lua require('core.terminal').toggle_log_view('nvim')<cr>", "view neovim log" },
-          L = { "<cmd>exe 'edit '.stdpath('cache').'/lsp.log'<cr>", "Open the LSP logfile" },
           p = {
             "<cmd>lua require('core.terminal').toggle_log_view('packer.nvim')<cr>",
             "view packer log",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add missing lsp.log entry in `log_viewer` which was always defaulting to the default log.

## How Has This Been Tested?

Each one of these should open a different file
- `<Leader>Lld`
- `<Leader>Lll`
- `<Leader>Lln`
