### PR TITLE
fix: overloading keymappings now works correctly even after reloading

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,4 @@ vim.cmd("colorscheme " .. lvim.colorscheme)
 local commands = require "lvim.core.commands"
 commands.load(commands.defaults)
 
-require("lvim.keymappings").setup()
-
 require("lvim.lsp").setup()

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -5,6 +5,11 @@ local M = {}
 local user_config_dir = get_config_dir()
 local user_config_file = utils.join_paths(user_config_dir, "config.lua")
 
+local function apply_defaults(configs, defaults)
+  configs = configs or {}
+  return vim.tbl_deep_extend("keep", configs, defaults)
+end
+
 ---Get the full path to the user configuration file
 ---@return string
 function M:get_user_config_path()
@@ -27,11 +32,14 @@ function M:init()
   local settings = require "lvim.config.settings"
   settings.load_options()
 
+  local default_keymaps = require("lvim.keymappings").get_defaults()
+  lvim.keys = apply_defaults(lvim.keys, default_keymaps)
+
   local autocmds = require "lvim.core.autocmds"
-  lvim.autocommands = autocmds.load_augroups()
+  lvim.autocommands = apply_defaults(lvim.autocommands, autocmds.load_augroups())
 
   local lvim_lsp_config = require "lvim.lsp.config"
-  lvim.lsp = vim.deepcopy(lvim_lsp_config)
+  lvim.lsp = apply_defaults(lvim.lsp, vim.deepcopy(lvim_lsp_config))
 
   local supported_languages = require "lvim.config.supported_languages"
   require("lvim.lsp.manager").init_defaults(supported_languages)
@@ -80,6 +88,9 @@ function M:load(config_path)
 
   autocmds.define_augroups(lvim.autocommands)
 
+  vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
+  require("lvim.keymappings").load(lvim.keys)
+
   local settings = require "lvim.config.settings"
   settings.load_commands()
 end
@@ -89,7 +100,7 @@ end
 function M:reload()
   local lvim_modules = {}
   for module, _ in pairs(package.loaded) do
-    if module:match "lvim" then
+    if module:match "lvim.core" then
       package.loaded.module = nil
       table.insert(lvim_modules, module)
     end
@@ -98,7 +109,6 @@ function M:reload()
   M:init()
   M:load()
 
-  require("lvim.keymappings").setup() -- this should be done before loading the plugins
   local plugins = require "lvim.plugins"
   utils.toggle_autoformat()
   local plugin_loader = require "lvim.plugin-loader"

--- a/lua/lvim/core/builtins/init.lua
+++ b/lua/lvim/core/builtins/init.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local builtins = {
-  "lvim.keymappings",
   "lvim.core.which-key",
   "lvim.core.gitsigns",
   "lvim.core.cmp",

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -57,13 +57,14 @@ end
 -- Load key mappings for all provided modes
 -- @param keymaps A list of key mappings for each mode
 function M.load(keymaps)
+  keymaps = keymaps or {}
   for mode, mapping in pairs(keymaps) do
     M.load_mode(mode, mapping)
   end
 end
 
-function M.config()
-  lvim.keys = {
+function M.get_defaults()
+  local keys = {
     ---@usage change or add keymappings for insert mode
     insert_mode = {
       -- 'jk' for quitting insert mode
@@ -151,12 +152,14 @@ function M.config()
   }
 
   if vim.fn.has "mac" == 1 then
-    lvim.keys.normal_mode["<A-Up>"] = lvim.keys.normal_mode["<C-Up>"]
-    lvim.keys.normal_mode["<A-Down>"] = lvim.keys.normal_mode["<C-Down>"]
-    lvim.keys.normal_mode["<A-Left>"] = lvim.keys.normal_mode["<C-Left>"]
-    lvim.keys.normal_mode["<A-Right>"] = lvim.keys.normal_mode["<C-Right>"]
+    keys.normal_mode["<A-Up>"] = keys.normal_mode["<C-Up>"]
+    keys.normal_mode["<A-Down>"] = keys.normal_mode["<C-Down>"]
+    keys.normal_mode["<A-Left>"] = keys.normal_mode["<C-Left>"]
+    keys.normal_mode["<A-Right>"] = keys.normal_mode["<C-Right>"]
     Log:debug "Activated mac keymappings"
   end
+
+  return keys
 end
 
 function M.print(mode)
@@ -166,11 +169,6 @@ function M.print(mode)
   else
     print(vim.inspect(lvim.keys))
   end
-end
-
-function M.setup()
-  vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
-  M.load(lvim.keys)
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Overloading keymappings now works correctly even after reloading.

Fixes #1758

## How Has This Been Tested?

`<leader>Lk` should show that the changes are persistent.
