### PR TITLE
fix: correct order for cmp's setup

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local uv = vim.loop
 local path_sep = uv.os_uname().version:match "Windows" and "\\" or "/"
+local in_headless = #vim.api.nvim_list_uis() == 0
 
 ---Join path segments that were passed as input
 ---@return string
@@ -77,7 +78,7 @@ function M:init(base_dir)
   vim.fn.mkdir(get_cache_dir(), "p")
 
   -- FIXME: currently unreliable in unit-tests
-  if not os.getenv "LVIM_TEST_ENV" then
+  if not in_headless then
     _G.PLENARY_DEBUG = false
     require("lvim.impatient").setup {
       path = join_paths(self.cache_dir, "lvim_cache"),

--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -146,8 +146,6 @@ end
 M.methods.jumpable = jumpable
 
 M.config = function()
-  lvim.builtin.cmp = {}
-
   local status_cmp_ok, cmp = pcall(require, "cmp")
   if not status_cmp_ok then
     return

--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -146,6 +146,8 @@ end
 M.methods.jumpable = jumpable
 
 M.config = function()
+  lvim.builtin.cmp = {}
+
   local status_cmp_ok, cmp = pcall(require, "cmp")
   if not status_cmp_ok then
     return
@@ -301,8 +303,7 @@ M.config = function()
   }
 end
 
-M.setup = function()
-  require("luasnip/loaders/from_vscode").lazy_load()
+function M.setup()
   require("cmp").setup(lvim.builtin.cmp)
 end
 

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -15,7 +15,7 @@ local commit = {
   nlsp_settings = "1e75ac7733f6492b501a7594870cf75c4ee23e81",
   null_ls = "b07ce47f02c7b12ad65bfb4da215c6380228a959",
   nvim_autopairs = "fba2503bd8cd0d8861054523aae39c4ac0680c07",
-  nvim_cmp = "ca6386854982199a532150cf3bd711395475ebd2",
+  nvim_cmp = "092fb66b6ddb4b12b9b542d105d7af40e4fbd9f2",
   nvim_dap = "4e8bb7ca12dc8ca6f7a500cbb4ecea185665c7f1",
   nvim_lsp_installer = "52183c68baf9019c8241b1abf33ba0b6594ab3c8",
   nvim_lspconfig = "b53f89c16bcc8052aa56d3a903fcad3aaa774041",
@@ -76,16 +76,14 @@ return {
   -- Install nvim-cmp, and buffer source as a dependency
   {
     "hrsh7th/nvim-cmp",
+    event = "BufEnter",
     commit = commit.nvim_cmp,
     config = function()
       require("lvim.core.cmp").setup()
     end,
-    run = function()
-      -- cmp's config requires cmp to be installed to run the first time
-      if not lvim.builtin.cmp then
-        require("lvim.core.cmp").config()
-      end
-    end,
+    requires = {
+      "L3MON4D3/LuaSnip",
+    },
   },
   {
     "rafamadriz/friendly-snippets",
@@ -95,27 +93,34 @@ return {
   },
   {
     "L3MON4D3/LuaSnip",
+    config = function()
+      require("luasnip/loaders/from_vscode").lazy_load()
+    end,
     commit = commit.luasnip,
-  },
-  {
-    "saadparwaiz1/cmp_luasnip",
-    commit = commit.cmp_luasnip,
-  },
-  {
-    "hrsh7th/cmp-buffer",
-    commit = commit.cmp_buffer,
   },
   {
     "hrsh7th/cmp-nvim-lsp",
     commit = commit.cmp_nvim_lsp,
   },
   {
+    "saadparwaiz1/cmp_luasnip",
+    commit = commit.cmp_luasnip,
+    after = "nvim-cmp",
+  },
+  {
+    "hrsh7th/cmp-buffer",
+    commit = commit.cmp_buffer,
+    after = "nvim-cmp",
+  },
+  {
     "hrsh7th/cmp-path",
     commit = commit.cmp_path,
+    after = "nvim-cmp",
   },
   {
     "hrsh7th/cmp-nvim-lua",
     commit = commit.cmp_nvim_lua,
+    after = "nvim-cmp",
   },
 
   -- Autopairs

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -78,17 +78,19 @@ return {
     "hrsh7th/nvim-cmp",
     commit = commit.nvim_cmp,
     config = function()
-      require("lvim.core.cmp").setup()
+      if lvim.builtin.cmp then
+        require("lvim.core.cmp").setup()
+      end
     end,
     requires = {
       "L3MON4D3/LuaSnip",
+      "rafamadriz/friendly-snippets",
     },
+    module = "cmp",
   },
   {
     "rafamadriz/friendly-snippets",
     commit = commit.friendly_snippets,
-    -- event = "InsertCharPre",
-    -- disable = not lvim.builtin.compe.active,
   },
   {
     "L3MON4D3/LuaSnip",
@@ -104,22 +106,22 @@ return {
   {
     "saadparwaiz1/cmp_luasnip",
     commit = commit.cmp_luasnip,
-    after = "nvim-cmp",
+    after = "cmp",
   },
   {
     "hrsh7th/cmp-buffer",
     commit = commit.cmp_buffer,
-    after = "nvim-cmp",
+    after = "cmp",
   },
   {
     "hrsh7th/cmp-path",
     commit = commit.cmp_path,
-    after = "nvim-cmp",
+    after = "cmp",
   },
   {
     "hrsh7th/cmp-nvim-lua",
     commit = commit.cmp_nvim_lua,
-    after = "nvim-cmp",
+    after = "cmp",
   },
 
   -- Autopairs

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -76,7 +76,6 @@ return {
   -- Install nvim-cmp, and buffer source as a dependency
   {
     "hrsh7th/nvim-cmp",
-    event = "BufEnter",
     commit = commit.nvim_cmp,
     config = function()
       require("lvim.core.cmp").setup()


### PR DESCRIPTION
# Description

Use lazy-loading to avoid configuration errors during headless installations. 

chore: bump cmp's version
fix: lazy-load cmp's setup
fix: proper order for luasnip setup

Fixes some issues with luasnip's vscode-loader

## How Has This Been Tested?

Passes the CI
