### PR TITLE
fix: nvim-tree taking half the window on open

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -79,6 +79,7 @@ function M.config()
           global = false,
         },
         open_file = {
+          resize_window = true,
           quit_on_open = false,
         },
         window_picker = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes the issue with nvim-tree when you do a `lvim .`
instead of taking half of the window, it will resize to`30`
