### PR TITLE
feat: add support for fsharp

### DIFF
--- a/ftdetect/fsautocomplete.lua
+++ b/ftdetect/fsautocomplete.lua
@@ -1,0 +1,3 @@
+vim.cmd [[
+  au BufNewFile,BufRead *.fs,*.fsx,*.fsi set filetype=fsharp
+]]

--- a/lua/lvim/config/supported_languages.lua
+++ b/lua/lvim/config/supported_languages.lua
@@ -26,6 +26,7 @@ return {
   "fennel",
   "fish",
   "fortran",
+  "fsautocomplete",
   "gdscript",
   "glimmer",
   "go",

--- a/lua/lvim/config/supported_languages.lua
+++ b/lua/lvim/config/supported_languages.lua
@@ -26,7 +26,7 @@ return {
   "fennel",
   "fish",
   "fortran",
-  "fsautocomplete",
+  "fsharp",
   "gdscript",
   "glimmer",
   "go",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This add's support for the language F#. The LSP is called `fsautocomplete` and is available in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fsautocomplete) and in [nvm-lsp-install](https://github.com/williamboman/nvim-lsp-installer/blob/main/lua/nvim-lsp-installer/servers/init.lua#L56)
This should be available with `LspInstall`. 

## How Has This Been Tested?

Added the auto command to a clean lvim installation and opened a fsharp project work with. The language type was correctly identified.