### PR TITLE
fix: the virtual_text charachter causes issues

### DIFF
--- a/lua/lsp/config.lua
+++ b/lua/lsp/config.lua
@@ -10,10 +10,7 @@ return {
         { name = "LspDiagnosticsSignInformation", text = "" },
       },
     },
-    virtual_text = {
-      prefix = "",
-      spacing = 0,
-    },
+    virtual_text = true,
     update_in_insert = false,
     underline = true,
     severity_sort = true,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

the character used for `virtual_text` causes random issues, just use the default one

Fixes #1609
