### PR TITLE
fix: disable the default intro message

### DIFF
--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -51,7 +51,8 @@ M.load_default_options = function()
   }
 
   ---  SETTINGS  ---
-  vim.opt.shortmess:append "c"
+  vim.opt.shortmess:append "c" -- don't show redundant messages from ins-completion-menu
+  vim.opt.shortmess:append "I" -- don't show the default intro message
   vim.opt.whichwrap:append "<,>,[,],h,l"
 
   for k, v in pairs(default_options) do


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The default intro message can be confusing if there's a problem with dashboard/alpha.

Related #2314, and many others :sweat_smile:

## How Has This Been Tested?


```lua
lvim.builtin.dashboard.active = false
```


