### PR TITLE
fix: no restart required when changing colorscheme

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,9 +15,6 @@ require("lvim.plugin-loader").load { plugins, lvim.plugins }
 local Log = require "lvim.core.log"
 Log:debug "Starting LunarVim"
 
-vim.g.colors_name = lvim.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
-vim.cmd("colorscheme " .. lvim.colorscheme)
-
 local commands = require "lvim.core.commands"
 commands.load(commands.defaults)
 

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -83,6 +83,10 @@ function plugin_loader.load(configurations)
     Log:warn "problems detected while loading plugins' configurations"
     Log:trace(debug.traceback())
   end
+
+  -- Colorscheme must get called after plugins are loaded or it will break new installs.
+  vim.g.colors_name = lvim.colorscheme
+  vim.cmd("colorscheme " .. lvim.colorscheme)
 end
 
 function plugin_loader.get_core_plugins()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Change the `colorscheme` without requiring a restart.

Fixes #1862

## How Has This Been Tested?

This should work correctly

```lua
lvim.plugins = {
    {"folke/tokyonight.nvim"},
    {
      "folke/trouble.nvim",
      cmd = "TroubleToggle",
    },
    {"ulwlu/elly.vim"},
}

lvim.colorscheme = "elly"
```

https://user-images.githubusercontent.com/59826753/144629989-0b540d61-facb-4986-bd04-8bfd167c2f67.mp4


