### PR TITLE
docs(readme): add powershell installer script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/
 
 Windows (Powershell):
 ```powershell
-iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1'))
+iwr https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 | iex
 ```
 
 ## Install Language support

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/
 
 Windows (Powershell):
 ```powershell
-iwr https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 | iex
+Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 | Invoke-Expression
 ```
 
 ## Install Language support

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/
 
 Windows (Powershell):
 ```powershell
-Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 | Invoke-Expression
+Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
 ```
 
 ## Install Language support

--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ You can find all the documentation for LunarVim at [lunarvim.org](https://www.lu
 
 Make sure you have the release version of Neovim (0.6).
 
+Linux:
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
+```
+
+Windows (Powershell):
+```powershell
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1'))
 ```
 
 ## Install Language support


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add command to install LunarVim on Windows to README.

I have installed LunarVim on a few different computers and have found it difficult to find the installer script because it was not listed in the README. 

Please feel free to change the labels for Windows/Linux installers; I don't know if the bash installer is also meant for Mac, and I'm sure there are other things I may have overlooked.

## How Has This Been Tested?

In Windows Sandbox:

- Install Chocolatey
- Run command: `choco install neovim git`
- Run command:
   ```powershell
   iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1'))
    ```

It should be noted that if the user does not have Git installed, the open Powershell instance will close without giving the user a chance to see the issue.