### PR TITLE
chore(terminal): avoid problematic layzgit mapping

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -40,9 +40,8 @@ M.config = function()
     -- lvim.builtin.terminal.execs = {{}} to overwrite
     -- lvim.builtin.terminal.execs[#lvim.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
     execs = {
-      -- TODO: this should probably be removed since it's hard to hit <leader>gg within the timeoutlen
       { "lazygit", "<leader>gg", "LazyGit", "float" },
-      { "lazygit", "<c-\\>", "LazyGit", "float" },
+      { "lazygit", "<c-\\><c-g>", "LazyGit", "float" },
     },
   }
 end


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Avoid binding `<c-\\>` directly, instead use `<c-\\><c-g>`
