### PR TITLE
Fix example of unmapping an lvim default

### DIFF
--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -18,7 +18,7 @@ lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- unmap a default keymapping
--- lvim.keys.normal_mode["<C-Up>"] = nil
+-- lvim.keys.normal_mode["<C-Up>"] = false
 -- edit a default keymapping
 -- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
 

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -18,7 +18,7 @@ lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- unmap a default keymapping
--- lvim.keys.normal_mode["<C-Up>"] = ""
+-- lvim.keys.normal_mode["<C-Up>"] = nil
 -- edit a default keymapping
 -- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
 


### PR DESCRIPTION
The example config file has a sample for unmapping a LunarVim key by
setting it to "".  When I tried that, the result was that the key became
a no-op.  If I instead set it to nil, the key returned to default vim
operation.  In particular, I was trying to unmap normal mode L and H.  I
got to nil by searching for how to delete a entry in a dictionary in
lua, but I'm not familiar with lua.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Please include a summary of the change and which issue is fixed. \
List any dependencies that are required for this change.

Fixes #(issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. \
Provide instructions so we can reproduce. \
Please also list any relevant details for your test configuration.

- Run command `:mycommand`
- Check logs
- ...

