### PR TITLE
feat: add option to automatically answer 'yes' for sh install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,18 @@ You can find all the documentation for LunarVim at [lunarvim.org](https://www.lu
 
 Make sure you have the release version of Neovim (0.6.1+).
 
-Linux:
+### Linux:
+
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
 ```
 
-> If you want to run it without any interaction you can pass the `-y` or `--install-dependencies` flag to automatically install all dependencies and have no prompts. The same way, you can use `-n` or `--no-install-dependencies` to skip the dependency installation.
+To run the install script without any interaction you can pass the `-y` flag to automatically install all dependencies and have no prompts. This is particularly useful in automated installations.
 
-Windows (Powershell):
+The same way, you can use `--no-install-dependencies` to skip the dependency installation.
+
+### Windows (Powershell):
+
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Linux:
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
 ```
 
+> If you want to run it without any interaction you can pass the `-y` or `--install-dependencies` flag to automatically install all dependencies and have no prompts. The same way, you can use `-n` or `--no-install-dependencies` to skip the dependency installation.
+
 Windows (Powershell):
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
@@ -159,7 +161,7 @@ lvim.plugins = {
 > - @mvllow, Potential LunarVim user.
 
 <div align="center" id="madewithlua">
-	
+
 [![Lua](https://img.shields.io/badge/Made%20with%20Lua-blue.svg?style=for-the-badge&logo=lua)](#madewithlua)
-	
+
 </div>

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -24,7 +24,8 @@ readonly BASEDIR
 
 declare ARGS_LOCAL=0
 declare ARGS_OVERWRITE=0
-declare ARGS_INSTALL_DEPENDENCIES=2
+declare ARGS_INSTALL_DEPENDENCIES=1
+declare INTERACTIVE_MODE=1
 
 declare -a __lvim_dirs=(
   "$LUNARVIM_CONFIG_DIR"
@@ -47,8 +48,9 @@ function usage() {
   echo "Options:"
   echo "    -h, --help                               Print this help message"
   echo "    -l, --local                              Install local copy of LunarVim"
+  echo "    -y, --yes                                Disable confirmation prompts (answer yes to all questions)"
   echo "    --overwrite                              Overwrite previous LunarVim configuration (a backup is always performed first)"
-  echo "    -y, -n, --[no]-install-dependencies      Whether to automatically install external dependencies (will prompt by default)"
+  echo "    --[no]-install-dependencies              Whether to automatically install external dependencies (will prompt by default)"
 }
 
 function parse_arguments() {
@@ -60,10 +62,13 @@ function parse_arguments() {
       --overwrite)
         ARGS_OVERWRITE=1
         ;;
-      -y | --install-dependencies)
+      -y | --yes)
+        INTERACTIVE_MODE=0
+        ;;
+      --install-dependencies)
         ARGS_INSTALL_DEPENDENCIES=1
         ;;
-      -n | --no-install-dependencies)
+      --no-install-dependencies)
         ARGS_INSTALL_DEPENDENCIES=0
         ;;
       -h | --help)
@@ -92,22 +97,24 @@ function main() {
 
   check_system_deps
 
-  if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 2 ]; then
-    msg "Would you like to install LunarVim's NodeJS dependencies?"
-    read -p "[y]es or [n]o (default: no) : " -r answer
-    [ "$answer" != "${answer#[Yy]}" ] && install_nodejs_deps
+  if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
+    if [ "$INTERACTIVE_MODE" -eq 1 ]; then
+      msg "Would you like to install LunarVim's NodeJS dependencies?"
+      read -p "[y]es or [n]o (default: no) : " -r answer
+      [ "$answer" != "${answer#[Yy]}" ] && install_nodejs_deps
 
-    msg "Would you like to install LunarVim's Python dependencies?"
-    read -p "[y]es or [n]o (default: no) : " -r answer
-    [ "$answer" != "${answer#[Yy]}" ] && install_python_deps
+      msg "Would you like to install LunarVim's Python dependencies?"
+      read -p "[y]es or [n]o (default: no) : " -r answer
+      [ "$answer" != "${answer#[Yy]}" ] && install_python_deps
 
-    msg "Would you like to install LunarVim's Rust dependencies?"
-    read -p "[y]es or [n]o (default: no) : " -r answer
-    [ "$answer" != "${answer#[Yy]}" ] && install_rust_deps
-  elif [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
-    install_nodejs_deps
-    install_python_deps
-    install_rust_deps
+      msg "Would you like to install LunarVim's Rust dependencies?"
+      read -p "[y]es or [n]o (default: no) : " -r answer
+      [ "$answer" != "${answer#[Yy]}" ] && install_rust_deps
+    else
+      install_nodejs_deps
+      install_python_deps
+      install_rust_deps
+    fi
   fi
 
   backup_old_config

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -24,7 +24,7 @@ readonly BASEDIR
 
 declare ARGS_LOCAL=0
 declare ARGS_OVERWRITE=0
-declare ARGS_INSTALL_DEPENDENCIES=1
+declare ARGS_INSTALL_DEPENDENCIES=2
 
 declare -a __lvim_dirs=(
   "$LUNARVIM_CONFIG_DIR"
@@ -48,7 +48,7 @@ function usage() {
   echo "    -h, --help                       Print this help message"
   echo "    -l, --local                      Install local copy of LunarVim"
   echo "    --overwrite                      Overwrite previous LunarVim configuration (a backup is always performed first)"
-  echo "    --[no]-install-dependencies      Whether to prompt to install external dependencies (will prompt by default)"
+  echo "    -y, -n, --[no]-install-dependencies      Whether to automatically install external dependencies (will prompt by default)"
 }
 
 function parse_arguments() {
@@ -60,10 +60,10 @@ function parse_arguments() {
       --overwrite)
         ARGS_OVERWRITE=1
         ;;
-      --install-dependencies)
+      -y | --install-dependencies)
         ARGS_INSTALL_DEPENDENCIES=1
         ;;
-      --no-install-dependencies)
+      -n | --no-install-dependencies)
         ARGS_INSTALL_DEPENDENCIES=0
         ;;
       -h | --help)
@@ -92,7 +92,7 @@ function main() {
 
   check_system_deps
 
-  if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
+  if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 2 ]; then
     msg "Would you like to install LunarVim's NodeJS dependencies?"
     read -p "[y]es or [n]o (default: no) : " -r answer
     [ "$answer" != "${answer#[Yy]}" ] && install_nodejs_deps
@@ -104,6 +104,10 @@ function main() {
     msg "Would you like to install LunarVim's Rust dependencies?"
     read -p "[y]es or [n]o (default: no) : " -r answer
     [ "$answer" != "${answer#[Yy]}" ] && install_rust_deps
+  elif [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
+    install_nodejs_deps
+    install_python_deps
+    install_rust_deps
   fi
 
   backup_old_config

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -45,9 +45,9 @@ function usage() {
   echo "Usage: install.sh [<options>]"
   echo ""
   echo "Options:"
-  echo "    -h, --help                       Print this help message"
-  echo "    -l, --local                      Install local copy of LunarVim"
-  echo "    --overwrite                      Overwrite previous LunarVim configuration (a backup is always performed first)"
+  echo "    -h, --help                               Print this help message"
+  echo "    -l, --local                              Install local copy of LunarVim"
+  echo "    --overwrite                              Overwrite previous LunarVim configuration (a backup is always performed first)"
   echo "    -y, -n, --[no]-install-dependencies      Whether to automatically install external dependencies (will prompt by default)"
 }
 


### PR DESCRIPTION
# Description

Add possibility for the user to auto install dependencies based on a flag that can be either `-y, --install-dependencies` which will not prompt the user for dependency installing, or `-n, -no-install-dependencies` which won't install deps altogether.

The default behavior of prompting is maintained.

## Why

Because while fiddling around with my dotfiles and automatic setup, I'd like to be able to run the script without any sort of interaction (heavily inspired on `npm init -y`

## How Has This Been Tested?

Ran the test locally in docker containers using the same installation configuration but with the different file:

- `bash <(curl -shttps://raw.githubusercontent.com/khaosdoctor/LunarVim/feature/auto-install-deps-sh/utils/installer/install.sh) -y`
- `bash <(curl -shttps://raw.githubusercontent.com/khaosdoctor/LunarVim/feature/auto-install-deps-sh/utils/installer/install.sh) -n`
- `bash <(curl -shttps://raw.githubusercontent.com/khaosdoctor/LunarVim/feature/auto-install-deps-sh/utils/installer/install.sh) --install-dependencies`
- `bash <(curl -shttps://raw.githubusercontent.com/khaosdoctor/LunarVim/feature/auto-install-deps-sh/utils/installer/install.sh) -no-install-dependencies`

