### PR TITLE
fix(reload): set lvim modules to nil correctly

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -101,7 +101,7 @@ function M:reload()
   local lvim_modules = {}
   for module, _ in pairs(package.loaded) do
     if module:match "lvim.core" then
-      package.loaded.module = nil
+      package.loaded[module] = nil
       table.insert(lvim_modules, module)
     end
   end


### PR DESCRIPTION

# Description

I only change to use `[ ]` when set modules, otherwise the modules didn't set to nil as they begin with `lvim.core` which can't use dot syntax.

After trying the following code snippet first and find it only output "aaa", I know that this is the right way to set modules.

```lua
  for module, _ in pairs(package.loaded) do
    if module:match "lvim.core" then
      -- print(module)
      if nil == package.loaded.module then
        print "aaa"
      end
      if nil == package.loaded[module] then
        print "bbb"
      end
    end
  end
```

## How Has This Been Tested?

Take https://github.com/LunarVim/LunarVim/pull/1897 as an example, I can't see the change I made to lualine by `LvimReload` since the `lvim.core.lualine` module didn't reload properly. After apply this commit, I can see the change after executing `LvimReload` immediately.





