### PR TITLE
fix(installer): check if npm-prefix is writable

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -210,6 +210,7 @@ function __install_nodejs_deps_npm() {
       npm install -g "$dep"
     fi
   done
+
   echo "All NodeJS dependencies are successfully installed"
 }
 
@@ -219,10 +220,22 @@ function __install_nodejs_deps_yarn() {
   echo "All NodeJS dependencies are successfully installed"
 }
 
+function __validate_node_installation() {
+  local pkg_manager="$1"
+  local manager_home
+  manager_home="$($pkg_manager config get prefix 2>/dev/null)"
+
+  if [ ! -d "$manager_home" ] || [ ! -w "$manager_home" ]; then
+    echo "[ERROR] Unable to install without administrative privilages. Please set you NPM_HOME correctly and try again."
+    exit 1
+  fi
+}
+
 function install_nodejs_deps() {
   local -a pkg_managers=("yarn" "npm")
   for pkg_manager in "${pkg_managers[@]}"; do
     if command -v "$pkg_manager" &>/dev/null; then
+      __validate_node_installation "$pkg_manager"
       eval "__install_nodejs_deps_$pkg_manager"
       return
     fi


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Avoid errors related to installing node-modules into a folder
that is not writable by the user executing the script.

## How Has This Been Tested?

1. no need execute the entire script, you can change the last line

```bash
# just call the function we want
# main "$@"
install_nodejs_deps
```

2. now set `$NPM_HOME` to some nonsense.
```bash
env NPM_HOME="/var/my_node_modules" bash ./utils/installer/install.sh
```
