### PR TITLE
[Bugfix] Allow user to pass table to null-ls setup function

### DIFF
--- a/lua/lsp/config.lua
+++ b/lua/lsp/config.lua
@@ -21,4 +21,7 @@ return {
   on_attach_callback = nil,
   on_init_callback = nil,
   automatic_servers_installation = true,
+  null_ls = {
+    setup = {},
+  },
 }

--- a/lua/lsp/null-ls/init.lua
+++ b/lua/lsp/null-ls/init.lua
@@ -12,7 +12,7 @@ function M:setup()
   end
 
   null_ls.config()
-  require("lspconfig")["null-ls"].setup {}
+  require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
   for _, filetype in pairs(lvim.lang) do
     if filetype.formatters then
       formatters.setup(filetype.formatters, filetype)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

A few month ago PR #1323 was merged into rolling. It allowed users to pass a custom table to null-ls setup function. A few days ago PR #1584 removed that feature.

In particular these lines:
https://github.com/LunarVim/LunarVim/commit/d01ba08eaec1640ac2d038893525b3ba0af25813#diff-064818389bf764a41f5910117a4eecd09ac7e0f2a7f34189854cfd7003021363L161
https://github.com/LunarVim/LunarVim/commit/d01ba08eaec1640ac2d038893525b3ba0af25813#diff-064818389bf764a41f5910117a4eecd09ac7e0f2a7f34189854cfd7003021363R117

To me this seems like an accident since the documentation ([example config](https://github.com/LunarVim/LunarVim/blob/rolling/utils/installer/config.example.lua#L85-L99)) has not been updated to accommodate for the feature removal, so I am submitting this PR to fix that mistake.

## How Has This Been Tested? (copy-pasted from the original PR)

I have tested this with `root_dir` overwrite.
Example config: 
```
lvim.lsp.null_ls.setup.root_dir = require("lspconfig").util.root_pattern("Makefile", ".git", "node_modules")
```

With this I can see null_ls root set to the `app` folder when opening a file in a project with structure like this
```
repo/
├── .git/
└── app/
    ├── node_modules/
    ├── App.js
    ├── package.json
    └── yarn.lock
```
