### PR TITLE
fix: add deprecation notice for lvim.lang.foo.lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ lvim.plugins = {
 
 - inside LunarVim `:PackerUpdate`
 
+## Breaking changes
+
+- `lvim.lang.FOO.lsp` is no longer supported after #1584.
+  You can either use `:NlspConfig` for most of the settings you might need, or override the setup by adding an entry to `lvim.lsp.override = { "FOO" }`.
+
 ## Resources
 
 - [Documentation](https://www.lunarvim.org)

--- a/lua/config/init.lua
+++ b/lua/config/init.lua
@@ -124,6 +124,20 @@ function M:init(opts)
   require("lsp.manager").init_defaults(supported_languages)
 end
 
+local function deprecation_notice()
+  for lang, entry in pairs(lvim.lang) do
+    if not vim.tbl_isempty(entry["lsp"]) then
+      local msg = string.format(
+        "Deprecation notice: [lvim.lang.%s.lsp] setting is no longer supported. See https://github.com/LunarVim/LunarVim#breaking-changes",
+        lang
+      )
+      vim.schedule(function()
+        vim.notify(msg, vim.log.levels.WARN)
+      end)
+    end
+  end
+end
+
 --- Override the configuration with a user provided one
 -- @param config_path The path to the configuration overrides
 function M:load(config_path)
@@ -136,6 +150,8 @@ function M:load(config_path)
     print(err)
     return
   end
+
+  deprecation_notice()
 
   self.path = config_path
 

--- a/lua/config/init.lua
+++ b/lua/config/init.lua
@@ -125,8 +125,14 @@ function M:init(opts)
 end
 
 local function deprecation_notice()
+  local in_headless = #vim.api.nvim_list_uis() == 0
+  if in_headless then
+    return
+  end
+
   for lang, entry in pairs(lvim.lang) do
-    if not vim.tbl_isempty(entry["lsp"]) then
+    local deprecated_config = entry["lsp"] or {}
+    if not vim.tbl_isempty(deprecated_config) then
       local msg = string.format(
         "Deprecation notice: [lvim.lang.%s.lsp] setting is no longer supported. See https://github.com/LunarVim/LunarVim#breaking-changes",
         lang


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description


`lvim.lang.FOO.lsp` is no longer supported after #1584.
 You can either use `:NlspConfig` for most of the settings you might need, or override the setup by adding an entry to `lvim.lsp.override = { "FOO" }`.


## How Has This Been Tested?

You should see a warning if you have any `lvim.lang.FOO.lsp` settings in your `config.lua`.
