### PR TITLE
fix(nvimtree): handle paths containing spaces

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -170,9 +170,9 @@ end
 function M.start_telescope(telescope_mode)
   local node = require("nvim-tree.lib").get_node_at_cursor()
   local abspath = node.link_to or node.absolute_path
-  local is_folder = node.has_children and true
+  local is_folder = node.open ~= nil
   local basedir = is_folder and abspath or vim.fn.fnamemodify(abspath, ":h")
-  vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. basedir)
+  vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. string.gsub(basedir, " ", "\\ "))
 end
 
 return M

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -173,7 +173,7 @@ function M.start_telescope(telescope_mode)
   local is_folder = node.open ~= nil
   local basedir = is_folder and abspath or vim.fn.fnamemodify(abspath, ":h")
   require("telescope.builtin")[telescope_mode] {
-    cwd = basedir
+    cwd = basedir,
   }
 end
 

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -172,7 +172,9 @@ function M.start_telescope(telescope_mode)
   local abspath = node.link_to or node.absolute_path
   local is_folder = node.open ~= nil
   local basedir = is_folder and abspath or vim.fn.fnamemodify(abspath, ":h")
-  vim.api.nvim_command("Telescope " .. telescope_mode .. " cwd=" .. string.gsub(basedir, " ", "\\ "))
+  require("telescope.builtin")[telescope_mode] {
+    cwd = basedir
+  }
 end
 
 return M


### PR DESCRIPTION
# Description
Fixes #2007
It caused issues if telescope was started in folders containing spaces or folders that are symlinks.

## How Has This Been Tested?

- Put the cursor on folders containing spaces or folders that are symlinks
- Press `gtf` or `gtg`
- Enjoy