### PR TITLE
fix: dont close if next char is a close pair and no pairs in same line

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -9,6 +9,7 @@ function M.config()
       all = "(",
       tex = "{",
     },
+    enable_check_bracket_line = false,
     ---@usage check treesitter
     check_ts = true,
     ts_config = {
@@ -26,6 +27,7 @@ M.setup = function()
 
   autopairs.setup {
     check_ts = lvim.builtin.autopairs.check_ts,
+    enable_check_bracket_line = lvim.builtin.autopairs.enable_check_bracket_line,
     ts_config = lvim.builtin.autopairs.ts_config,
   }
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

if next character is a close pair and it doesn't have an open pair in same line, then it will not add a close pair
[More Info](https://github.com/windwp/nvim-autopairs#dont-add-pairs-if-it-already-has-a-close-pair-in-the-same-line)

Fixes #2015

