### PR TITLE
fix(autopairs): remove weird tex rules from autopairs

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -49,7 +49,6 @@ end
 M.setup = function()
   local autopairs = require "nvim-autopairs"
   local Rule = require "nvim-autopairs.rule"
-  local cond = require "nvim-autopairs.conds"
 
   autopairs.setup {
     check_ts = lvim.builtin.autopairs.check_ts,
@@ -64,25 +63,6 @@ M.setup = function()
     map_bs = lvim.builtin.autopairs.map_bs,
     disable_in_visualblock = lvim.builtin.autopairs.disable_in_visualblock,
     fast_wrap = lvim.builtin.autopairs.fast_wrap,
-  }
-
-  autopairs.add_rule(Rule("$$", "$$", "tex"))
-  autopairs.add_rules {
-    Rule("$", "$", { "tex", "latex" }) -- don't add a pair if the next character is %
-      :with_pair(cond.not_after_regex_check "%%") -- don't add a pair if  the previous character is xxx
-      :with_pair(cond.not_before_regex_check("xxx", 3)) -- don't move right when repeat character
-      :with_move(cond.none()) -- don't delete if the next character is xx
-      :with_del(cond.not_after_regex_check "xx") -- disable  add newline when press <cr>
-      :with_cr(cond.none()),
-  }
-  autopairs.add_rules {
-    Rule("$$", "$$", "tex"):with_pair(function(opts)
-      print(vim.inspect(opts))
-      if opts.line == "aa $$" then
-        -- don't add pair on that line
-        return false
-      end
-    end),
   }
 
   require("nvim-treesitter.configs").setup { autopairs = { enable = true } }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

we don't need to add these weird rules, let the user add them if they wanted to

Fixes #2204 

```lua
lvim.builtin.autopairs.on_config_done = function(autopairs)
    autopairs.add_rule(Rule("$$", "$$", "tex"))
    -- and more
end
```

