### PR TITLE
fix(windows): remove redundant `resolve` call

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -7,7 +7,7 @@ function M.load_augroups()
 
   if vim.loop.os_uname().version:match "Windows" then
     -- autocmds require forward slashes even on windows
-    user_config_file = vim.fn.resolve(user_config_file:gsub("\\", "/"))
+    user_config_file = user_config_file:gsub("\\", "/")
   end
 
   return {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

> It's better not to use `vim.fn.resolve` and set it like this:
> 
> ```lua
>   if vim.loop.os_uname().version:match "Windows" then  
>     -- autocmds require forward slashes even on windows
>     user_config_file = user_config_file:gsub("\\", "/")
>   end
> ```
> 
> Otherwise it will cause error as `string.gsub()` has two return values.
> 
> ```
> E5113: Error while calling lua chunk: Vim:E118: Too many arguments for function: resolve
> ```


