### PR TITLE
feat(luadev): better vim api completion

### DIFF
--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -7,8 +7,6 @@ local opts = {
       workspace = {
         library = {
           [require("lvim.utils").join_paths(get_runtime_dir(), "lvim", "lua")] = true,
-          [vim.fn.expand "$VIMRUNTIME/lua"] = true,
-          [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
         },
         maxPreload = 100000,
         preloadFileSize = 10000,
@@ -16,4 +14,21 @@ local opts = {
     },
   },
 }
-return opts
+
+local lua_dev_loaded, lua_dev = pcall(require, "lua-dev")
+if not lua_dev_loaded then
+  return opts
+end
+
+local dev_opts = {
+  library = {
+    vimruntime = true, -- runtime path
+    types = true, -- full signature, docs and completion of vim.api, vim.treesitter, vim.lsp and others
+    -- plugins = true, -- installed opt or start plugins in packpath
+    -- you can also specify the list of plugins to make available as a workspace library
+    plugins = { "plenary.nvim" },
+  },
+  lspconfig = opts,
+}
+
+return lua_dev.setup(dev_opts)

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -3,7 +3,7 @@ local commit = {
   cmp_buffer = "e26cdfb26f645cd4c6330b541b7e74ff69daa483",
   cmp_luasnip = "7bd2612533db6863381193df83f9934b373b21e1",
   cmp_nvim_lsp = "134117299ff9e34adde30a735cd8ca9cf8f3db81",
-  cmp_nvim_lua = "d276254e7198ab7d00f117e88e223b4bd8c02d21",
+  lua_dev = "4331626b02f636433b504b9ab6a8c11fb9de4a24",
   cmp_path = "81d88dfcafe26cc0cc856fc66f4677b20e6a9ffc",
   comment = "9e80d5146013275277238c89bbcaf4164f4e5140",
   dapinstall = "dd09e9dd3a6e29f02ac171515b8a089fb82bb425",
@@ -115,8 +115,8 @@ return {
     commit = commit.cmp_path,
   },
   {
-    "hrsh7th/cmp-nvim-lua",
-    commit = commit.cmp_nvim_lua,
+    "folke/lua-dev.nvim",
+    commit = commit.lua_dev,
   },
 
   -- Autopairs

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -116,6 +116,7 @@ return {
   },
   {
     "folke/lua-dev.nvim",
+    module = "lua-dev",
     commit = commit.lua_dev,
   },
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Use [lua-dev.nvim](https://github.com/folke/lua-dev.nvim) instead of `cmp-nvim-lua`.
It provides better signature support.

Origin
![image](https://user-images.githubusercontent.com/9511136/144932687-49e7bb1f-ae25-4345-99f1-c94e31480b50.png)


Now
![image](https://user-images.githubusercontent.com/9511136/144932630-e6bcbd69-fd05-4cd7-95d3-85cc6c5c2547.png)

It could also have plugin's completion by modifying [here](https://github.com/LunarVim/LunarVim/pull/2043/files#diff-072b5a568c83434dda5a33ca67ecdcb46358ba94308236464a9dc8b1578bbff7R7)