### PR TITLE
[Bugfix] Allow disabling the open binding for ToggleTerm

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -60,7 +60,9 @@ M.setup = function()
     direction = lvim.builtin.terminal.direction,
     size = lvim.builtin.terminal.size,
   }
-  M.add_exec(default_term_opts)
+  if lvim.builtin.terminal.open_mapping then
+    M.add_exec(default_term_opts)
+  end
 
   for i, exec in pairs(lvim.builtin.terminal.execs) do
     local opts = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Instead of throwing an error if `lvim.builtin.terminal.open_mapping` is set to `nil`, this simply doesn't add the default binding

## How Has This Been Tested?

Set `lvim.builtin.terminal.open_mapping = nil` in `config.lua`. Note that it doesn't throw errors on startup. 