### PR TITLE
Bugfix: installer backup linked files with rsync

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -288,7 +288,7 @@ function backup_old_config() {
     touch "$dir/ignore"
     msg "Backing up old $dir to $dir.bak"
     if command -v rsync &>/dev/null; then
-      rsync --archive -hh --stats --partial --cvs-exclude "$dir"/ "$dir.bak"
+      rsync --archive -hh --stats --partial --copy-links --cvs-exclude "$dir"/ "$dir.bak"
     else
       OS="$(uname -s)"
       case "$OS" in


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This allows backup to succeed for people who use symlinks for managing dotfiles.

Currently errors with the following:
```
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1350) [sender=3.2.3]
````

## How Has This Been Tested?

Tested locally with `~/.config/lvim/config.lua` symlinked to a local file.

- Run command `./utils/installer/install.sh`
