### PR TITLE
fix: packersync issue when you have large number of plugins

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -23,6 +23,7 @@ function plugin_loader.init(opts)
     compile_path = compile_path,
     log = { level = "warn" },
     git = { clone_timeout = 300 },
+    max_jobs = 50,
     display = {
       open_fn = function()
         return require("packer.util").float { border = "rounded" }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

if you have large number of plugins ( more than 70) running `:PackerSync` wouldn't finish
and gets stuck, this fixes that by forcing at most 50 concurrent git jobs for packer

more info:
https://github.com/wbthomason/packer.nvim/issues/120

