### PR TITLE
[Feature]: User configurable LSP key map

### DIFF
--- a/lua/lsp/config.lua
+++ b/lua/lsp/config.lua
@@ -21,4 +21,21 @@ return {
   on_attach_callback = nil,
   on_init_callback = nil,
   automatic_servers_installation = true,
+  buffer_mappings = {
+    normal_mode = {
+      ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>", "Show hover" },
+      ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
+      ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>", "Goto declaration" },
+      ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>", "Goto references" },
+      ["gI"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>", "Goto Implementation" },
+      ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>", "show signature help" },
+      ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>", "Peek definition" },
+      ["gl"] = {
+        "<cmd>lua require'lsp.handlers'.show_line_diagnostics()<CR>",
+        "Show line diagnostics",
+      },
+    },
+    insert_mode = {},
+    visual_mode = {},
+  },
 }

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -22,25 +22,29 @@ local function lsp_highlight_document(client)
 end
 
 local function add_lsp_buffer_keybindings(bufnr)
-  local status_ok, wk = pcall(require, "which-key")
-  if not status_ok then
-    return
-  end
-
-  local keys = {
-    ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>", "Show hover" },
-    ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
-    ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>", "Goto declaration" },
-    ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>", "Goto references" },
-    ["gI"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>", "Goto Implementation" },
-    ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>", "show signature help" },
-    ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>", "Peek definition" },
-    ["gl"] = {
-      "<cmd>lua require'lsp.handlers'.show_line_diagnostics()<CR>",
-      "Show line diagnostics",
-    },
+  local mappings = {
+    normal_mode = "n",
+    insert_mode = "i",
+    visual_mode = "v",
   }
-  wk.register(keys, { mode = "n", buffer = bufnr })
+
+  if lvim.builtin.which_key.active then
+    -- Remap using which_key
+    local status_ok, wk = pcall(require, "which-key")
+    if not status_ok then
+      return
+    end
+    for mode_name, mode_char in pairs(mappings) do
+      wk.register(lvim.lsp.buffer_mappings[mode_name], { mode = mode_char, buffer = bufnr })
+    end
+  else
+    -- Remap using nvim api
+    for mode_name, mode_char in pairs(mappings) do
+      for key, remap in pairs(lvim.lsp.buffer_mappings[mode_name]) do
+        vim.api.nvim_buf_set_keymap(bufnr, mode_char, key, remap[1], { noremap = true, silent = true })
+      end
+    end
+  end
 end
 
 function M.common_capabilities()


### PR DESCRIPTION
# Description

This PR makes the lsp buffer keymaps configurable by the user. The mappings are set up in `lvim.lsp.buffer_mappings.normal_mode`. Similarly, `insert_mode` and `visual_mode` mappings are also created but are currently empty. 

This follows from #1651. 

This PR has the changes requested by @kylo252 in #1651. 

Fixes #1494


