### PR TITLE
refactor: more consistent autocmds

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -86,16 +86,12 @@ function M.enable_format_on_save(opts)
 end
 
 function M.disable_format_on_save()
-  M.remove_augroup "format_on_save"
+  M.disable_augroup "format_on_save"
   Log:debug "disabled format-on-save"
 end
 
 function M.configure_format_on_save()
   if lvim.format_on_save then
-    if vim.fn.exists "#format_on_save#BufWritePre" == 1 then
-      M.remove_augroup "format_on_save"
-      Log:debug "reloading format-on-save configuration"
-    end
     local opts = get_format_on_save_opts()
     M.enable_format_on_save(opts)
   else
@@ -112,24 +108,73 @@ function M.toggle_format_on_save()
   end
 end
 
-function M.remove_augroup(name)
-  if vim.fn.exists("#" .. name) == 1 then
-    vim.cmd("au! " .. name)
-  end
+function M.enable_lsp_document_highlight(client_id)
+  M.define_augroups({
+    lsp_document_highlight = {
+      {
+        "CursorHold",
+        "<buffer>",
+        string.format("lua require('lvim.lsp.utils').conditional_document_highlight(%d)", client_id),
+      },
+      {
+        "CursorMoved",
+        "<buffer>",
+        "lua vim.lsp.buf.clear_references()",
+      },
+    },
+  }, true)
 end
 
-function M.define_augroups(definitions) -- {{{1
-  -- Create autocommand groups based on the passed definitions
-  --
-  -- The key will be the name of the group, and each definition
-  -- within the group should have:
-  --    1. Trigger
-  --    2. Pattern
-  --    3. Text
-  -- just like how they would normally be defined from Vim itself
+function M.disable_lsp_document_highlight()
+  M.disable_augroup "lsp_document_highlight"
+end
+
+function M.enable_code_lens_refresh()
+  M.define_augroups({
+    lsp_code_lens_refresh = {
+      {
+        "InsertLeave ",
+        "<buffer>",
+        "lua vim.lsp.codelens.refresh()",
+      },
+      {
+        "InsertLeave ",
+        "<buffer>",
+        "lua vim.lsp.codelens.display()",
+      },
+    },
+  }, true)
+end
+
+function M.disable_code_lens_refresh()
+  M.disable_augroup "lsp_code_lens_refresh"
+end
+
+--- Disable autocommand groups if it exists
+--- This is more reliable than trying to delete the augroup itself
+---@param name string the augroup name
+function M.disable_augroup(name)
+  -- defer the function in case the autocommand is still in-use
+  vim.schedule(function()
+    if vim.fn.exists("#" .. name) == 1 then
+      vim.cmd("augroup " .. name)
+      vim.cmd "autocmd!"
+      vim.cmd "augroup END"
+    end
+  end)
+end
+
+--- Create autocommand groups based on the passed definitions
+---@param definitions table contains trigger, pattern and text. The key will be used as a group name
+---@param buffer boolean indicate if the augroup should be local to the buffer
+function M.define_augroups(definitions, buffer)
   for group_name, definition in pairs(definitions) do
     vim.cmd("augroup " .. group_name)
-    vim.cmd "autocmd!"
+    if buffer then
+      vim.cmd [[autocmd! * <buffer>]]
+    else
+      vim.cmd [[autocmd!]]
+    end
 
     for _, def in pairs(definition) do
       local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -24,6 +24,7 @@ local function resolve_config(name, user_config)
   local config = {
     on_attach = require("lvim.lsp").common_on_attach,
     on_init = require("lvim.lsp").common_on_init,
+    on_exit = require("lvim.lsp").common_on_exit,
     capabilities = require("lvim.lsp").common_capabilities(),
   }
 

--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -76,4 +76,14 @@ function M.get_all_supported_filetypes()
   return vim.tbl_keys(lsp_installer_filetypes or {})
 end
 
+function M.conditional_document_highlight(id)
+  local client_ok, method_supported = pcall(function()
+    return vim.lsp.get_client_by_id(id).resolved_capabilities.document_highlight
+  end)
+  if not client_ok or not method_supported then
+    return
+  end
+  vim.lsp.buf.document_highlight()
+end
+
 return M

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -21,14 +21,14 @@ function M.run_on_packer_complete()
   require("lvim.plugin-loader").recompile()
   -- forcefully activate nvim-web-devicons
   require("nvim-web-devicons").set_up_highlights()
+  if package.loaded["lspconfig"] then
+    vim.cmd [[ LspStart ]]
+  end
   Log:info "Reloaded configuration"
 end
 
 function M.run_post_reload()
   Log:debug "Starting post-reload hook"
-  if package.loaded["lspconfig"] then
-    vim.cmd [[ LspRestart ]]
-  end
 
   M.reset_cache()
   require("lvim.plugin-loader").ensure_installed()
@@ -68,7 +68,7 @@ function M.run_post_update()
       -- TODO: add a changelog
       vim.notify("Update complete", vim.log.levels.INFO)
       if package.loaded["lspconfig"] then
-        vim.cmd [[ LspRestart ]]
+        vim.cmd [[ LspStart ]]
       end
     end)
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes the issue where `highlight_document` is still active when the server has already been stopped, when using `LspStop` or `LvimReload` for example.

## How Has This Been Tested?

You should no longer see any warnings after about `document_highlight` after calling `LspStop`.
