### PR TITLE
fix(lsp): allow overriding servers with custom providers

### DIFF
--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -19,8 +19,7 @@ end
 ---@param server_name string name of a valid language server, e.g. pyright, gopls, tsserver, etc.
 ---@param dir string the full path to the desired directory
 function M.generate_ftplugin(server_name, dir)
-  local has_custom_provider, _ = pcall(require, "lvim/lsp/providers/" .. server_name)
-  if vim.tbl_contains(lvim.lsp.override, server_name) and not has_custom_provider then
+  if vim.tbl_contains(lvim.lsp.override, server_name) then
     return
   end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- fix(lsp): correct client_id parsing in lvim-info
- fix(lsp): allow overriding custom providers

## How Has This Been Tested?

- Can open `LvimInfo`
- Can override `sumneko_lua` with "lua-dev"
- Can disable `vuels` and actually remove the generated `vue.lua`
```lua
vim.list_extend(lvim.lsp.override, {"vuels" })
```