### PR TITLE
feat(installer): use pnpm to install nodejs dependencies(#2279)

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -201,6 +201,12 @@ function check_system_deps() {
   check_neovim_min_version
 }
 
+function __install_nodejs_deps_pnpm() {
+  echo "Installing node modules with pnpm.."
+  pnpm install -g "${__npm_deps[@]}"
+  echo "All NodeJS dependencies are successfully installed"
+}
+
 function __install_nodejs_deps_npm() {
   echo "Installing node modules with npm.."
   for dep in "${__npm_deps[@]}"; do
@@ -229,6 +235,8 @@ function __validate_node_installation() {
 
   if [ "$pkg_manager" == "npm" ]; then
     manager_home="$(npm config get prefix 2>/dev/null)"
+  elif [ "$pkg_manager" == "pnpm" ]; then
+    manager_home="$(pnpm config get prefix 2>/dev/null)"
   else
     manager_home="$(yarn global bin 2>/dev/null)"
   fi
@@ -242,7 +250,7 @@ function __validate_node_installation() {
 }
 
 function install_nodejs_deps() {
-  local -a pkg_managers=("yarn" "npm")
+  local -a pkg_managers=("pnpm" "yarn" "npm")
   for pkg_manager in "${pkg_managers[@]}"; do
     if __validate_node_installation "$pkg_manager"; then
       eval "__install_nodejs_deps_$pkg_manager"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This PR adds yarn support for the installer script. Nothing else.

Fixes #2279

## Specific changes

In `utils/installer/install.sh` install_nodejs_deps uses pnpm then yarn and falls back to npm at last.

## How Has This Been Tested?

```shell
curl -fsSL https://get.pnpm.io/install.sh | sh -
# or brew install pnpm

bash utils/installer/install.sh
```