### PR TITLE
fix: more accessible changelog

### DIFF
--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -17,6 +17,7 @@ M.defaults = {
   [[ command! LvimSyncCorePlugins lua require('lvim.plugin-loader'):sync_core_plugins() ]],
   [[ command! LvimReload lua require('lvim.config'):reload() ]],
   [[ command! LvimToggleFormatOnSave lua require('lvim.core.autocmds').toggle_format_on_save() ]],
+  [[ command! LvimVersion lua require('lvim.core.telescope.custom-finders').view_lunarvim_changelog() ]],
 }
 
 M.load = function(commands)

--- a/lua/lvim/core/dashboard.lua
+++ b/lua/lvim/core/dashboard.lua
@@ -84,7 +84,7 @@ M.setup = function()
 
   if lvim_version then
     table.insert(footer, 2, "")
-    table.insert(footer, 3, "v" .. lvim_version)
+    table.insert(footer, 2, lvim_version)
   end
 
   local text = require "lvim.interface.text"

--- a/lua/lvim/core/telescope/custom-finders.lua
+++ b/lua/lvim/core/telescope/custom-finders.lua
@@ -39,12 +39,22 @@ function M.grep_lunarvim_files(opts)
   builtin.live_grep(opts)
 end
 
+local copy_to_clipboard_action = function(prompt_bufnr)
+  local _, action_state = pcall(require, "telescope.actions.state")
+  local entry = action_state.get_selected_entry()
+  local version = entry.value
+  vim.fn.setreg("+", version)
+  vim.fn.setreg('"', version)
+  vim.notify("Copied " .. version .. " to clipboard", vim.log.levels.INFO)
+  actions.close(prompt_bufnr)
+end
+
 function M.view_lunarvim_changelog()
-  local opts = { cwd = get_lvim_base_dir() }
+  local opts = themes.get_ivy { cwd = get_lvim_base_dir() }
   opts.entry_maker = make_entry.gen_from_git_commits(opts)
 
   pickers.new(opts, {
-    prompt_title = "LunarVim changelog",
+    prompt_title = "~ LunarVim Changelog ~",
 
     finder = finders.new_oneshot_job(
       vim.tbl_flatten {
@@ -56,16 +66,13 @@ function M.view_lunarvim_changelog()
       opts
     ),
     previewer = {
-      previewers.git_commit_diff_to_parent.new(opts),
-      previewers.git_commit_diff_to_head.new(opts),
       previewers.git_commit_diff_as_was.new(opts),
-      previewers.git_commit_message.new(opts),
     },
 
     --TODO: consider opening a diff view when pressing enter
     attach_mappings = function(_, map)
-      map("i", "<enter>", actions._close)
-      map("n", "<enter>", actions._close)
+      map("i", "<enter>", copy_to_clipboard_action)
+      map("n", "<enter>", copy_to_clipboard_action)
       map("i", "<esc>", actions._close)
       map("n", "<esc>", actions._close)
       map("n", "q", actions._close)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Fix `lvim` version not displaying correctly on Dashboard when on rolling.
- Add `LvimVersion` that calls `get_changelog()`
- some enhancements to `get_changelog()` including copy to clipboard on `<CR>` and a better default previewer.

![image](https://user-images.githubusercontent.com/59826753/144306321-c51dc6dd-ce95-435e-893b-b140d7bc1104.png)

![image](https://user-images.githubusercontent.com/59826753/144306391-0460ddcb-306d-4b9a-bd81-b5ce1afb3f5b.png)
