### PR TITLE
fix(lsp): formatter now use new null-ls api function

### DIFF
--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -73,7 +73,7 @@ local function select_default_formater(client)
   local formatters = require "lvim.lsp.null-ls.formatters"
   local client_filetypes = client.config.filetypes or {}
   for _, filetype in ipairs(client_filetypes) do
-    if #vim.tbl_keys(formatters.list_registered_providers(filetype)) > 0 then
+    if #vim.tbl_keys(formatters.list_registered(filetype)) > 0 then
       Log:debug("Formatter overriding detected. Disabling formatting capabilities for " .. client.name)
       client.resolved_capabilities.document_formatting = false
       client.resolved_capabilities.document_range_formatting = false


### PR DESCRIPTION
# Description

- The formatter in the `select_default_formater` function is still using its old function, that make `format_on_save` doesn't choose `null-ls` as default formatter
- Change the name of that function to new null-ls api function to make it work correctly