### PR TITLE
fix(lualine): add space to diff components

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -35,7 +35,7 @@ return {
   diff = {
     "diff",
     source = diff_source,
-    symbols = { added = "  ", modified = "柳", removed = " " },
+    symbols = { added = "  ", modified = "柳 ", removed = " " },
     diff_color = {
       added = { fg = colors.green },
       modified = { fg = colors.yellow },


### PR DESCRIPTION

# Description

Add proper space between glyphs and number for diff components.

Before:
![图片](https://user-images.githubusercontent.com/45989017/140028611-52332258-35f0-468f-b48c-f0286dc27429.png)

After:
![图片](https://user-images.githubusercontent.com/45989017/140028432-57f58b0f-f342-413c-9c3d-22784196337b.png)

