### PR TITLE
fix(installer): usernames can contain @ symbol

### DIFF
--- a/utils/installer/install_bin.sh
+++ b/utils/installer/install_bin.sh
@@ -24,9 +24,9 @@ function setup_shim() {
 
   cp "$src" "$dst"
 
-  sed -e s"@RUNTIME_DIR_VAR@\"${LUNARVIM_RUNTIME_DIR}\"@"g \
-    -e s"@CONFIG_DIR_VAR@\"${LUNARVIM_CONFIG_DIR}\"@"g \
-    -e s"@CACHE_DIR_VAR@\"${LUNARVIM_CACHE_DIR}\"@"g "$src" \
+  sed -e s"#RUNTIME_DIR_VAR#\"${LUNARVIM_RUNTIME_DIR}\"#"g \
+    -e s"#CONFIG_DIR_VAR#\"${LUNARVIM_CONFIG_DIR}\"#"g \
+    -e s"#CACHE_DIR_VAR#\"${LUNARVIM_CACHE_DIR}\"#"g "$src" \
     | tee "$dst" >/dev/null
 
   chmod u+x "$dst"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Switch the delimiter used in `sed` since usernames can contain `@` symbol

Fixes #2162

## How Has This Been Tested?

```bash
bash utils/installer/install_bin.sh
```
