### PR TITLE
fix(nvimtree): restore default mappings + make them customizable

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -2,6 +2,7 @@ local M = {}
 local Log = require "lvim.core.log"
 
 function M.config()
+  local tree_cb = require'nvim-tree.config'.nvim_tree_callback
   lvim.builtin.nvimtree = {
     active = true,
     on_config_done = nil,
@@ -54,7 +55,11 @@ function M.config()
         relativenumber = false,
         mappings = {
           custom_only = false,
-          list = {},
+          list = {
+            { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
+            { key = "h", cb = tree_cb "close_node" },
+            { key = "v", cb = tree_cb "vsplit" },
+          },
         },
       },
       filters = {
@@ -116,16 +121,6 @@ function M.setup()
     lvim.builtin.nvimtree.setup.disable_netrw = false
     lvim.builtin.nvimtree.setup.hijack_netrw = false
     vim.g.netrw_banner = false
-  end
-
-  local tree_cb = nvim_tree_config.nvim_tree_callback
-
-  if not lvim.builtin.nvimtree.setup.view.mappings.list then
-    lvim.builtin.nvimtree.setup.view.mappings.list = {
-      { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
-      { key = "h", cb = tree_cb "close_node" },
-      { key = "v", cb = tree_cb "vsplit" },
-    }
   end
 
   local tree_view = require "nvim-tree.view"

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -168,10 +168,10 @@ function M.change_tree_dir(dir)
 end
 
 function M.start_telescope(telescope_mode)
-  local node = require "nvim-tree.lib".get_node_at_cursor()
+  local node = require("nvim-tree.lib").get_node_at_cursor()
   local abspath = node.link_to or node.absolute_path
   local stats = vim.loop.fs_stat(abspath)
-  local is_dir = stats and stats.type == 'directory'
+  local is_dir = stats and stats.type == "directory"
   if is_dir then
     vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. abspath)
   else

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -119,11 +119,13 @@ function M.setup()
 
   -- Add useful keymaps
   local tree_cb = nvim_tree_config.nvim_tree_callback
-  vim.list_extend(lvim.builtin.nvimtree.setup.view.mappings.list, {
-    { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
-    { key = "h", cb = tree_cb "close_node" },
-    { key = "v", cb = tree_cb "vsplit" },
-  })
+  if #lvim.builtin.nvimtree.setup.view.mappings.list == 0 then
+    lvim.builtin.nvimtree.setup.view.mappings.list = {
+      { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
+      { key = "h", cb = tree_cb "close_node" },
+      { key = "v", cb = tree_cb "vsplit" },
+    }
+  end
 
   -- Add nvim_tree open callback
   local tree_view = require "nvim-tree.view"

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -2,7 +2,13 @@ local M = {}
 local Log = require "lvim.core.log"
 
 function M.config()
-  local tree_cb = require'nvim-tree.config'.nvim_tree_callback
+  local status_ok, nvim_tree_config = pcall(require, "nvim-tree.config")
+  if not status_ok then
+    Log:error "Failed to load nvim-tree.config"
+    return
+  end
+  local tree_cb = nvim_tree_config.nvim_tree_callback
+
   lvim.builtin.nvimtree = {
     active = true,
     on_config_done = nil,

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -124,6 +124,9 @@ function M.setup()
       { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
       { key = "h", cb = tree_cb "close_node" },
       { key = "v", cb = tree_cb "vsplit" },
+      { key = "C", cb = tree_cb "cd" },
+      { key = "gtf", cb = "<cmd>lua require'lvim.core.nvimtree'.start_telescope('find_files')<cr>" },
+      { key = "gtg", cb = "<cmd>lua require'lvim.core.nvimtree'.start_telescope('live_grep')<cr>" },
     }
   end
 
@@ -161,6 +164,18 @@ function M.change_tree_dir(dir)
   local lib_status_ok, lib = pcall(require, "nvim-tree.lib")
   if lib_status_ok then
     lib.change_dir(dir)
+  end
+end
+
+function M.start_telescope(telescope_mode)
+  local node = require "nvim-tree.lib".get_node_at_cursor()
+  local abspath = node.link_to or node.absolute_path
+  local stats = vim.loop.fs_stat(abspath)
+  local is_dir = stats and stats.type == 'directory'
+  if is_dir then
+    vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. abspath)
+  else
+    vim.api.nvim_command("Telescope " .. telescope_mode)
   end
 end
 

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -170,13 +170,9 @@ end
 function M.start_telescope(telescope_mode)
   local node = require("nvim-tree.lib").get_node_at_cursor()
   local abspath = node.link_to or node.absolute_path
-  local stats = vim.loop.fs_stat(abspath)
-  local is_dir = stats and stats.type == "directory"
-  if is_dir then
-    vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. abspath)
-  else
-    vim.api.nvim_command("Telescope " .. telescope_mode)
-  end
+  local is_folder = node.has_children and true
+  local basedir = is_folder and abspath or vim.fn.fnamemodify(abspath, ":h")
+  vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. basedir)
 end
 
 return M

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -7,6 +7,7 @@ function M.config()
     Log:error "Failed to load nvim-tree.config"
     return
   end
+  M.nvim_tree_config = nvim_tree_config
   local tree_cb = nvim_tree_config.nvim_tree_callback
 
   lvim.builtin.nvimtree = {
@@ -109,11 +110,6 @@ function M.config()
 end
 
 function M.setup()
-  local status_ok, nvim_tree_config = pcall(require, "nvim-tree.config")
-  if not status_ok then
-    Log:error "Failed to load nvim-tree.config"
-    return
-  end
   local g = vim.g
 
   for opt, val in pairs(lvim.builtin.nvimtree) do
@@ -141,7 +137,7 @@ function M.setup()
   vim.cmd "au WinClosed * lua require('lvim.core.nvimtree').on_close()"
 
   if lvim.builtin.nvimtree.on_config_done then
-    lvim.builtin.nvimtree.on_config_done(nvim_tree_config)
+    lvim.builtin.nvimtree.on_config_done(M.nvim_tree_config)
   end
   require("nvim-tree").setup(lvim.builtin.nvimtree.setup)
 end


### PR DESCRIPTION
# Description
Since last update custom nvimtree keymaps stopped working (e.g. `l` to open into folder)
This PR moves them under `lvim.builtin.nvimtree.setup.view.mappings.list`, so they're customizable by users.


## How Has This Been Tested?
To add a new keymap in `config.lua`
``` lua
local nvim_tree_cb = require("nvim-tree.config").nvim_tree_callback
table.insert(lvim.builtin.nvimtree.setup.view.mappings.list, { key = "C", cb = nvim_tree_cb "cd" })
```
Also what about adding `C` mapping by default? It's like nerdtree's one and it's a good alternative to the default one, `<c-]>`
