### PR TITLE
:bug: Fixing error message in nvim-tree.

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -7,6 +7,8 @@ function M.config()
     on_config_done = nil,
     setup = {
       open_on_setup = false,
+      ignore = { ".git", "node_modules", ".cache" },
+      hide_dotfiles = 1,
       auto_close = true,
       open_on_tab = false,
       update_focused_file = {
@@ -37,9 +39,7 @@ function M.config()
       folder_arrows = 1,
       tree_width = 30,
     },
-    ignore = { ".git", "node_modules", ".cache" },
     quit_on_open = 0,
-    hide_dotfiles = 1,
     git_hl = 1,
     root_folder_modifier = ":t",
     allow_resize = 1,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Changed location of configuration in `nvimtree.lua` file to match the error message displayed by nvim-tree.

Fixes #(issue)
This fixes the following error message that shows when opening LunarVim:
![image](https://user-images.githubusercontent.com/6407557/141213281-30331c9f-a5f3-4825-89f7-32e4f2dfd261.png)


## How Has This Been Tested?
After changes, the error message is no longer showing.
