### PR TITLE
[Feature]: add lvim_provider to opt in provider

### DIFF
--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -74,7 +74,7 @@ M.config = function()
         name = "Buffers",
         j = { "<cmd>BufferLinePick<cr>", "Jump" },
         f = { "<cmd>Telescope buffers<cr>", "Find" },
-        b = { "<cmd>BufferLineCyclePrev<cr>", "Previous" },
+        b = { "<cmd>b#<cr>", "Previous" },
         -- w = { "<cmd>BufferWipeout<cr>", "Wipeout" }, -- TODO: implement this for bufferline
         e = {
           "<cmd>BufferLinePickClose<cr>",

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -29,7 +29,8 @@ local function resolve_config(name, user_config)
   }
 
   local has_custom_provider, custom_config = pcall(require, "lvim/lsp/providers/" .. name)
-  if has_custom_provider then
+  local use_custom_provider = not user_config or (user_config.lvim_provider ~= false)
+  if has_custom_provider and use_custom_provider then
     Log:debug("Using custom configuration for requested server: " .. name)
     config = vim.tbl_deep_extend("force", config, custom_config)
   end


### PR DESCRIPTION
# Description

Fixes #2290. Allow users to opt in LS settings from "lsp/providers":

Only when `user_config.lvim_provider` is set to false, providers' settings will not be used.


