### PR TITLE
refactor(install.sh): fix typo in node error message

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -226,7 +226,7 @@ function __validate_node_installation() {
   manager_home="$($pkg_manager config get prefix 2>/dev/null)"
 
   if [ ! -d "$manager_home" ] || [ ! -w "$manager_home" ]; then
-    echo "[ERROR] Unable to install without administrative privilages. Please set you NPM_HOME correctly and try again."
+    echo "[ERROR] Unable to install without administrative privileges. Please set your NPM_HOME correctly and try again."
     exit 1
   fi
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Typos existed  in the error message when installing node dependencies. You was changed to your.  "Please set you NPM_HOME correctly and try again." is now "Please set your NPM_HOME correctly and try again." The misspelling of privileges was also fixed. 

Testing:

- Run command `./install.sh` (do not use sudo, and also ensure you have not set up a prefix for the global installation directory as described [here](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally). 
- Ensure the error message regarding NPM is now grammatically correct.

