### PR TITLE
fix(lsp): set the handlers opts for v0.6 as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ lvim.plugins = {
 ## Breaking changes
 
 - `lvim.lang.FOO` is no longer supported. Refer to <https://www.lunarvim.org/languages> for up-to-date instructions.
+- `lvim.lsp.popup_border` has been deprecated in favor of `lvim.lsp.float.border` and `lvim.lsp.diagnostics.float.border`.
 
 ## Resources
 

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -66,6 +66,11 @@ local function handle_deprecated_settings()
       deprecation_notice(string.format("lvim.lang.%s", lang))
     end
   end
+
+  -- lvim.lsp.popup_border
+  if vim.tbl_contains(vim.tbl_keys(lvim.lsp), "popup_border") then
+    deprecation_notice "lvim.lsp.popup_border"
+  end
 end
 
 --- Override the configuration with a user provided one

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -32,7 +32,11 @@ return {
   },
   document_highlight = true,
   code_lens_refresh = true,
-  popup_border = "single",
+  float = {
+    focusable = false,
+    style = "minimal",
+    border = "rounded",
+  },
   on_attach_callback = nil,
   on_init_callback = nil,
   automatic_servers_installation = true,

--- a/lua/lvim/lsp/handlers.lua
+++ b/lua/lvim/lsp/handlers.lua
@@ -28,15 +28,11 @@ function M.setup()
       end
       vim.lsp.diagnostic.display(diagnostics, bufnr, client_id, config)
     end
-
-    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-      border = lvim.lsp.popup_border,
-    })
-
-    vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
-      border = lvim.lsp.popup_border,
-    })
   end
+
+  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, lvim.lsp.float)
+
+  vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, lvim.lsp.float)
 end
 
 function M.show_line_diagnostics()


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- unify the style between the handlers and diagnostics float-opts
- deprecate `lvim.lsp.popup_border` in favor of `lvim.lsp.float`
to allow further customizations

Fixes #2095

## How Has This Been Tested?

Invoking `vim.lsp.buf.hover()` (you can use `<K>`) should show borders now by default.
