### PR TITLE
fix: use an indepdent shadafile from neovim

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -46,7 +46,7 @@ end
 function M:init(base_dir)
   self.runtime_dir = get_runtime_dir()
   self.config_dir = get_config_dir()
-  self.cache_path = get_cache_dir()
+  self.cache_dir = get_cache_dir()
   self.pack_dir = join_paths(self.runtime_dir, "site", "pack")
   self.packer_install_dir = join_paths(self.runtime_dir, "site", "pack", "packer", "start", "packer.nvim")
   self.packer_cache_path = join_paths(self.config_dir, "plugin", "packer_compiled.lua")
@@ -80,7 +80,7 @@ function M:init(base_dir)
   if not os.getenv "LVIM_TEST_ENV" then
     _G.PLENARY_DEBUG = false
     require("lvim.impatient").setup {
-      path = vim.fn.stdpath "cache" .. "/lvim_cache",
+      path = join_paths(self.cache_dir, "lvim_cache"),
       enable_profiling = true,
     }
   end

--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -51,6 +51,8 @@ M.load_options = function()
 
   vim.opt.shortmess:append "c"
 
+  vim.opt.shadafile = utils.join_paths(get_cache_dir(), "lvim.shada")
+
   for k, v in pairs(default_options) do
     vim.opt[k] = v
   end

--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -1,6 +1,6 @@
 local Log = {}
 
-local logfile = string.format("%s/%s.log", vim.fn.stdpath "cache", "lvim")
+local logfile = string.format("%s/%s.log", get_cache_dir(), "lvim")
 
 Log.levels = {
   TRACE = 1,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Use an independent [shadafile](https://neovim.io/doc/user/starting.html#shada-file) from base Neovim.

Fixes mingled jumplists when using both Neovim and LunarVim.

