### PR TITLE
fix(cmp): revert broken sequential loading

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -86,7 +86,6 @@ return {
       "L3MON4D3/LuaSnip",
       "rafamadriz/friendly-snippets",
     },
-    module = "cmp",
   },
   {
     "rafamadriz/friendly-snippets",
@@ -106,22 +105,18 @@ return {
   {
     "saadparwaiz1/cmp_luasnip",
     commit = commit.cmp_luasnip,
-    after = "cmp",
   },
   {
     "hrsh7th/cmp-buffer",
     commit = commit.cmp_buffer,
-    after = "cmp",
   },
   {
     "hrsh7th/cmp-path",
     commit = commit.cmp_path,
-    after = "cmp",
   },
   {
     "hrsh7th/cmp-nvim-lua",
     commit = commit.cmp_nvim_lua,
-    after = "cmp",
   },
 
   -- Autopairs


### PR DESCRIPTION
It had worked correctly for installing, but not when upgrading.
