### PR TITLE
fix(lsp): avoid accessing undefined user_data

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -23,7 +23,7 @@ return {
       prefix = "",
       format = function(d)
         local t = vim.deepcopy(d)
-        local code = d.code or d.user_data.lsp.code
+        local code = d.code or (d.user_data and d.user_data.lsp.code)
         if code then
           t.message = string.format("%s [%s]", t.message, code):gsub("1. ", "")
         end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# 

Do not throw exception in case of incorrect eslint configuration

## How Has This Been Tested?
1. Open a project with eslint
1. Add a syntax error to `.eslintrc`
1. Open any js file in the project and hover a first line

**Before change**
Lunarvim throws the following error:
```
E5108: Error executing /.local/share/lunarvim/lvim/lua/lvim/lsp/config.lua:26: attempt to index field 'user_data' (a nil value)
```

**After change**
There is a float window with a correct message
```
eslint_d: SyntaxError: Cannot read config file: .eslintrc.json
Error: Unexpected token { in JSON at position 1
```