### PR TITLE
refactor(null-ls): allow passing full list of options for sources 

### DIFF
--- a/lua/lvim/lsp/null-ls/code_actions.lua
+++ b/lua/lvim/lsp/null-ls/code_actions.lua
@@ -1,63 +1,14 @@
 local M = {}
 
-local null_ls = require "null-ls"
-local services = require "lvim.lsp.null-ls.services"
 local Log = require "lvim.core.log"
 
-local METHOD = null_ls.methods.CODE_ACTION
-
-local is_registered = function(name)
-  local query = {
-    name = name,
-    method = METHOD,
-  }
-  return require("null-ls.sources").is_registered(query)
-end
+local null_ls = require "null-ls"
+local services = require "lvim.lsp.null-ls.services"
+local method = null_ls.methods.CODE_ACTION
 
 function M.list_registered(filetype)
   local registered_providers = services.list_registered_providers_names(filetype)
-  return registered_providers[METHOD] or {}
-end
-
-function M.list_configured(actions_configs)
-  local actors, errors = {}, {}
-
-  for _, config in ipairs(actions_configs) do
-    vim.validate {
-      ["config.name"] = { config.name, "string" },
-    }
-
-    local name = config.name:gsub("-", "_")
-    local actor = null_ls.builtins.code_actions[name]
-
-    if not actor then
-      Log:error("Not a valid code_actions: " .. config.name)
-      errors[name] = {} -- Add data here when necessary
-    elseif is_registered(config.name) then
-      Log:trace "Skipping registering  the source more than once"
-    else
-      local command
-      if actor._opts.command then
-        command = services.find_command(actor._opts.command)
-      end
-      if not command and actor._opts.command ~= nil then
-        Log:warn("Not found: " .. actor._opts.command)
-        errors[name] = {} -- Add data here when necessary
-      else
-        Log:debug("Using code_actions: " .. (command or config.name))
-        table.insert(
-          actors,
-          actor.with {
-            command = command, -- could be nil
-            extra_args = config.args,
-            filetypes = config.filetypes,
-          }
-        )
-      end
-    end
-  end
-
-  return { supported = actors, unsupported = errors }
+  return registered_providers[method] or {}
 end
 
 function M.setup(actions_configs)
@@ -65,8 +16,11 @@ function M.setup(actions_configs)
     return
   end
 
-  local actions = M.list_configured(actions_configs)
-  null_ls.register { sources = actions.supported }
+  local registered = services.register_sources(actions_configs, method)
+
+  if #registered > 0 then
+    Log:debug("Registered the following action-handlers: " .. unpack(registered))
+  end
 end
 
 return M

--- a/lua/lvim/lsp/null-ls/formatters.lua
+++ b/lua/lvim/lsp/null-ls/formatters.lua
@@ -1,22 +1,14 @@
 local M = {}
 
-local null_ls = require "null-ls"
-local services = require "lvim.lsp.null-ls.services"
 local Log = require "lvim.core.log"
 
-local is_registered = function(name)
-  local query = {
-    name = name,
-    method = require("null-ls").methods.FORMATTING,
-  }
-  return require("null-ls.sources").is_registered(query)
-end
+local null_ls = require "null-ls"
+local services = require "lvim.lsp.null-ls.services"
+local method = null_ls.methods.FORMATTING
 
 function M.list_registered(filetype)
-  local null_ls_methods = require "null-ls.methods"
-  local formatter_method = null_ls_methods.internal["FORMATTING"]
   local registered_providers = services.list_registered_providers_names(filetype)
-  return registered_providers[formatter_method] or {}
+  return registered_providers[method] or {}
 end
 
 function M.list_supported(filetype)
@@ -26,47 +18,16 @@ function M.list_supported(filetype)
   return supported_formatters
 end
 
-function M.list_configured(formatter_configs)
-  local formatters, errors = {}, {}
-
-  for _, fmt_config in ipairs(formatter_configs) do
-    local name = fmt_config.exe:gsub("-", "_")
-    local formatter = null_ls.builtins.formatting[name]
-
-    if not formatter then
-      Log:error("Not a valid formatter: " .. fmt_config.exe)
-      errors[name] = {} -- Add data here when necessary
-    elseif is_registered(fmt_config.exe) then
-      Log:trace "Skipping registering  the source more than once"
-    else
-      local formatter_cmd = services.find_command(formatter._opts.command)
-      if not formatter_cmd then
-        Log:warn("Not found: " .. formatter._opts.command)
-        errors[name] = {} -- Add data here when necessary
-      else
-        Log:debug("Using formatter: " .. formatter_cmd)
-        table.insert(
-          formatters,
-          formatter.with {
-            command = formatter_cmd,
-            extra_args = fmt_config.args,
-            filetypes = fmt_config.filetypes,
-          }
-        )
-      end
-    end
-  end
-
-  return { supported = formatters, unsupported = errors }
-end
-
 function M.setup(formatter_configs)
   if vim.tbl_isempty(formatter_configs) then
     return
   end
 
-  local formatters = M.list_configured(formatter_configs)
-  null_ls.register { sources = formatters.supported }
+  local registered = services.register_sources(formatter_configs, method)
+
+  if #registered > 0 then
+    Log:debug("Registered the following formatters: " .. unpack(registered))
+  end
 end
 
 return M

--- a/lua/lvim/lsp/null-ls/linters.lua
+++ b/lua/lvim/lsp/null-ls/linters.lua
@@ -1,22 +1,14 @@
 local M = {}
 
-local null_ls = require "null-ls"
-local services = require "lvim.lsp.null-ls.services"
 local Log = require "lvim.core.log"
 
-local is_registered = function(name)
-  local query = {
-    name = name,
-    method = require("null-ls").methods.DIAGNOSTICS,
-  }
-  return require("null-ls.sources").is_registered(query)
-end
+local null_ls = require "null-ls"
+local services = require "lvim.lsp.null-ls.services"
+local method = null_ls.methods.DIAGNOSTICS
 
 function M.list_registered(filetype)
-  local null_ls_methods = require "null-ls.methods"
-  local linter_method = null_ls_methods.internal["DIAGNOSTICS"]
   local registered_providers = services.list_registered_providers_names(filetype)
-  return registered_providers[linter_method] or {}
+  return registered_providers[method] or {}
 end
 
 function M.list_supported(filetype)
@@ -26,47 +18,16 @@ function M.list_supported(filetype)
   return supported_linters
 end
 
-function M.list_configured(linter_configs)
-  local linters, errors = {}, {}
-
-  for _, lnt_config in pairs(linter_configs) do
-    local name = lnt_config.exe:gsub("-", "_")
-    local linter = null_ls.builtins.diagnostics[name]
-
-    if not linter then
-      Log:error("Not a valid linter: " .. lnt_config.exe)
-      errors[lnt_config.exe] = {} -- Add data here when necessary
-    elseif is_registered(lnt_config.exe) then
-      Log:trace "Skipping registering the source more than once"
-    else
-      local linter_cmd = services.find_command(linter._opts.command)
-      if not linter_cmd then
-        Log:warn("Not found: " .. linter._opts.command)
-        errors[name] = {} -- Add data here when necessary
-      else
-        Log:debug("Using linter: " .. linter_cmd)
-        table.insert(
-          linters,
-          linter.with {
-            command = linter_cmd,
-            extra_args = lnt_config.args,
-            filetypes = lnt_config.filetypes,
-          }
-        )
-      end
-    end
-  end
-
-  return { supported = linters, unsupported = errors }
-end
-
 function M.setup(linter_configs)
   if vim.tbl_isempty(linter_configs) then
     return
   end
 
-  local linters = M.list_configured(linter_configs)
-  null_ls.register { sources = linters.supported }
+  local registered = services.register_sources(linter_configs, method)
+
+  if #registered > 0 then
+    Log:debug("Registered the following linters: " .. unpack(registered))
+  end
 end
 
 return M

--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -91,7 +91,9 @@ function M.register_sources(configs, method)
     end
   end
 
-  null_ls.register { sources = sources }
+  if #sources > 0 then
+    null_ls.register { sources = sources }
+  end
   return registered_names
 end
 


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- allow passing the full list of options when registering sources,
such as `{ cwd = "", disabled_filetypes = "", ... }`
- both `cmd` and `exe` are allowed (backwards compatibility)
- `args` is internally translate to `extra_args` (backwards compatibility)
but can still use `generator_opts.args` instead

Fixes #1833

## How Has This Been Tested?

Your current configuration should still work, but now you can pass any other option that null-ls accepts

```lua
local linters = require "lvim.lsp.null-ls.linters"
linters.setup {
  {
    exe = "luacheck", -- you can also use `command = "luacheck"
    cwd = function(params) -- force luacheck to find its '.luacheckrc' file
      local u = require "null-ls.utils"
      return u.root_pattern ".luacheckrc"(params.bufname)
    end,
  },
}

local formatters = require "lvim.lsp.null-ls.formatters"
formatters.setup {
  {
    exe = "prettier", -- you can also use `command = "prettier"
    -- this will run every time the source runs,
    -- so you should prefer caching results if possible
    runtime_condition = function(params)
        return params.root:match("my-monorepo-subdir") ~= nil
    end,
  },
}
```

Refer to https://github.com/jose-elias-alvarez/null-ls.nvim/doc/BUILTINS.md for the full list
