### PR TITLE
fix(keymap): unset on reload, load correct order, add unset default

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -32,9 +32,6 @@ function M:init()
   local settings = require "lvim.config.settings"
   settings.load_options()
 
-  local default_keymaps = require("lvim.keymappings").get_defaults()
-  lvim.keys = apply_defaults(lvim.keys, default_keymaps)
-
   local autocmds = require "lvim.core.autocmds"
   lvim.autocommands = apply_defaults(lvim.autocommands, autocmds.load_augroups())
 
@@ -89,6 +86,9 @@ function M:load(config_path)
   autocmds.define_augroups(lvim.autocommands)
 
   vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
+
+  local default_keymaps = require("lvim.keymappings").get_defaults()
+  lvim.keys = apply_defaults(lvim.keys, default_keymaps)
   require("lvim.keymappings").load(lvim.keys)
 
   local settings = require "lvim.config.settings"
@@ -98,6 +98,8 @@ end
 --- Override the configuration with a user provided one
 -- @param config_path The path to the configuration overrides
 function M:reload()
+  require("lvim.keymappings").clear(lvim.keys)
+
   local lvim_modules = {}
   for module, _ in pairs(package.loaded) do
     if module:match "lvim.core" then

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -42,7 +42,7 @@ function M.clear(keymaps)
     mode = mode_adapters[mode] and mode_adapters[mode] or mode
     for key, _ in pairs(mappings) do
       -- some plugins may override default bindings that the user hasn't manually overriden
-      if default[mode][key] ~= nil then
+      if default[mode] == nil or default[mode][key] ~= nil then
         pcall(vim.api.nvim_del_keymap, mode, key)
       end
     end

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -24,9 +24,23 @@ local mode_adapters = {
 -- Append key mappings to lunarvim's defaults for a given mode
 -- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
 function M.append_to_defaults(keymaps)
+  local default = M.get_defaults()
+  lvim.keys = lvim.keys or default
   for mode, mappings in pairs(keymaps) do
-    for k, v in ipairs(mappings) do
+    lvim.keys[mode] = lvim.keys[mode] or default[mode]
+    for k, v in pairs(mappings) do
       lvim.keys[mode][k] = v
+    end
+  end
+end
+
+-- Unsets all keybindings defined in keymaps
+-- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
+function M.clear(keymaps)
+  for mode, mappings in pairs(keymaps) do
+    mode = mode_adapters[mode] and mode_adapters[mode] or mode
+    for key, _ in pairs(mappings) do
+      pcall(vim.api.nvim_del_keymap, mode, key)
     end
   end
 end
@@ -41,7 +55,11 @@ function M.set_keymaps(mode, key, val)
     opt = val[2]
     val = val[1]
   end
-  vim.api.nvim_set_keymap(mode, key, val, opt)
+  if val then
+    vim.api.nvim_set_keymap(mode, key, val, opt)
+  else
+    pcall(vim.api.nvim_del_keymap, mode, key)
+  end
 end
 
 -- Load key mappings for a given mode

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -37,10 +37,14 @@ end
 -- Unsets all keybindings defined in keymaps
 -- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
 function M.clear(keymaps)
+  local default = M.get_defaults()
   for mode, mappings in pairs(keymaps) do
     mode = mode_adapters[mode] and mode_adapters[mode] or mode
     for key, _ in pairs(mappings) do
-      pcall(vim.api.nvim_del_keymap, mode, key)
+      -- some plugins may override default bindings that the user hasn't manually overriden
+      if default[mode][key] ~= nil then
+        pcall(vim.api.nvim_del_keymap, mode, key)
+      end
     end
   end
 end

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -39,11 +39,11 @@ end
 function M.clear(keymaps)
   local default = M.get_defaults()
   for mode, mappings in pairs(keymaps) do
-    mode = mode_adapters[mode] and mode_adapters[mode] or mode
+    local translated_mode = mode_adapters[mode] and mode_adapters[mode] or mode
     for key, _ in pairs(mappings) do
       -- some plugins may override default bindings that the user hasn't manually overriden
-      if default[mode] == nil or default[mode][key] ~= nil then
-        pcall(vim.api.nvim_del_keymap, mode, key)
+      if default[mode][key] ~= nil or (default[translated_mode] ~= nil and default[translated_mode][key] ~= nil) then
+        pcall(vim.api.nvim_del_keymap, translated_mode, key)
       end
     end
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Prior to this PR:

- A key mapping remains after reloading even after removing the line setting it
- Key mappings were loading using the user's config before being reloaded
- There was no way to easily unmap a default key mapping

After this PR:

- Removing the line setting a key mapping and triggering a reload will unbind that key mapping
- Key mappings are loaded after the user's config is loaded
- Setting a key mapping to false will explicitly unset that binding

## How Has This Been Tested?

Open `config.lua`, set the following and save:
```
lvim.keys = {
  normal_mode = {
      ["<C-b>"] = "<cmd>lua print('hi!')<cr>",
      ["<A-j"] = false
  }
}
```
`:nmap <A-j>` will show that `<A-j>` has been unset
`:nmap <C-b>` will show that `<C-b>` has been set

Set to the following (remove the two normal mode binding lines):
```
lvim.keys = {
  normal_mode = {
  }
}
```
`:nmap <A-j>` will show that `<A-j>` is the default binding
`:nmap <C-b>` will show that `<C-b>` has been unset