### PR TITLE
feat: let users disable nvim-web-devicons

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -177,7 +177,11 @@ return {
   },
 
   -- Icons
-  { "kyazdani42/nvim-web-devicons", commit = commit.nvim_web_devicons },
+  {
+    "kyazdani42/nvim-web-devicons",
+    commit = commit.nvim_web_devicons,
+    disable = lvim.builtin.nvim_web_devicons ~= nil,
+  },
 
   -- Status Line and Bufferline
   {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Basically it is a feature for me :)
it would let users disable nvim-web-devicons and use sth like https://github.com/Nguyen-Hoang-Nam/nvim-mini-file-icons if they wanted to

before this change:
<img width="745" alt="Screen Shot 2021-11-06 at 12 28 35 PM" src="https://user-images.githubusercontent.com/10992695/140604075-1fdd582f-be38-47fb-a135-2adf782c8875.png">

after this change:
<img width="754" alt="Screen Shot 2021-11-06 at 12 26 37 PM" src="https://user-images.githubusercontent.com/10992695/140604046-b564bb48-75da-4090-a103-fb43f24a6440.png">

