### PR TITLE
feat: add support for using minimal_lsp on windows

### DIFF
--- a/tests/minimal_lsp.lua
+++ b/tests/minimal_lsp.lua
@@ -1,8 +1,25 @@
-vim.cmd [[set runtimepath=$VIMRUNTIME]]
-vim.cmd [[set packpath=/tmp/nvim/site]]
+local on_windows = vim.loop.os_uname().version:match "Windows"
 
-local package_root = "/tmp/nvim/site/pack"
-local install_path = package_root .. "/packer/start/packer.nvim"
+local function join_paths(...)
+  local path_sep = on_windows and "\\" or "/"
+  local result = table.concat({ ... }, path_sep)
+  return result
+end
+
+vim.cmd [[set runtimepath=$VIMRUNTIME]]
+
+local temp_dir
+if on_windows then
+  temp_dir = vim.loop.os_getenv "TEMP"
+else
+  temp_dir = "/tmp"
+end
+
+vim.cmd("set packpath=" .. join_paths(temp_dir, "nvim", "site"))
+
+local package_root = join_paths(temp_dir, "nvim", "site", "pack")
+local install_path = join_paths(package_root, "packer", "start", "packer.nvim")
+local compile_path = join_paths(install_path, "plugin", "packer_compiled.lua")
 
 -- Choose whether to use the executable that's managed by lsp-installer
 local use_lsp_installer = true
@@ -16,7 +33,7 @@ local function load_plugins()
     },
     config = {
       package_root = package_root,
-      compile_path = install_path .. "/plugin/packer_compiled.lua",
+      compile_path = compile_path,
     },
   }
 end

--- a/utils/bin/lvim.ps1
+++ b/utils/bin/lvim.ps1
@@ -6,4 +6,4 @@ $env:LUNARVIM_RUNTIME_DIR = ($env:LUNARVIM_RUNTIME_DIR, "$env:XDG_DATA_HOME\luna
 $env:LUNARVIM_CONFIG_DIR = ($env:LUNARVIM_CONFIG_DIR, "$env:XDG_CONFIG_HOME\lvim", 1 -ne $null)[0]
 $env:LUNARVIM_CACHE_DIR = ($env:LUNARVIM_CACHE_DIR, "$env:XDG_CACHE_HOME\lvim", 1 -ne $null)[0]
 
-nvim -u "$env:LUNARVIM_RUNTIME_DIR\lvim\init.lua"
+nvim -u "$env:LUNARVIM_RUNTIME_DIR\lvim\init.lua" @args


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Allow using `minimal_lsp.lua` on Windows
Fixes a problem where args aren't passed when using `lvim.ps1` 

## How Has This Been Tested?

This now works on Windows

```pwsh
nvim -u .\minimal_lsp.lua
```

