### PR TITLE
fix: remove "error" message from git tag

### DIFF
--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -106,7 +106,6 @@ function M.get_lvim_tag(type)
   local lvim_full_ver = results[1] or ""
 
   if ret ~= 0 or string.match(lvim_full_ver, "%d") == nil then
-    Log:error "Unable to retrieve current tag. Check the log for further information"
     return nil
   end
   if type == "short" then


### PR DESCRIPTION
# Description
Removing a `Log:error` line that was added but is, imo, more problematic than helpful.

I think the root cause is that the install script for lunarvim uses `--depth 1` when cloning which means the only ref/tag is `master` by default. So, the check for if the first tag is a number `%d` will result in the error message always being printed, causing a notification and message that is annoying/misleading and could potentially cause someone to waste time figuring the "problem". 

## How Has This Been Tested?
1. Uninstall lunarvim with the uninstall script.
2. Install lunarvim with the install script.
3. Open lunarvim/lvim. Before this fix I was seeing a notify and a message: "Unable to retrieve current tag. Check the log for further information"