### PR TITLE
fix(lsp): correct map and prevent highlight leak of diagnostic signs in 0.6

### DIFF
--- a/lua/lvim/lsp/handlers.lua
+++ b/lua/lvim/lsp/handlers.lua
@@ -36,16 +36,6 @@ function M.setup()
         if not vim.api.nvim_buf_is_loaded(bufnr) then
           return
         end
-
-        local sign_names = {
-          "DiagnosticSignError",
-          "DiagnosticSignWarn",
-          "DiagnosticSignInfo",
-          "DiagnosticSignHint",
-        }
-        for i, sign in ipairs(lvim.lsp.diagnostics.signs.values) do
-          vim.fn.sign_define(sign_names[i], { texthl = sign_names[i], text = sign.text, numhl = "" })
-        end
         vim_diag.show(namespace, bufnr, diagnostics, config)
       else
         vim.lsp.diagnostic.save(diagnostics, bufnr, ctx.client_id)

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -136,6 +136,13 @@ function M.get_common_opts()
   }
 end
 
+local LSP_DEPRECATED_SIGN_MAP = {
+  ["LspDiagnosticsSignError"] = "DiagnosticSignError",
+  ["LspDiagnosticsSignWarning"] = "DiagnosticSignWarn",
+  ["LspDiagnosticsSignHint"] = "DiagnosticSignHint",
+  ["LspDiagnosticsSignInformation"] = "DiagnosticSignInfo",
+}
+
 function M.setup()
   Log:debug "Setting up LSP support"
 
@@ -144,7 +151,13 @@ function M.setup()
     return
   end
 
+  local is_neovim_nightly = vim.fn.has "nvim-0.5.1" > 0
+
   for _, sign in ipairs(lvim.lsp.diagnostics.signs.values) do
+    local lsp_sign_name = LSP_DEPRECATED_SIGN_MAP[sign.name]
+    if is_neovim_nightly and lsp_sign_name then
+      vim.fn.sign_define(lsp_sign_name, { texthl = lsp_sign_name, text = sign.text, numhl = lsp_sign_name })
+    end
     vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })
   end
 


### PR DESCRIPTION
# Description

For Neovim nightly builds (versions greater than 0.5.1), every time the LSP server published diagnostics (quite frequently in my case), it would define and re-define a sign, leaving hundreds of cleared highlight groups.

Additionally, because position was being used instead of mapping by name, the highlight groups were incorrect.

This PR fixes both of these problems.

Fixes #1880

## How Has This Been Tested?

Use neovim nightly, open a decently sized document that has a supported and setup LSP.
Make an error that triggers a lot of diagnostic errors (for example an `{` in the middle of a function), then trigger cmp autocomplete and scroll through. This error should no longer occur while using this PR.