### PR TITLE
refactor(settings): add headless-mode settings

### DIFF
--- a/lua/lvim/config/defaults.lua
+++ b/lua/lvim/config/defaults.lua
@@ -1,7 +1,6 @@
 return {
   leader = "space",
   colorscheme = "onedarker",
-  line_wrap_cursor_movement = true,
   transparent_window = false,
   format_on_save = {
     ---@usage pattern string pattern used for the autocommand (Default: '*')

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -95,8 +95,9 @@ function M:load(config_path)
 
   require("lvim.keymappings").load(lvim.keys)
 
-  local settings = require "lvim.config.settings"
-  settings.load_commands()
+  if lvim.transparent_window then
+    autocmds.enable_transparent_mode()
+  end
 end
 
 --- Override the configuration with a user provided one

--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -1,6 +1,7 @@
 local M = {}
-local utils = require "lvim.utils"
-M.load_options = function()
+local join_paths = require("lvim.utils").join_paths
+
+M.load_default_options = function()
   local default_options = {
     backup = false, -- creates a backup file
     clipboard = "unnamedplus", -- allows neovim to access the system clipboard
@@ -28,7 +29,7 @@ M.load_options = function()
     timeoutlen = 100, -- time to wait for a mapped sequence to complete (in milliseconds)
     title = true, -- set the title of window to the value of the titlestring
     -- opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
-    undodir = utils.join_paths(get_cache_dir(), "undo"), -- set an undo directory
+    undodir = join_paths(get_cache_dir(), "undo"), -- set an undo directory
     undofile = true, -- enable persistent undo
     updatetime = 300, -- faster completion
     writebackup = false, -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
@@ -43,38 +44,35 @@ M.load_options = function()
     wrap = false, -- display lines as one long line
     spell = false,
     spelllang = "en",
-    spellfile = utils.join_paths(get_config_dir(), "spell", "en.utf-8.add"),
-    scrolloff = 8, -- is one of my fav
-    sidescrolloff = 8,
+    spellfile = join_paths(get_config_dir(), "spell", "en.utf-8.add"),
+    shadafile = join_paths(get_cache_dir(), "lvim.shada"),
+    scrolloff = 8, -- minimal number of screen lines to keep above and below the cursor.
+    sidescrolloff = 8, -- minimal number of screen lines to keep left and right of the cursor.
   }
 
   ---  SETTINGS  ---
-
   vim.opt.shortmess:append "c"
-
-  vim.opt.shadafile = utils.join_paths(get_cache_dir(), "lvim.shada")
+  vim.opt.whichwrap:append "<,>,[,],h,l"
 
   for k, v in pairs(default_options) do
     vim.opt[k] = v
   end
 end
 
-M.load_commands = function()
-  local cmd = vim.cmd
-  if lvim.line_wrap_cursor_movement then
-    cmd "set whichwrap+=<,>,[,],h,l"
-  end
+M.load_headless_options = function()
+  vim.opt.shortmess = "" -- try to prevent echom from cutting messages off or prompting
+  vim.opt.more = false -- don't pause listing when screen is filled
+  vim.opt.cmdheight = 9999 -- helps avoiding |hit-enter| prompts.
+  vim.opt.columns = 9999 -- set the widest screen possible
+  vim.opt.swapfile = false -- don't use a swap file
+end
 
-  if lvim.transparent_window then
-    cmd "au ColorScheme * hi Normal ctermbg=none guibg=none"
-    cmd "au ColorScheme * hi SignColumn ctermbg=none guibg=none"
-    cmd "au ColorScheme * hi NormalNC ctermbg=none guibg=none"
-    cmd "au ColorScheme * hi MsgArea ctermbg=none guibg=none"
-    cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
-    cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
-    cmd "au ColorScheme * hi EndOfBuffer ctermbg=none guibg=none"
-    cmd "let &fcs='eob: '"
+M.load_options = function()
+  if #vim.api.nvim_list_uis() == 0 then
+    M.load_headless_options()
+    return
   end
+  M.load_default_options()
 end
 
 return M

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -150,6 +150,17 @@ function M.disable_code_lens_refresh()
   M.disable_augroup "lsp_code_lens_refresh"
 end
 
+function M.enable_transparent_mode()
+  vim.cmd "au ColorScheme * hi Normal ctermbg=none guibg=none"
+  vim.cmd "au ColorScheme * hi SignColumn ctermbg=none guibg=none"
+  vim.cmd "au ColorScheme * hi NormalNC ctermbg=none guibg=none"
+  vim.cmd "au ColorScheme * hi MsgArea ctermbg=none guibg=none"
+  vim.cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
+  vim.cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
+  vim.cmd "au ColorScheme * hi EndOfBuffer ctermbg=none guibg=none"
+  vim.cmd "let &fcs='eob: '"
+end
+
 --- Disable autocommand groups if it exists
 --- This is more reliable than trying to delete the augroup itself
 ---@param name string the augroup name

--- a/tests/specs/bootstrap_spec.lua
+++ b/tests/specs/bootstrap_spec.lua
@@ -27,6 +27,7 @@ a.describe("initial start", function()
   end)
 
   a.it("should be able to pass basic checkhealth without errors", function()
+    vim.cmd "set cmdheight&"
     vim.cmd "checkhealth nvim"
     local errmsg = vim.fn.eval "v:errmsg"
     local exception = vim.fn.eval "v:exception"

--- a/tests/specs/config_loader_spec.lua
+++ b/tests/specs/config_loader_spec.lua
@@ -1,6 +1,5 @@
 local a = require "plenary.async_lib.tests"
 local config = require "lvim.config"
-local utils = require "lvim.utils"
 
 a.describe("config-loader", function()
   local user_config_path = config:get_user_config_path()
@@ -18,22 +17,29 @@ a.describe("config-loader", function()
   end)
 
   a.it("should be able to reload user-config without errors", function()
-    vim.opt.undodir = "/tmp"
-    assert.equal(vim.opt.undodir:get()[1], "/tmp")
+    config:load(user_config_path)
+    local test_path = "/tmp/lvim"
+    os.execute(string.format([[echo "vim.opt.undodir = '%s'" >> %s]], test_path, user_config_path))
     config:reload()
-    assert.equal(vim.opt.undodir:get()[1], utils.join_paths(get_cache_dir(), "undo"))
+    assert.equal(vim.opt.undodir:get()[1], test_path)
   end)
 
   a.it("should not get interrupted by errors in user-config", function()
-    vim.opt.undodir = "/tmp"
-    assert.equal(vim.opt.undodir:get()[1], "/tmp")
+    local test_path = "/tmp/lunarvim"
+    os.execute(string.format([[echo "vim.opt.undodir = '%s'" >> %s]], test_path, user_config_path))
+    config:reload()
+    assert.equal(vim.opt.undodir:get()[1], test_path)
     os.execute(string.format("echo 'bad_string_test' >> %s", user_config_path))
     local error_handler = function(msg)
       return msg
     end
     local err = xpcall(config:reload(), error_handler)
     assert.falsy(err)
-    assert.equal(vim.opt.undodir:get()[1], utils.join_paths(get_cache_dir(), "undo"))
+    assert.equal(vim.opt.undodir:get()[1], test_path)
+    local errmsg = vim.fn.eval "v:errmsg"
+    local exception = vim.fn.eval "v:exception"
+    assert.equal("", errmsg) -- v:errmsg was not updated.
+    assert.equal("", exception)
     os.execute(string.format("echo '' > %s", user_config_path))
   end)
 end)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- add headless-mode settings that can help prevent truncating error messages
- move the colorscheme autocmds into their correct module
