### PR TITLE
fix: update which-key bindings for LvimReload

### DIFF
--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -14,6 +14,7 @@ M.defaults = {
   [[ command! LvimInfo lua require('lvim.core.info').toggle_popup(vim.bo.filetype) ]],
   [[ command! LvimCacheReset lua require('lvim.utils.hooks').reset_cache() ]],
   [[ command! LvimUpdate lua require('lvim.bootstrap').update() ]],
+  [[ command! LvimReload lua require('lvim.config'):reload() ]],
 }
 
 M.load = function(commands)

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -98,7 +98,7 @@ M.config = function()
         name = "Packer",
         c = { "<cmd>PackerCompile<cr>", "Compile" },
         i = { "<cmd>PackerInstall<cr>", "Install" },
-        r = { "<cmd>lua require('lvim.utils').reload_lv_config()<cr>", "Reload" },
+        r = { "<cmd>lua require('lvim.plugin-loader').cache_reset()<cr>", "Re-compile" },
         s = { "<cmd>PackerSync<cr>", "Sync" },
         S = { "<cmd>PackerStatus<cr>", "Status" },
         u = { "<cmd>PackerUpdate<cr>", "Update" },
@@ -220,7 +220,7 @@ M.config = function()
           },
           P = { "<cmd>exe 'edit '.stdpath('cache').'/packer.nvim.log'<cr>", "Open the Packer logfile" },
         },
-        r = { "<cmd>lua require('lvim.utils').reload_lv_config()<cr>", "Reload configurations" },
+        r = { "<cmd>LvimReload<cr>", "Reload LunarVim's configuration" },
         u = { "<cmd>LvimUpdate<cr>", "Update LunarVim" },
       },
       s = {

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -43,7 +43,7 @@ function plugin_loader:cache_clear()
 end
 
 function plugin_loader:cache_reset()
-  self.cache_clear()
+  plugin_loader:cache_clear()
   require("packer").compile()
   if utils.is_file(compile_path) then
     Log:debug "generated packer_compiled.lua"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Add `LvimReload` as a command for ease of use
- Update which-key entries

Fixes #1746

## How Has This Been Tested?

- `<leader>Lr` -> reload lunarvim's configuration
- `<leader>pr` -> packer re-comiple
