### PR TITLE
fix(lsp): correct client_id parsing in lvim-info

### DIFF
--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -31,8 +31,10 @@ function M.get_client_capabilities(client_id)
         break
       end
     end
+  else
+    client = vim.lsp.get_client_by_id(tonumber(client_id))
   end
-  if not client_id then
+  if not client then
     error "Unable to determine client_id"
     return
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes an issue with `LvimInfo` not parsing the `client_id` correctly.
