### PR TITLE
fix: return correctly for overridden lang servers

### DIFF
--- a/lua/lsp/manager.lua
+++ b/lua/lsp/manager.lua
@@ -18,7 +18,7 @@ local function is_overridden(server)
   local overrides = lvim.lsp.override
   if type(overrides) == "table" then
     if vim.tbl_contains(overrides, server) then
-      return
+      return true
     end
   end
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

because we are using `is_overridden` in here:
```lua
  if lsp_utils.is_client_active(server_name) or is_overridden(server_name) then
```
we need to make sure it returns true if the lang server is actually overriden