### PR TITLE
fix(zsh): don't set filetype to sh

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -34,11 +34,7 @@ function M.load_augroups()
         "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
       },
     },
-    _filetypechanges = {
-      { "BufWinEnter", ".tf", "setlocal filetype=terraform" },
-      { "BufRead", "*.tf", "setlocal filetype=terraform" },
-      { "BufNewFile", "*.tf", "setlocal filetype=terraform" },
-    },
+    _filetypechanges = {},
     _git = {
       { "FileType", "gitcommit", "setlocal wrap" },
       { "FileType", "gitcommit", "setlocal spell" },

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -38,9 +38,6 @@ function M.load_augroups()
       { "BufWinEnter", ".tf", "setlocal filetype=terraform" },
       { "BufRead", "*.tf", "setlocal filetype=terraform" },
       { "BufNewFile", "*.tf", "setlocal filetype=terraform" },
-      { "BufWinEnter", ".zsh", "setlocal filetype=sh" },
-      { "BufRead", "*.zsh", "setlocal filetype=sh" },
-      { "BufNewFile", "*.zsh", "setlocal filetype=sh" },
     },
     _git = {
       { "FileType", "gitcommit", "setlocal wrap" },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Should not use `sh` filetype for `zsh`.
They have much different syntax.