### PR TITLE
[Bugfix]: added -ScriptBlock to run commands ```install.ps1```

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.1
 $ErrorActionPreference = "Stop" # exit when command fails
 
 # set script variables

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -139,9 +139,10 @@ function check_system_deps() {
 }
 
 function install_nodejs_deps() {
+    $dep = "node"
     try {
-        check_system_dep "node"
-        Invoke-Command npm install -g neovim tree-sitter-cli -ErrorAction Break
+        check_system_dep "$dep"
+        Invoke-Command -ScriptBlock { npm install --global neovim tree-sitter-cli } -ErrorAction Break
     }
     catch {
         print_missing_dep_msg "$dep"
@@ -149,9 +150,10 @@ function install_nodejs_deps() {
 }
 
 function install_python_deps() {
+    $dep = "pip"
     try {
-        check_system_dep "pip"
-        Invoke-Command python -m pip install --user pynvim -ErrorAction Break
+        check_system_dep "$dep"
+        Invoke-Command -ScriptBlock { python -m pip install --user pynvim } -ErrorAction Break
     }
     catch {
         print_missing_dep_msg "$dep"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes a bug in install.ps1 that throws error running while installing node/python dependencies.

Fixes #2178 

## How Has This Been Tested?
Tested by running install.ps1 on PowerShell 7.2.1, dependencies are now installed.
NOTE: This does not work on PowerShell 5.x as we are using *-ErrorAction Break*.

Reproduce:
```
Set-ExecutionPolicy Bypass -Scope Process -Force
pwsh .\utils\installer\install.ps1
```

Logs:
```
...
[INFO]: Checking dependencies..
Would you like to check lunarvim's NodeJS dependencies?
[y]es or [n]o (default: no) : y

changed 35 packages, and audited 36 packages in 5s

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Would you like to check lunarvim's Python dependencies?
[y]es or [n]o (default: no) : y
Requirement already satisfied: pynvim in c:\users\adrian\appdata\roaming\python\python39\site-packages (0.4.3)
Requirement already satisfied: msgpack>=0.5.0 in c:\users\adrian\appdata\roaming\python\python39\site-packages (from pynvim) (1.0.3)
Requirement already satisfied: greenlet in c:\users\adrian\appdata\roaming\python\python39\site-packages (from pynvim) (1.1.2)
--------------------------------------------------------------------------------
...
```
