### PR TITLE
fix(diag): show lsp-diag code in open_float

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -23,8 +23,9 @@ return {
       prefix = "",
       format = function(d)
         local t = vim.deepcopy(d)
-        if d.code then
-          t.message = string.format("%s [%s]", t.message, t.code):gsub("1. ", "")
+        local code = d.code or d.user_data.lsp.code
+        if code then
+          t.message = string.format("%s [%s]", t.message, code):gsub("1. ", "")
         end
         return t.message
       end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Show the code of lsp diagnostics when available. 

This was working fine already for null-ls, now it should work fine as well for lsp servers.

## How Has This Been Tested?

**old**
![image](https://user-images.githubusercontent.com/59826753/149618843-1b6624f1-6a5d-4b1e-aa49-0391cc4886df.png)

**new**
![image](https://user-images.githubusercontent.com/59826753/149618850-05d480ec-0230-4155-a4a3-1ebaf7e9ba39.png)
