### PR TITLE
filterd __pycache__ in nvimtree

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -59,7 +59,7 @@ function M.config()
       },
       filters = {
         dotfiles = false,
-        custom = { ".git", "node_modules", ".cache" },
+        custom = { ".git", "node_modules", ".cache", "__pycache__" },
       },
     },
     show_icons = {


### PR DESCRIPTION
Filtered `__pycache__` on nvimtree. (which it only contains `.pyc` files and we never need to modify them).