### PR TITLE
[Feature] better code action prompt and auto show codelens actions

### DIFF
--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -161,9 +161,18 @@ end
 
 function M.code_actions()
   local opts = {
-    winblend = 10,
+    winblend = 15,
+    layout_config = {
+      prompt_position = "top",
+      width = 80,
+      height = 12,
+    },
+    borderchars = {
+      prompt = { "─", "│", " ", "│", "╭", "╮", "│", "│" },
+      results = { "─", "│", "─", "│", "├", "┤", "╯", "╰" },
+      preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
+    },
     border = {},
-    borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     previewer = false,
     shorten_path = false,
   }

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -159,6 +159,16 @@ function M.view_lunarvim_changelog()
   }):find()
 end
 
+function M.code_actions()
+  local opts = {
+    winblend = 10,
+    border = true,
+    previewer = false,
+    shorten_path = false,
+  }
+  require("telescope.builtin").lsp_code_actions(require("telescope.themes").get_dropdown(opts))
+end
+
 function M.setup()
   local telescope = require "telescope"
 

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -162,7 +162,8 @@ end
 function M.code_actions()
   local opts = {
     winblend = 10,
-    border = true,
+    border = {},
+    borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
     previewer = false,
     shorten_path = false,
   }

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -139,7 +139,7 @@ M.config = function()
 
       l = {
         name = "LSP",
-        a = { "<cmd>lua vim.lsp.buf.code_action()<cr>", "Code Action" },
+        a = { "<cmd>lua require('core.telescope').code_actions()<cr>", "Code Action" },
         d = {
           "<cmd>Telescope lsp_document_diagnostics<cr>",
           "Document Diagnostics",
@@ -159,6 +159,7 @@ M.config = function()
           "<cmd>lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = lvim.lsp.popup_border}})<cr>",
           "Prev Diagnostic",
         },
+        l = { "<cmd>lua vim.lsp.codelens.run()<cr>", "CodeLens Action" },
         p = {
           name = "Peek",
           d = { "<cmd>lua require('lsp.peek').Peek('definition')<cr>", "Definition" },

--- a/lua/lsp/config.lua
+++ b/lua/lsp/config.lua
@@ -17,6 +17,7 @@ return {
   },
   override = {},
   document_highlight = true,
+  code_lens_refresh = true,
   popup_border = "single",
   on_attach_callback = nil,
   on_init_callback = nil,

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -21,6 +21,25 @@ local function lsp_highlight_document(client)
   end
 end
 
+local function lsp_code_lens_refresh(client)
+  if lvim.lsp.code_lens_refresh == false then
+    return
+  end
+
+  if client.resolved_capabilities.code_lens then
+    vim.api.nvim_exec(
+      [[
+      augroup lsp_code_lens_refresh
+        autocmd! * <buffer>
+        autocmd InsertLeave <buffer> lua vim.lsp.codelens.refresh()
+        autocmd InsertLeave <buffer> lua vim.lsp.codelens.display()
+      augroup END
+    ]],
+      false
+    )
+  end
+end
+
 local function add_lsp_buffer_keybindings(bufnr)
   local status_ok, wk = pcall(require, "which-key")
   if not status_ok then
@@ -29,6 +48,7 @@ local function add_lsp_buffer_keybindings(bufnr)
 
   local keys = {
     ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>", "Show hover" },
+    ["ga"] = { "<cmd>lua vim.lsp.buf.code_action()<CR>", "Code Action" },
     ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
     ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>", "Goto declaration" },
     ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>", "Goto references" },
@@ -95,6 +115,7 @@ function M.common_on_attach(client, bufnr)
     Log:debug "Called lsp.on_attach_callback"
   end
   lsp_highlight_document(client)
+  lsp_code_lens_refresh(client)
   add_lsp_buffer_keybindings(bufnr)
 end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

1. the default prompt for code actions is really ugly, use the one that the telescope provides instead
2. add new auto command to refresh and display code lens actions in supported language servers
which can be disabled using
```lua
lvim.lsp.code_lens_refresh = false
```

## How Has This Been Tested?

the code action would look like this:
<img width="703" alt="Screen Shot 2021-10-05 at 7 43 07 PM" src="https://user-images.githubusercontent.com/10992695/136061785-3d8da840-c48b-4d52-b151-8ce73e3cc581.png">

and the lens thingies would look like this in rust:
<img width="398" alt="Screen Shot 2021-10-05 at 7 39 38 PM" src="https://user-images.githubusercontent.com/10992695/136061834-8c3a5163-43b2-49a8-aeb2-9131f6d3b3d3.png">
<img width="677" alt="Screen Shot 2021-10-05 at 7 39 48 PM" src="https://user-images.githubusercontent.com/10992695/136061999-f3933181-61f5-4e1a-86fa-c3987b343b47.png">
