### PR TITLE
refactor: load the default keymaps once

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -26,7 +26,7 @@ function M:init()
     lvim.database = { save_location = utils.join_paths(home_dir, ".config", "lunarvim_db"), auto_execute = 1 }
   end
 
-  lvim.keys = apply_defaults(lvim.keys, require("lvim.keymappings").get_defaults())
+  require("lvim.keymappings").load_defaults()
 
   local builtins = require "lvim.core.builtins"
   builtins.config { user_config_file = user_config_file }
@@ -89,8 +89,6 @@ function M:load(config_path)
 
   vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
 
-  local default_keymaps = require("lvim.keymappings").get_defaults()
-  lvim.keys = apply_defaults(lvim.keys, default_keymaps)
   require("lvim.keymappings").load(lvim.keys)
 
   local settings = require "lvim.config.settings"
@@ -100,8 +98,6 @@ end
 --- Override the configuration with a user provided one
 -- @param config_path The path to the configuration overrides
 function M:reload()
-  require("lvim.keymappings").clear(lvim.keys)
-
   local lvim_modules = {}
   for module, _ in pairs(package.loaded) do
     if module:match "lvim.core" then

--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -5,17 +5,13 @@ M.config = function()
     active = true,
     on_config_done = nil,
     keymap = {
-      normal_mode = {
-        ["<S-l>"] = ":BufferNext<CR>",
-        ["<S-h>"] = ":BufferPrevious<CR>",
-      },
+      normal_mode = {},
     },
   }
 end
 
 M.setup = function()
-  local keymap = require "lvim.keymappings"
-  keymap.append_to_defaults(lvim.builtin.bufferline.keymap)
+  require("lvim.keymappings").load(lvim.builtin.bufferline.keymap)
 
   if lvim.builtin.bufferline.on_config_done then
     lvim.builtin.bufferline.on_config_done()

--- a/lua/lvim/core/dashboard.lua
+++ b/lua/lvim/core/dashboard.lua
@@ -58,6 +58,7 @@ M.config = function(config)
 
     footer = { "lunarvim.org" },
   }
+  lvim.builtin.which_key.mappings[";"] = { "<cmd>Dashboard<CR>", "Dashboard" }
 end
 
 M.setup = function()
@@ -68,8 +69,6 @@ M.setup = function()
   vim.g.dashboard_default_executive = lvim.builtin.dashboard.search_handler
 
   vim.g.dashboard_custom_section = lvim.builtin.dashboard.custom_section
-
-  lvim.builtin.which_key.mappings[";"] = { "<cmd>Dashboard<CR>", "Dashboard" }
 
   vim.g.dashboard_session_directory = lvim.builtin.dashboard.session_directory
 

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -65,6 +65,7 @@ function M.config()
       },
     },
   }
+  lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 end
 
 function M.setup()
@@ -97,8 +98,6 @@ function M.setup()
       { key = "v", cb = tree_cb "vsplit" },
     }
   end
-
-  lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 
   local tree_view = require "nvim-tree.view"
 

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -188,7 +188,7 @@ M.config = function()
           "<cmd>lua require('lvim.core.telescope.custom-finders').grep_lunarvim_files()<cr>",
           "Grep LunarVim files",
         },
-        k = { "<cmd>lua require('lvim.keymappings').print()<cr>", "View LunarVim's default keymappings" },
+        k = { "<cmd>Telescope keymaps<cr>", "View LunarVim's keymappings" },
         i = {
           "<cmd>lua require('lvim.core.info').toggle_popup(vim.bo.filetype)<cr>",
           "Toggle LunarVim Info",

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -21,15 +21,107 @@ local mode_adapters = {
   command_mode = "c",
 }
 
+local defaults = {
+  ---@usage change or add keymappings for insert mode
+  insert_mode = {
+    -- 'jk' for quitting insert mode
+    ["jk"] = "<ESC>",
+    -- 'kj' for quitting insert mode
+    ["kj"] = "<ESC>",
+    -- 'jj' for quitting insert mode
+    ["jj"] = "<ESC>",
+    -- Move current line / block with Alt-j/k ala vscode.
+    ["<A-j>"] = "<Esc>:m .+1<CR>==gi",
+    -- Move current line / block with Alt-j/k ala vscode.
+    ["<A-k>"] = "<Esc>:m .-2<CR>==gi",
+    -- navigation
+    ["<A-Up>"] = "<C-\\><C-N><C-w>k",
+    ["<A-Down>"] = "<C-\\><C-N><C-w>j",
+    ["<A-Left>"] = "<C-\\><C-N><C-w>h",
+    ["<A-Right>"] = "<C-\\><C-N><C-w>l",
+  },
+
+  ---@usage change or add keymappings for normal mode
+  normal_mode = {
+    -- Better window movement
+    ["<C-h>"] = "<C-w>h",
+    ["<C-j>"] = "<C-w>j",
+    ["<C-k>"] = "<C-w>k",
+    ["<C-l>"] = "<C-w>l",
+
+    -- Resize with arrows
+    ["<C-Up>"] = ":resize -2<CR>",
+    ["<C-Down>"] = ":resize +2<CR>",
+    ["<C-Left>"] = ":vertical resize -2<CR>",
+    ["<C-Right>"] = ":vertical resize +2<CR>",
+
+    -- Tab switch buffer
+    ["<S-l>"] = ":BufferNext<CR>",
+    ["<S-h>"] = ":BufferPrevious<CR>",
+
+    -- Move current line / block with Alt-j/k a la vscode.
+    ["<A-j>"] = ":m .+1<CR>==",
+    ["<A-k>"] = ":m .-2<CR>==",
+
+    -- QuickFix
+    ["]q"] = ":cnext<CR>",
+    ["[q"] = ":cprev<CR>",
+    ["<C-q>"] = ":call QuickFixToggle()<CR>",
+  },
+
+  ---@usage change or add keymappings for terminal mode
+  term_mode = {
+    -- Terminal window navigation
+    ["<C-h>"] = "<C-\\><C-N><C-w>h",
+    ["<C-j>"] = "<C-\\><C-N><C-w>j",
+    ["<C-k>"] = "<C-\\><C-N><C-w>k",
+    ["<C-l>"] = "<C-\\><C-N><C-w>l",
+  },
+
+  ---@usage change or add keymappings for visual mode
+  visual_mode = {
+    -- Better indenting
+    ["<"] = "<gv",
+    [">"] = ">gv",
+
+    -- ["p"] = '"0p',
+    -- ["P"] = '"0P',
+  },
+
+  ---@usage change or add keymappings for visual block mode
+  visual_block_mode = {
+    -- Move selected line / block of text in visual mode
+    ["K"] = ":move '<-2<CR>gv-gv",
+    ["J"] = ":move '>+1<CR>gv-gv",
+
+    -- Move current line / block with Alt-j/k ala vscode.
+    ["<A-j>"] = ":m '>+1<CR>gv-gv",
+    ["<A-k>"] = ":m '<-2<CR>gv-gv",
+  },
+
+  ---@usage change or add keymappings for command mode
+  command_mode = {
+    -- navigate tab completion with <c-j> and <c-k>
+    -- runs conditionally
+    ["<C-j>"] = { 'pumvisible() ? "\\<C-n>" : "\\<C-j>"', { expr = true, noremap = true } },
+    ["<C-k>"] = { 'pumvisible() ? "\\<C-p>" : "\\<C-k>"', { expr = true, noremap = true } },
+  },
+}
+
+if vim.fn.has "mac" == 1 then
+  defaults.normal_mode["<A-Up>"] = defaults.normal_mode["<C-Up>"]
+  defaults.normal_mode["<A-Down>"] = defaults.normal_mode["<C-Down>"]
+  defaults.normal_mode["<A-Left>"] = defaults.normal_mode["<C-Left>"]
+  defaults.normal_mode["<A-Right>"] = defaults.normal_mode["<C-Right>"]
+  Log:debug "Activated mac keymappings"
+end
+
 -- Append key mappings to lunarvim's defaults for a given mode
 -- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
 function M.append_to_defaults(keymaps)
-  local default = M.get_defaults()
-  lvim.keys = lvim.keys or default
   for mode, mappings in pairs(keymaps) do
-    lvim.keys[mode] = lvim.keys[mode] or default[mode]
     for k, v in pairs(mappings) do
-      lvim.keys[mode][k] = v
+      defaults[mode][k] = v
     end
   end
 end
@@ -39,7 +131,7 @@ end
 function M.clear(keymaps)
   local default = M.get_defaults()
   for mode, mappings in pairs(keymaps) do
-    local translated_mode = mode_adapters[mode] and mode_adapters[mode] or mode
+    local translated_mode = mode_adapters[mode] or mode
     for key, _ in pairs(mappings) do
       -- some plugins may override default bindings that the user hasn't manually overriden
       if default[mode][key] ~= nil or (default[translated_mode] ~= nil and default[translated_mode][key] ~= nil) then
@@ -54,7 +146,7 @@ end
 -- @param key The key of keymap
 -- @param val Can be form as a mapping or tuple of mapping and user defined opt
 function M.set_keymaps(mode, key, val)
-  local opt = generic_opts[mode] and generic_opts[mode] or generic_opts_any
+  local opt = generic_opts[mode] or generic_opts_any
   if type(val) == "table" then
     opt = val[2]
     val = val[1]
@@ -70,7 +162,7 @@ end
 -- @param mode The keymap mode, can be one of the keys of mode_adapters
 -- @param keymaps The list of key mappings
 function M.load_mode(mode, keymaps)
-  mode = mode_adapters[mode] and mode_adapters[mode] or mode
+  mode = mode_adapters[mode] or mode
   for k, v in pairs(keymaps) do
     M.set_keymaps(mode, k, v)
   end
@@ -85,112 +177,18 @@ function M.load(keymaps)
   end
 end
 
-function M.get_defaults()
-  local keys = {
-    ---@usage change or add keymappings for insert mode
-    insert_mode = {
-      -- 'jk' for quitting insert mode
-      ["jk"] = "<ESC>",
-      -- 'kj' for quitting insert mode
-      ["kj"] = "<ESC>",
-      -- 'jj' for quitting insert mode
-      ["jj"] = "<ESC>",
-      -- Move current line / block with Alt-j/k ala vscode.
-      ["<A-j>"] = "<Esc>:m .+1<CR>==gi",
-      -- Move current line / block with Alt-j/k ala vscode.
-      ["<A-k>"] = "<Esc>:m .-2<CR>==gi",
-      -- navigation
-      ["<A-Up>"] = "<C-\\><C-N><C-w>k",
-      ["<A-Down>"] = "<C-\\><C-N><C-w>j",
-      ["<A-Left>"] = "<C-\\><C-N><C-w>h",
-      ["<A-Right>"] = "<C-\\><C-N><C-w>l",
-    },
-
-    ---@usage change or add keymappings for normal mode
-    normal_mode = {
-      -- Better window movement
-      ["<C-h>"] = "<C-w>h",
-      ["<C-j>"] = "<C-w>j",
-      ["<C-k>"] = "<C-w>k",
-      ["<C-l>"] = "<C-w>l",
-
-      -- Resize with arrows
-      ["<C-Up>"] = ":resize -2<CR>",
-      ["<C-Down>"] = ":resize +2<CR>",
-      ["<C-Left>"] = ":vertical resize -2<CR>",
-      ["<C-Right>"] = ":vertical resize +2<CR>",
-
-      -- Tab switch buffer
-      ["<S-l>"] = ":BufferNext<CR>",
-      ["<S-h>"] = ":BufferPrevious<CR>",
-
-      -- Move current line / block with Alt-j/k a la vscode.
-      ["<A-j>"] = ":m .+1<CR>==",
-      ["<A-k>"] = ":m .-2<CR>==",
-
-      -- QuickFix
-      ["]q"] = ":cnext<CR>",
-      ["[q"] = ":cprev<CR>",
-      ["<C-q>"] = ":call QuickFixToggle()<CR>",
-    },
-
-    ---@usage change or add keymappings for terminal mode
-    term_mode = {
-      -- Terminal window navigation
-      ["<C-h>"] = "<C-\\><C-N><C-w>h",
-      ["<C-j>"] = "<C-\\><C-N><C-w>j",
-      ["<C-k>"] = "<C-\\><C-N><C-w>k",
-      ["<C-l>"] = "<C-\\><C-N><C-w>l",
-    },
-
-    ---@usage change or add keymappings for visual mode
-    visual_mode = {
-      -- Better indenting
-      ["<"] = "<gv",
-      [">"] = ">gv",
-
-      -- ["p"] = '"0p',
-      -- ["P"] = '"0P',
-    },
-
-    ---@usage change or add keymappings for visual block mode
-    visual_block_mode = {
-      -- Move selected line / block of text in visual mode
-      ["K"] = ":move '<-2<CR>gv-gv",
-      ["J"] = ":move '>+1<CR>gv-gv",
-
-      -- Move current line / block with Alt-j/k ala vscode.
-      ["<A-j>"] = ":m '>+1<CR>gv-gv",
-      ["<A-k>"] = ":m '<-2<CR>gv-gv",
-    },
-
-    ---@usage change or add keymappings for command mode
-    command_mode = {
-      -- navigate tab completion with <c-j> and <c-k>
-      -- runs conditionally
-      ["<C-j>"] = { 'pumvisible() ? "\\<C-n>" : "\\<C-j>"', { expr = true, noremap = true } },
-      ["<C-k>"] = { 'pumvisible() ? "\\<C-p>" : "\\<C-k>"', { expr = true, noremap = true } },
-    },
-  }
-
-  if vim.fn.has "mac" == 1 then
-    keys.normal_mode["<A-Up>"] = keys.normal_mode["<C-Up>"]
-    keys.normal_mode["<A-Down>"] = keys.normal_mode["<C-Down>"]
-    keys.normal_mode["<A-Left>"] = keys.normal_mode["<C-Left>"]
-    keys.normal_mode["<A-Right>"] = keys.normal_mode["<C-Right>"]
-    Log:debug "Activated mac keymappings"
+-- Load the default keymappings
+function M.load_defaults()
+  M.load(M.get_defaults())
+  lvim.keys = {}
+  for idx, _ in pairs(defaults) do
+    lvim.keys[idx] = {}
   end
-
-  return keys
 end
 
-function M.print(mode)
-  print "List of LunarVim's default keymappings (not including which-key)"
-  if mode then
-    print(vim.inspect(lvim.keys[mode]))
-  else
-    print(vim.inspect(lvim.keys))
-  end
+-- Get the default keymappings
+function M.get_defaults()
+  return defaults
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- `lvim.keys` no longer holds the default values
- only load the default keymaps once
- `lvim.keys` is always loaded after the default values, so it will always take precedence
- configurable which-key registration for `dashboard` and `nvimtree`

Fixes #1548, #1755, 

## How Has This Been Tested?

- These should all be assigned to the *same value* inside the table. They should override each other, so the result will always be `Binoculars`

```lua
lvim.keys.normal_mode["B"] = ":echo 'Banana'<cr>"
lvim.keys.normal_mode["<S-b>"] = ":echo 'Basketball'<cr>"
lvim.keys.normal_mode["<s-b>"] = ":echo 'Binoculars'<cr>"
```

- it's also possible to override NvimTree's binding directly now

```lua
lvim.keys.normal_mode["<space>e"] = ":echo 'hello'<cr>"
```

