### PR TITLE
fix: remove autopairs cmp completion

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -85,14 +85,6 @@ M.setup = function()
     end),
   }
 
-  local cmp_status_ok, cmp = pcall(require, "cmp")
-  if cmp_status_ok then
-    -- If you want insert `(` after select function or method item
-    local cmp_autopairs = require "nvim-autopairs.completion.cmp"
-    local map_char = lvim.builtin.autopairs.map_char
-    cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done { map_char = map_char })
-  end
-
   require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
 
   local ts_conds = require "nvim-autopairs.ts-conds"


### PR DESCRIPTION
# Description

This removes nvim-cmp/nvim-autopairs auto-completion behavior that's problematic. I give specific examples in #2082 showcasing the problem.

It's still possible to auto-complete with parens. If the auto-completion menu is open, typing `(` will add the opening and closing parens in addition to importing the function. I think this is simpler and clearer.

Fixes #2082

## How Has This Been Tested?

I ran this locally and it seems to work fine. The problematic examples I gave in #2082 have been fixed.