### PR TITLE
Bugfix: allow LunarVim changelog to work outside the lvim directory

### DIFF
--- a/lua/lvim/core/telescope/custom-finders.lua
+++ b/lua/lvim/core/telescope/custom-finders.lua
@@ -40,7 +40,7 @@ function M.grep_lunarvim_files(opts)
 end
 
 function M.view_lunarvim_changelog()
-  local opts = {}
+  local opts = { cwd = get_lvim_base_dir() }
   opts.entry_maker = make_entry.gen_from_git_commits(opts)
 
   pickers.new(opts, {
@@ -52,8 +52,6 @@ function M.view_lunarvim_changelog()
         "log",
         "--pretty=oneline",
         "--abbrev-commit",
-        "--",
-        ".",
       },
       opts
     ),


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This sets the git dir and work tree to where lvim is installed. Without this, viewing the
changelog shows the git log for the current working directory.

The previewers don't work, but the commit list shows. The previewers may
need changes to telescope.

## How Has This Been Tested?

Run `lua require('lvim.core.telescope.custom-finders').view_lunarvim_changelog()` in a git
work tree that is not for LunarVim. It will now show the log for LunarVim.
