### PR TITLE
fix: dashboard now runs on fresh installs

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -71,7 +71,11 @@ M.setup = function()
     return
   end
 
-  treesitter_configs.setup(lvim.builtin.treesitter)
+  local opts = vim.deepcopy(lvim.builtin.treesitter)
+
+  -- avoid running any installers in headless mode since it's harder to detect failures
+  opts.ensure_installed = #vim.api.nvim_list_uis() == 0 and {} or opts.ensure_installed
+  treesitter_configs.setup(opts)
 
   if lvim.builtin.treesitter.on_config_done then
     lvim.builtin.treesitter.on_config_done(treesitter_configs)

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -353,16 +353,13 @@ function setup_lvim() {
 
   echo "Preparing Packer setup"
 
-  rm -f "$LUNARVIM_CONFIG_DIR/config.lua"
-  touch "$LUNARVIM_CONFIG_DIR/config.lua"
+  cp "$LUNARVIM_RUNTIME_DIR/lvim/utils/installer/config.example.lua" "$LUNARVIM_CONFIG_DIR/config.lua"
 
   "$INSTALL_PREFIX/bin/lvim" --headless \
     -c 'autocmd User PackerComplete quitall' \
     -c 'PackerSync'
 
   echo "Packer setup complete"
-
-  cp "$LUNARVIM_RUNTIME_DIR/lvim/utils/installer/config.example.lua" "$LUNARVIM_CONFIG_DIR/config.lua"
 }
 
 function update_lvim() {


### PR DESCRIPTION
# Description

There was a regression from https://github.com/LunarVim/LunarVim/pull/1841 causing toggleterm and dashboard to not appear due to PackerSync not running with them enabled.

Fixes #1895