### PR TITLE
refactor: avoid running ts.setup in headless

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -74,16 +74,20 @@ M.config = function()
 end
 
 M.setup = function()
+  -- avoid running in headless mode since it's harder to detect failures
+  if #vim.api.nvim_list_uis() == 0 then
+    Log:debug "headless mode detected, skipping running setup for treesitter"
+    return
+  end
+
   local status_ok, treesitter_configs = pcall(require, "nvim-treesitter.configs")
   if not status_ok then
-    Log:get_default().error "Failed to load nvim-treesitter.configs"
+    Log:error "Failed to load nvim-treesitter.configs"
     return
   end
 
   local opts = vim.deepcopy(lvim.builtin.treesitter)
 
-  -- avoid running any installers in headless mode since it's harder to detect failures
-  opts.ensure_installed = #vim.api.nvim_list_uis() == 0 and {} or opts.ensure_installed
   treesitter_configs.setup(opts)
 
   if lvim.builtin.treesitter.on_config_done then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Avoid running the setup for treesitter in headless mode since it's harder to debug.
