### PR TITLE
Revert "fix(which-key): temporary solution for which-key (#2150)"

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -177,10 +177,8 @@ return {
 
   -- Whichkey
   {
-    -- "folke/which-key.nvim",
-    -- commit = commit.which_key,
-    "zeertzjq/which-key.nvim",
-    branch = "patch-1",
+    "folke/which-key.nvim",
+    commit = commit.which_key,
     config = function()
       require("lvim.core.which-key").setup()
     end,


### PR DESCRIPTION
This reverts commit 6740afd743a05028cc48e8f1e203e7f81345aced.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Since this fix folke/which-key.nvim#227 merged, and the patch branch have been deleted, the temporary solution should revert to prevent lvim broken. @meijieru 
