### PR TITLE
feat(terminal): lazygit can now be toggled

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -16,7 +16,7 @@ M.config = function()
     insert_mappings = true, -- whether or not the open mapping applies in insert mode
     persist_size = false,
     -- direction = 'vertical' | 'horizontal' | 'window' | 'float',
-    direction = "horizontal",
+    direction = "float",
     close_on_exit = true, -- close the terminal window when the process exits
     shell = vim.o.shell, -- change the default shell
     -- This field is only relevant if direction is set to 'float'

--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -16,7 +16,7 @@ M.config = function()
     insert_mappings = true, -- whether or not the open mapping applies in insert mode
     persist_size = false,
     -- direction = 'vertical' | 'horizontal' | 'window' | 'float',
-    direction = "float",
+    direction = "horizontal",
     close_on_exit = true, -- close the terminal window when the process exits
     shell = vim.o.shell, -- change the default shell
     -- This field is only relevant if direction is set to 'float'
@@ -40,53 +40,77 @@ M.config = function()
     -- lvim.builtin.terminal.execs = {{}} to overwrite
     -- lvim.builtin.terminal.execs[#lvim.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
     execs = {
-      { "lazygit", "gg", "LazyGit" },
+      -- TODO: this should probably be removed since it's hard to hit <leader>gg within the timeoutlen
+      { "lazygit", "<leader>gg", "LazyGit", "float" },
+      { "lazygit", "<c-\\>", "LazyGit", "float" },
     },
   }
 end
 
 M.setup = function()
   local terminal = require "toggleterm"
-  for _, exec in pairs(lvim.builtin.terminal.execs) do
-    require("lvim.core.terminal").add_exec(exec[1], exec[2], exec[3])
-  end
   terminal.setup(lvim.builtin.terminal)
+
+  -- setup the default terminal so it's always reachable
+  local default_term_opts = {
+    cmd = lvim.builtin.terminal.shell,
+    keymap = lvim.builtin.terminal.open_mapping,
+    label = "Toggle terminal",
+    count = 1,
+    direction = lvim.builtin.terminal.direction,
+    size = lvim.builtin.terminal.size,
+  }
+  M.add_exec(default_term_opts)
+
+  for i, exec in pairs(lvim.builtin.terminal.execs) do
+    local opts = {
+      cmd = exec[1],
+      keymap = exec[2],
+      label = exec[3],
+      count = i + 1,
+      direction = exec[4] or lvim.builtin.terminal.direction,
+      size = lvim.builtin.terminal.size,
+    }
+
+    M.add_exec(opts)
+  end
 
   if lvim.builtin.terminal.on_config_done then
     lvim.builtin.terminal.on_config_done(terminal)
   end
 end
 
-M.add_exec = function(exec, keymap, name)
-  vim.api.nvim_set_keymap(
-    "n",
-    "<leader>" .. keymap,
-    "<cmd>lua require('lvim.core.terminal')._exec_toggle('" .. exec .. "')<CR>",
-    { noremap = true, silent = true }
-  )
-  lvim.builtin.which_key.mappings[keymap] = name
-end
-
-M._split = function(inputstr, sep)
-  if sep == nil then
-    sep = "%s"
-  end
-  local t = {}
-  for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
-    table.insert(t, str)
-  end
-  return t
-end
-
-M._exec_toggle = function(exec)
-  local binary = M._split(exec)[1]
+M.add_exec = function(opts)
+  local binary = opts.cmd:match "(%S+)"
   if vim.fn.executable(binary) ~= 1 then
     Log:error("Unable to run executable " .. binary .. ". Please make sure it is installed properly.")
     return
   end
+
+  local exec_func = string.format(
+    "<cmd>lua require('lvim.core.terminal')._exec_toggle({ cmd = '%s', count = %d, direction = '%s'})<CR>",
+    opts.cmd,
+    opts.count,
+    opts.direction
+  )
+
+  require("lvim.keymappings").load {
+    normal_mode = { [opts.keymap] = exec_func },
+    term_mode = { [opts.keymap] = exec_func },
+  }
+
+  local wk_status_ok, wk = pcall(require, "whichkey")
+  if not wk_status_ok then
+    return
+  end
+  wk.register({ [opts.keymap] = { opts.label } }, { mode = "n" })
+  wk.register({ [opts.keymap] = { opts.label } }, { mode = "t" })
+end
+
+M._exec_toggle = function(opts)
   local Terminal = require("toggleterm.terminal").Terminal
-  local exec_term = Terminal:new { cmd = exec, hidden = true }
-  exec_term:toggle()
+  local term = Terminal:new { cmd = opts.cmd, count = opts.count, direction = opts.direction }
+  term:toggle(lvim.builtin.terminal.size, opts.direction)
 end
 
 ---Toggles a log viewer according to log.viewer.layout_config


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- remove `hidden` parameter, so it can be persistent
- map keybinding for both normal and term modes
- a default shell is now always reachable with `<C-t>` according to `lvim.builtin.terminal.direction`
- add an addition keybinding `<C-\>` for `lazygit`
since it's hard to hit `<leader>gg` within the `timeoutlen` < 300ms

## How Has This Been Tested?

Try both `<C-t>` and `<C-\>` and see how `lazygit` is persistent.

https://user-images.githubusercontent.com/59826753/144755634-5a398719-403f-4721-b29b-f0e222d80d03.mp4


