### PR TITLE
 [Bugfix] Fix small typo in nvim command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ lvim.plugins = {
 ## Updating LunarVim
 
 - inside LunarVim `:LvimUpdate`
-- from the command-line `lvim +LvimUpdate +q`
+- from the command-line `nvim +LvimUpdate +q`
 
 ### Update the plugins
 


### PR DESCRIPTION
 [Bugfix]

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

You use lvim, but the command to launch neovim is nvim

## How Has This Been Tested?

- `lvim`
Command 'lvim' not found, but there are 25 similar ones.
- `nvim`
works.


