### PR TITLE
fix(autopairs): add missing configuration entries

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -4,18 +4,44 @@ function M.config()
   lvim.builtin.autopairs = {
     active = true,
     on_config_done = nil,
-    ---@usage  -- modifies the function or method delimiter by filetypes
+    ---@usage  modifies the function or method delimiter by filetypes
     map_char = {
       all = "(",
       tex = "{",
     },
+    ---@usage check bracket in same line
     enable_check_bracket_line = false,
     ---@usage check treesitter
     check_ts = true,
     ts_config = {
-      lua = { "string" },
-      javascript = { "template_string" },
+      lua = { "string", "source" },
+      javascript = { "string", "template_string" },
       java = false,
+    },
+    disable_filetype = { "TelescopePrompt", "spectre_panel" },
+    ignored_next_char = string.gsub([[ [%w%%%'%[%"%.] ]], "%s+", ""),
+    enable_moveright = true,
+    ---@usage disable when recording or executing a macro
+    disable_in_macro = false,
+    ---@usage add bracket pairs after quote
+    enable_afterquote = true,
+    ---@usage map the <BS> key
+    map_bs = true,
+    ---@usage map <c-w> to delete a pair if possible
+    map_c_w = false,
+    ---@usage disable when insert after visual block mode
+    disable_in_visualblock = false,
+    ---@usage  change default fast_wrap
+    fast_wrap = {
+      map = "<M-e>",
+      chars = { "{", "[", "(", '"', "'" },
+      pattern = string.gsub([[ [%'%"%)%>%]%)%}%,] ]], "%s+", ""),
+      offset = 0, -- Offset from pattern match
+      end_key = "$",
+      keys = "qwertyuiopzxcvbnmasdfghjkl",
+      check_comma = true,
+      highlight = "Search",
+      highlight_grey = "Comment",
     },
   }
 end
@@ -29,9 +55,16 @@ M.setup = function()
     check_ts = lvim.builtin.autopairs.check_ts,
     enable_check_bracket_line = lvim.builtin.autopairs.enable_check_bracket_line,
     ts_config = lvim.builtin.autopairs.ts_config,
+    disable_filetype = lvim.builtin.autopairs.disable_filetype,
+    disable_in_macro = lvim.builtin.autopairs.disable_in_macro,
+    ignored_next_char = lvim.builtin.autopairs.ignored_next_char,
+    enable_moveright = lvim.builtin.autopairs.enable_moveright,
+    enable_afterquote = lvim.builtin.autopairs.enable_afterquote,
+    map_c_w = lvim.builtin.autopairs.map_c_w,
+    map_bs = lvim.builtin.autopairs.map_bs,
+    disable_in_visualblock = lvim.builtin.autopairs.disable_in_visualblock,
+    fast_wrap = lvim.builtin.autopairs.fast_wrap,
   }
-
-  -- vim.g.completion_confirm_key = ""
 
   autopairs.add_rule(Rule("$$", "$$", "tex"))
   autopairs.add_rules {


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

New additions:
```lua
{
    disable_filetype = lvim.builtin.autopairs.disable_filetype,
    disable_in_macro = lvim.builtin.autopairs.disable_in_macro,
    ignored_next_char = lvim.builtin.autopairs.ignored_next_char,
    enable_moveright = lvim.builtin.autopairs.enable_moveright,
    enable_afterquote = lvim.builtin.autopairs.enable_afterquote,
    map_c_w = lvim.builtin.autopairs.map_c_w,
    map_bs = lvim.builtin.autopairs.map_bs,
    disable_in_visualblock = lvim.builtin.autopairs.disable_in_visualblock,
    fast_wrap = lvim.builtin.autopairs.fast_wrap,
}
```

Partially fixes #1997

## How Has This Been Tested?

```lua
vim.list_extend(lvim.builtin.autopairs.disable_filetype, {"sh"})
```

