### PR TITLE
fix: disable unintended luasnip jump-to-prev

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -14,6 +14,11 @@ lvim.autocommands = {
       "nnoremap <silent> <buffer> q :q<CR>",
     },
     {
+      "InsertLeave",
+      "*",
+      "lua require'luasnip'.unlink_current()",
+    },
+    {
       "FileType",
       "lsp-installer",
       "nnoremap <silent> <buffer> q :q<CR>",

--- a/lua/core/cmp.lua
+++ b/lua/core/cmp.lua
@@ -4,7 +4,6 @@ local check_backspace = function()
   local col = vim.fn.col "." - 1
   return col == 0 or vim.fn.getline("."):sub(col, col):match "%s"
 end
-
 local function T(str)
   return vim.api.nvim_replace_termcodes(str, true, true, true)
 end
@@ -139,11 +138,7 @@ M.config = function()
       ["<C-e>"] = cmp.mapping.close(),
       ["<CR>"] = cmp.mapping(function(fallback)
         if not require("cmp").confirm(lvim.builtin.cmp.confirm_opts) then
-          if luasnip.jumpable() then
-            vim.fn.feedkeys(T "<Plug>luasnip-jump-next", "")
-          else
-            fallback()
-          end
+          fallback()
         end
       end),
     },


### PR DESCRIPTION
- pressing enter will no longer activate luasnip.
- exiting insert-mode will unlink the current snippet.

Fixes #1645

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Please include a summary of the change and which issue is fixed. \
List any dependencies that are required for this change.

Fixes #(issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. \
Provide instructions so we can reproduce. \
Please also list any relevant details for your test configuration.

- Run command `:mycommand`
- Check logs
- ...

