### PR TITLE
fix: better default, ignore `.git` in `live_grep`

### DIFF
--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -37,6 +37,7 @@ function M.config()
         "--column",
         "--smart-case",
         "--hidden",
+        "--glob=!.git/",
       },
       mappings = {
         i = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Ignore files in `.git` in `live_grep`.
I think it's a more sane default.
