### PR TITLE
fix(lualine): compacter size for treesitter icon

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -74,7 +74,7 @@ return {
     function()
       local b = vim.api.nvim_get_current_buf()
       if next(vim.treesitter.highlighter.active[b]) then
-        return "  "
+        return ""
       end
       return ""
     end,


### PR DESCRIPTION
Remove the space for the treesitter icon.
Looks like 
![image](https://user-images.githubusercontent.com/9511136/152495824-89cad56c-a7fb-4fed-a92e-d8992b310a6a.png)
