### PR TITLE
feat: global install

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -102,7 +102,7 @@ end
 ---pulls the latest changes from github and, resets the startup cache
 function M:update()
   hooks.run_pre_update()
-  M:update_repo()
+  --M:update_repo()
   hooks.run_post_update()
 end
 

--- a/utils/bin/lvim
+++ b/utils/bin/lvim
@@ -1,6 +1,23 @@
 #!/bin/sh
 
-export LUNARVIM_RUNTIME_DIR="${LUNARVIM_RUNTIME_DIR:-$HOME/.local/share/lunarvim}"
-export LUNARVIM_CONFIG_DIR="${LUNARVIM_CONFIG_DIR:-$HOME/.config/lvim}"
+LUNARVIM_INIT="/usr/local/share/lunarvim/lvim/init.lua"
 
-exec nvim -u "$LUNARVIM_RUNTIME_DIR/lvim/init.lua" "$@"
+if [ -f "$HOME/.local/share/lunarvim/lvim/init.lua" ]; then
+  LUNARVIM_INIT="$HOME/.local/share/lunarvim/lvim/init.lua"
+fi
+
+export LUNARVIM_RUNTIME_DIR="$HOME/.local/share/lunarvim/data"
+export LUNARVIM_CACHE_DIR="$HOME/.local/share/lunarvim/cache"
+export LUNARVIM_CONFIG_DIR="$HOME/.config/lvim"
+
+#
+# When running as lvim the neovim process MUST never refer to the standard user config:
+# Anything that uses stdpath('data'), stdpath('cache') etc will get:
+#
+# LUNARVIM_x_DIR/nvim
+#
+export XDG_CONFIG_HOME="${LUNARVIM_CONFIG_DIR}"
+export XDG_DATA_HOME="${LUNARVIM_RUNTIME_DIR}"
+export XDG_CACHE_HOME="${LUNARVIM_CACHE_DIR}"
+
+exec nvim -u "${LUNARVIM_INIT}" "$@"

--- a/utils/bin/test_runner.sh
+++ b/utils/bin/test_runner.sh
@@ -2,7 +2,7 @@
 set -e
 
 export LUNARVIM_CONFIG_DIR="${LUNARVIM_CONFIG_DIR:-"$HOME/.config/lvim"}"
-export LUNARVIM_RUNTIME_DIR="${LUNARVIM_RUNTIME_DIR:-"$HOME/.local/share/lunarvim"}"
+export LUNARVIM_RUNTIME_DIR="${LUNARVIM_RUNTIME_DIR:-"$HOME/.local/share/lunarvim/lvim"}"
 
 export LVIM_TEST_ENV=true
 

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -319,14 +319,7 @@ function setup_shim() {
   if [ ! -d "$INSTALL_PREFIX/bin" ]; then
     mkdir -p "$INSTALL_PREFIX/bin"
   fi
-  cat >"$INSTALL_PREFIX/bin/lvim" <<EOF
-#!/bin/sh
-
-export LUNARVIM_CONFIG_DIR="\${LUNARVIM_CONFIG_DIR:-$LUNARVIM_CONFIG_DIR}"
-export LUNARVIM_RUNTIME_DIR="\${LUNARVIM_RUNTIME_DIR:-$LUNARVIM_RUNTIME_DIR}"
-
-exec nvim -u "\$LUNARVIM_RUNTIME_DIR/lvim/init.lua" "\$@"
-EOF
+  cp "$LUNARVIM_RUNTIME_DIR/lvim/utils/bin/lvim" "$INSTALL_PREFIX/bin/lvim"
   chmod +x "$INSTALL_PREFIX/bin/lvim"
 }
 


### PR DESCRIPTION
Resurrected my global-install PR again to work with the latest rolling release.

This ensures that bin/lvim defines all of the LUNARVIM_x_DIR variables correctly.

Also when running as lvim (instead of nvim) we should guarantee that stdpath('data') etc do not give paths to the user standard neovim installation.