### PR TITLE
[Bugfix]: require lspconfig for a language server only if it's not already loaded

### DIFF
--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -51,7 +51,9 @@ end
 function M.get_supported_filetypes(server_name)
   -- print("got filetypes query request for: " .. server_name)
   local configs = require "lspconfig/configs"
-  pcall(require, ("lspconfig/" .. server_name))
+  if configs[server_name] == nil then
+    pcall(require, ("lspconfig/" .. server_name))
+  end
   for _, config in pairs(configs) do
     if config.name == server_name then
       return config.document_config.default_config.filetypes or {}


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

After running `:LvimUpdate` when .go or .yaml file is open language features stop working. I was able to track it down to the ftplugin regen issue - basically `:LvimUpdate` removes all files from `~/.local/share/lunarvim/site/after/ftplugin` and regenerates them, but it doesn't do it for the actively running lsp server. The fix is to require specific language server only if it's not already loaded.

## How Has This Been Tested?

- Run `lvim main.go`
- Run command `:LvimUpdate`
- Restart lvim
- Run `lvim main.go`
- Check that language features are working (`gd` for example)

