### PR TITLE
refactor: deprecate lvim.lang.FOO

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ lvim.plugins = {
 
 ## Breaking changes
 
-- `lvim.lang.FOO.lsp` is no longer supported after #1584.
+- `lvim.lang.FOO` is no longer supported. Refer to <https://www.lunarvim.org/languages> for up-to-date instructions.
 
 ## Resources
 

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -63,9 +63,9 @@ local function handle_deprecated_settings()
 
   ---lvim.lang.FOO.lsp
   for lang, entry in pairs(lvim.lang) do
-    local deprecated_config = entry["lsp"] or {}
+    local deprecated_config = entry.formatters or entry.linters or {}
     if not vim.tbl_isempty(deprecated_config) then
-      deprecation_notice(string.format("lvim.lang.%s.lsp", lang))
+      deprecation_notice(string.format("lvim.lang.%s", lang))
     end
   end
 end

--- a/lua/lvim/lsp/null-ls/init.lua
+++ b/lua/lvim/lsp/null-ls/init.lua
@@ -1,8 +1,6 @@
 local M = {}
 
 local Log = require "lvim.core.log"
-local formatters = require "lvim.lsp.null-ls.formatters"
-local linters = require "lvim.lsp.null-ls.linters"
 
 function M:setup()
   local status_ok, null_ls = pcall(require, "null-ls")
@@ -19,20 +17,6 @@ function M:setup()
   end
 
   require("lspconfig")["null-ls"].setup(lvim.lsp.null_ls.setup)
-  for filetype, config in pairs(lvim.lang) do
-    if not vim.tbl_isempty(config.formatters) then
-      vim.tbl_map(function(c)
-        c.filetypes = { filetype }
-      end, config.formatters)
-      formatters.setup(config.formatters)
-    end
-    if not vim.tbl_isempty(config.linters) then
-      vim.tbl_map(function(c)
-        c.filetypes = { filetype }
-      end, config.formatters)
-      linters.setup(config.linters)
-    end
-  end
 end
 
 return M


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Consolidate configuration styles for linters and formatters

Fixes #1756

## How Has This Been Tested?

- Add this to your `config.lua`

```lua
lvim.lang.c.formatters = {"test"}
```
