### PR TITLE
fix(installer): universal bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 install:
 	@echo starting LunarVim installer


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Fixes inability to install LunarVim for Nix users by replacing the default `/bin/bash` with `/usr/bin/env bash`.

Fixes #2240

## How Has This Been Tested?

- Point branch + repository of `install.sh` to my local repository.
- Change `/bin/bash` to `/usr/bin/env bash` and push that commit.
- Successful installation of LunarVim.

