### PR TITLE
fix(lualine): use 1-char width symbol for changed

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -35,7 +35,7 @@ return {
   diff = {
     "diff",
     source = diff_source,
-    symbols = { added = "  ", modified = "柳 ", removed = " " },
+    symbols = { added = "  ", modified = " ", removed = " " },
     diff_color = {
       added = { fg = colors.green },
       modified = { fg = colors.yellow },


### PR DESCRIPTION
The 2-char width characters cause problems in windows terminal.
Related to #1897