### PR TITLE
feat: full compatibility with neovim v0.6

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -14,6 +14,17 @@ return {
     update_in_insert = false,
     underline = true,
     severity_sort = true,
+    float = {
+      source = "always",
+      show_header = false,
+      format = function(d)
+        local t = vim.deepcopy(d)
+        if d.code then
+          t.message = string.format("%s [%s]", t.message, t.code):gsub("1. ", "")
+        end
+        return t.message
+      end,
+    },
   },
   document_highlight = true,
   code_lens_refresh = true,

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -15,6 +15,9 @@ return {
     underline = true,
     severity_sort = true,
     float = {
+      focusable = false,
+      style = "minimal",
+      border = "rounded",
       source = "always",
       header = "",
       prefix = "",

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -4,10 +4,10 @@ return {
     signs = {
       active = true,
       values = {
-        { name = "LspDiagnosticsSignError", text = "" },
-        { name = "LspDiagnosticsSignWarning", text = "" },
-        { name = "LspDiagnosticsSignHint", text = "" },
-        { name = "LspDiagnosticsSignInformation", text = "" },
+        { name = "DiagnosticSignError", text = "" },
+        { name = "DiagnosticSignWarn", text = "" },
+        { name = "DiagnosticSignHint", text = "" },
+        { name = "DiagnosticSignInfo", text = "" },
       },
     },
     virtual_text = true,

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -16,7 +16,8 @@ return {
     severity_sort = true,
     float = {
       source = "always",
-      show_header = false,
+      header = "",
+      prefix = "",
       format = function(d)
         local t = vim.deepcopy(d)
         if d.code then

--- a/lua/lvim/lsp/handlers.lua
+++ b/lua/lvim/lsp/handlers.lua
@@ -9,42 +9,10 @@ function M.setup()
     underline = lvim.lsp.diagnostics.underline,
     update_in_insert = lvim.lsp.diagnostics.update_in_insert,
     severity_sort = lvim.lsp.diagnostics.severity_sort,
+    float = lvim.lsp.diagnostics.float,
   }
-  if vim.fn.has "nvim-0.5.1" > 0 then
-    vim.lsp.handlers["textDocument/publishDiagnostics"] = function(_, result, ctx, _)
-      local uri = result.uri
-      local bufnr = vim.uri_to_bufnr(uri)
-      if not bufnr then
-        return
-      end
-
-      local diagnostics = result.diagnostics
-      local ok, vim_diag = pcall(require, "vim.diagnostic")
-      if ok then
-        -- FIX: why can't we just use vim.diagnostic.get(buf_id)?
-        config.signs = true
-        for i, diagnostic in ipairs(diagnostics) do
-          local rng = diagnostic.range
-          diagnostics[i].lnum = rng["start"].line
-          diagnostics[i].end_lnum = rng["end"].line
-          diagnostics[i].col = rng["start"].character
-          diagnostics[i].end_col = rng["end"].character
-        end
-        local namespace = vim.lsp.diagnostic.get_namespace(ctx.client_id)
-
-        vim_diag.set(namespace, bufnr, diagnostics, config)
-        if not vim.api.nvim_buf_is_loaded(bufnr) then
-          return
-        end
-        vim_diag.show(namespace, bufnr, diagnostics, config)
-      else
-        vim.lsp.diagnostic.save(diagnostics, bufnr, ctx.client_id)
-        if not vim.api.nvim_buf_is_loaded(bufnr) then
-          return
-        end
-        vim.lsp.diagnostic.display(diagnostics, bufnr, ctx.client_id, config)
-      end
-    end
+  if vim.fn.has "nvim-0.6" > 1 then
+    vim.diagnostic.config(config)
   else
     vim.lsp.handlers["textDocument/publishDiagnostics"] = function(_, _, params, client_id, _)
       local uri = params.uri
@@ -60,27 +28,29 @@ function M.setup()
       end
       vim.lsp.diagnostic.display(diagnostics, bufnr, client_id, config)
     end
+
+    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
+      border = lvim.lsp.popup_border,
+    })
+
+    vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
+      border = lvim.lsp.popup_border,
+    })
   end
-
-  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-    border = lvim.lsp.popup_border,
-  })
-
-  vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
-    border = lvim.lsp.popup_border,
-  })
-end
-
-local function split_by_chunk(text, chunkSize)
-  local s = {}
-  for i = 1, #text, chunkSize do
-    s[#s + 1] = text:sub(i, i + chunkSize - 1)
-  end
-  return s
 end
 
 function M.show_line_diagnostics()
-  -- TODO: replace all this with vim.diagnostic.show_position_diagnostics()
+  if vim.fn.has "nvim-0.6" > 1 then
+    return vim.diagnostic.open_float(0, { scope = "line" })
+  end
+
+  local function split_by_chunk(text, chunkSize)
+    local s = {}
+    for i = 1, #text, chunkSize do
+      s[#s + 1] = text:sub(i, i + chunkSize - 1)
+    end
+    return s
+  end
   local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
   local severity_highlight = {
     "LspDiagnosticsFloatingError",

--- a/lua/lvim/lsp/handlers.lua
+++ b/lua/lvim/lsp/handlers.lua
@@ -11,7 +11,7 @@ function M.setup()
     severity_sort = lvim.lsp.diagnostics.severity_sort,
     float = lvim.lsp.diagnostics.float,
   }
-  if vim.fn.has "nvim-0.6" > 1 then
+  if vim.fn.has "nvim-0.6" == 1 then
     vim.diagnostic.config(config)
   else
     vim.lsp.handlers["textDocument/publishDiagnostics"] = function(_, _, params, client_id, _)
@@ -40,7 +40,7 @@ function M.setup()
 end
 
 function M.show_line_diagnostics()
-  if vim.fn.has "nvim-0.6" > 1 then
+  if vim.fn.has "nvim-0.6" == 1 then
     return vim.diagnostic.open_float(0, { scope = "line" })
   end
 

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -137,10 +137,10 @@ function M.get_common_opts()
 end
 
 local LSP_DEPRECATED_SIGN_MAP = {
-  ["LspDiagnosticsSignError"] = "DiagnosticSignError",
-  ["LspDiagnosticsSignWarning"] = "DiagnosticSignWarn",
-  ["LspDiagnosticsSignHint"] = "DiagnosticSignHint",
-  ["LspDiagnosticsSignInformation"] = "DiagnosticSignInfo",
+  ["DiagnosticSignError"] = "LspDiagnosticsSignError",
+  ["DiagnosticSignWarn"] = "LspDiagnosticsSignWarning",
+  ["DiagnosticSignHint"] = "LspDiagnosticsSignHint",
+  ["DiagnosticSignInfo"] = "LspDiagnosticsSignInformation",
 }
 
 function M.setup()
@@ -151,11 +151,11 @@ function M.setup()
     return
   end
 
-  local is_neovim_nightly = vim.fn.has "nvim-0.5.1" > 0
+  local is_neovim_5 = vim.fn.has "nvim-0.6" ~= 1
 
   for _, sign in ipairs(lvim.lsp.diagnostics.signs.values) do
     local lsp_sign_name = LSP_DEPRECATED_SIGN_MAP[sign.name]
-    if is_neovim_nightly and lsp_sign_name then
+    if is_neovim_5 and lsp_sign_name then
       vim.fn.sign_define(lsp_sign_name, { texthl = lsp_sign_name, text = sign.text, numhl = lsp_sign_name })
     end
     vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -134,7 +134,7 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     commit = commit.treesitter,
-    branch = "0.5-compat",
+    branch = vim.fn.has "nvim-0.6" == 1 and "master" or "0.5-compat",
     -- run = ":TSUpdate",
     config = function()
       require("lvim.core.treesitter").setup()

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -7,7 +7,9 @@ local in_headless = #vim.api.nvim_list_uis() == 0
 function M.run_pre_update()
   Log:debug "Starting pre-update hook"
   _G.__luacache.clear_cache()
-  vim.cmd "LspStop"
+  if package.loaded["lspconfig"] then
+    vim.cmd [[ LspStop ]]
+  end
 end
 
 ---Reset any startup cache files used by Packer and Impatient
@@ -34,9 +36,14 @@ function M.run_post_update()
 
   if not in_headless then
     vim.schedule(function()
+      if package.loaded["nvim-treesitter"] then
+        vim.cmd [[ TSUpdateSync ]]
+      end
       -- TODO: add a changelog
       vim.notify("Update complete", vim.log.levels.INFO)
-      vim.cmd "LspRestart"
+      if package.loaded["lspconfig"] then
+        vim.cmd [[ LspRestart ]]
+      end
     end)
   end
 end

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -183,6 +183,20 @@ function check_system_deps() {
     print_missing_dep_msg "neovim"
     exit 1
   fi
+
+  local major_version
+  major_version=$(nvim --version | head -n 1 | grep -oP "v0\.\K([0-9])")
+  if [ "$major_version" -eq 6 ]; then
+    return
+  fi
+
+  # TODO: consider locking the requirement to 0.6+
+  local minor_version
+  minor_version=$(nvim --version | head -n 1 | grep -oP "v0\.[0-9].\K([0-9])")
+  if [ ! "$minor_version" -eq 1 ]; then
+    echo "[ERROR]: LunarVim requires at least Neovim v0.5.1 or higher"
+    exit 1
+  fi
 }
 
 function __install_nodejs_deps_npm() {

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -174,6 +174,17 @@ function print_missing_dep_msg() {
   fi
 }
 
+function check_neovim_min_version() {
+  # TODO: consider locking the requirement to 0.6+
+  local verify_version_cmd='if !has("nvim-0.5.1") | cquit | else | quit | endif'
+
+  # exit with an error if min_version not found
+  if ! nvim --headless -u NONE -c "$verify_version_cmd"; then
+    echo "[ERROR]: LunarVim requires at least Neovim v0.5.1 or higher"
+    exit 1
+  fi
+}
+
 function check_system_deps() {
   if ! command -v git &>/dev/null; then
     print_missing_dep_msg "git"
@@ -183,20 +194,7 @@ function check_system_deps() {
     print_missing_dep_msg "neovim"
     exit 1
   fi
-
-  local major_version
-  major_version=$(nvim --version | head -n 1 | grep -oP "v0\.\K([0-9])")
-  if [ "$major_version" -eq 6 ]; then
-    return
-  fi
-
-  # TODO: consider locking the requirement to 0.6+
-  local minor_version
-  minor_version=$(nvim --version | head -n 1 | grep -oP "v0\.[0-9].\K([0-9])")
-  if [ ! "$minor_version" -eq 1 ]; then
-    echo "[ERROR]: LunarVim requires at least Neovim v0.5.1 or higher"
-    exit 1
-  fi
+  check_neovim_min_version
 }
 
 function __install_nodejs_deps_npm() {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Add some missing handlers configuration for full compatbility with Neovim v0.6
- Remove code that specific to v0.5.0 considering that most plugins don't support it anymore
- Add a check in the installer to verify that v0.5.1 or higher is available
- bump treesitter version with `vim.cmd` parsing support

## How Has This Been Tested?

Using `gl` now uses the new `vim.diagnostic.open_float()` call.
