### PR TITLE
refactor(term): leave the first few ids unassigned

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -50,25 +50,13 @@ M.setup = function()
   local terminal = require "toggleterm"
   terminal.setup(lvim.builtin.terminal)
 
-  -- setup the default terminal so it's always reachable
-  local default_term_opts = {
-    cmd = lvim.builtin.terminal.shell,
-    keymap = lvim.builtin.terminal.open_mapping,
-    label = "Toggle terminal",
-    count = 1,
-    direction = lvim.builtin.terminal.direction,
-    size = lvim.builtin.terminal.size,
-  }
-  if lvim.builtin.terminal.open_mapping then
-    M.add_exec(default_term_opts)
-  end
-
   for i, exec in pairs(lvim.builtin.terminal.execs) do
     local opts = {
       cmd = exec[1],
       keymap = exec[2],
       label = exec[3],
-      count = i + 1,
+      -- NOTE: unable to consistently bind id/count <= 9, see #2146
+      count = i + 100,
       direction = exec[4] or lvim.builtin.terminal.direction,
       size = lvim.builtin.terminal.size,
     }


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This is due to inconsistencies of `:2ToggleTerm`

Fixes #2146

---

Thank you @00sapo for looking into this!
