### PR TITLE
fix(lsp): no need to stop clients on LvimReload

### DIFF
--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -42,10 +42,6 @@ end
 ---The files are generated to a runtimepath: "$LUNARVIM_RUNTIME_DIR/site/after/ftplugin/template.lua"
 ---@param servers_names table list of servers to be enabled. Will add all by default
 function M.generate_templates(servers_names)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    client:stop()
-  end
-
   servers_names = servers_names or {}
 
   Log:debug "Templates installation in progress"

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -21,9 +21,6 @@ function M.run_post_reload()
   Log:debug "Starting post-reload hook"
   require("lvim.plugin-loader").ensure_installed()
   M.reset_cache()
-  if package.loaded["lspconfig"] then
-    pcall(vim.cmd, "LspRestart")
-  end
 end
 
 ---Reset any startup cache files used by Packer and Impatient


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

No need to stop clients on `LvimReload` since we're not using `lspconfig/configs` directly anymore. And `LspRestart` doesn't currently re-attaches all the buffers correctly.

Fixes a regression from #2157

