### PR TITLE
[Feature]: Add possibility to override plugin loading event

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -36,6 +36,7 @@ end
 M.config = function()
   lvim.builtin.bufferline = {
     active = true,
+    event = "BufWinEnter",
     on_config_done = nil,
     keymap = {
       normal_mode = {},

--- a/lua/lvim/core/comment.lua
+++ b/lua/lvim/core/comment.lua
@@ -9,6 +9,7 @@ function M.config()
   end
   lvim.builtin.comment = {
     active = true,
+    event = "BufRead",
     on_config_done = nil,
     ---Add a space b/w comment and the line
     ---@type boolean

--- a/lua/lvim/core/dashboard.lua
+++ b/lua/lvim/core/dashboard.lua
@@ -4,6 +4,7 @@ local utils = require "lvim.utils"
 M.config = function(config)
   lvim.builtin.dashboard = {
     active = false,
+    event = "BufWinEnter",
     on_config_done = nil,
     search_handler = "telescope",
     disable_at_vim_enter = 0,

--- a/lua/lvim/core/gitsigns.lua
+++ b/lua/lvim/core/gitsigns.lua
@@ -3,6 +3,7 @@ local M = {}
 M.config = function()
   lvim.builtin.gitsigns = {
     active = true,
+    event = "BufRead",
     on_config_done = nil,
     opts = {
       signs = {

--- a/lua/lvim/core/notify.lua
+++ b/lua/lvim/core/notify.lua
@@ -4,6 +4,7 @@ local Log = require "lvim.core.log"
 
 local defaults = {
   active = false,
+  event = "BufRead",
   on_config_done = nil,
   opts = {
     ---@usage Animation style one of { "fade", "slide", "fade_in_slide_out", "static" }

--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -3,6 +3,7 @@ local Log = require "lvim.core.log"
 
 M.config = function()
   lvim.builtin["terminal"] = {
+    event = "BufWinEnter",
     on_config_done = nil,
     -- size can be a number or function which is passed the current terminal
     size = 20,

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -4,6 +4,7 @@ M.config = function()
   lvim.builtin.which_key = {
     ---@usage disable which-key completely [not recommended]
     active = true,
+    event = "BufWinEnter",
     on_config_done = nil,
     setup = {
       plugins = {

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -58,7 +58,7 @@ return {
     config = function()
       require("lvim.core.notify").setup()
     end,
-    event = "BufRead",
+    event = lvim.builtin.notify.event,
   },
   { "Tastyep/structlog.nvim", commit = commit.structlog },
 
@@ -172,7 +172,7 @@ return {
     config = function()
       require("lvim.core.gitsigns").setup()
     end,
-    event = "BufRead",
+    event = lvim.builtin.gitsigns.event,
     disable = not lvim.builtin.gitsigns.active,
   },
 
@@ -183,7 +183,7 @@ return {
     config = function()
       require("lvim.core.which-key").setup()
     end,
-    event = "BufWinEnter",
+    event = lvim.builtin.which_key.event,
     disable = not lvim.builtin.which_key.active,
   },
 
@@ -191,7 +191,7 @@ return {
   {
     "numToStr/Comment.nvim",
     commit = commit.comment,
-    event = "BufRead",
+    event = lvim.builtin.comment.event,
     config = function()
       require("lvim.core.comment").setup()
     end,
@@ -229,7 +229,7 @@ return {
     config = function()
       require("lvim.core.bufferline").setup()
     end,
-    event = "BufWinEnter",
+    event = lvim.builtin.bufferline.event,
     disable = not lvim.builtin.bufferline.active,
   },
 
@@ -256,7 +256,7 @@ return {
   -- Dashboard
   {
     "ChristianChiarulli/dashboard-nvim",
-    event = "BufWinEnter",
+    event = lvim.builtin.dashboard.event,
     config = function()
       require("lvim.core.dashboard").setup()
     end,
@@ -267,7 +267,7 @@ return {
   {
     "akinsho/toggleterm.nvim",
     commit = commit.toggleterm,
-    event = "BufWinEnter",
+    event = lvim.builtin.terminal.event,
     config = function()
       require("lvim.core.terminal").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

It can be useful be able to override which event a core plugin should be loaded from the user configuration.

Add an `event` attribute to the default configuration of all core plugins that have an event configured and refer to that from the plugins module.

This implements the approach suggested in #1692.

## How Has This Been Tested?

My use case was to make `gitsigns.nvim` load on startup when not starting vim with a file as argument (not only when `BufRead` event is triggered).
I use the [gitsigns](https://github.com/lewis6991/gitsigns.nvim) plugin to review all the changes of last commit by changing its base (e.g. `HEAD~1`).

In my `config.lua` I override the default configuration like this:

```lua
lvim.builtin.gitsigns.event = "VimEnter"
```

This makes the plugin available at start without having to open a file first.
