### PR TITLE
[Bugfix]: correct typo in backup function

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -322,7 +322,7 @@ function verify_lvim_dirs() {
 
 function backup_old_config() {
   local src="$LUNARVIM_CONFIG_DIR"
-  if [ ! -d "$dir" ]; then
+  if [ ! -d "$src" ]; then
     return
   fi
   mkdir -p "$src.old"


### PR DESCRIPTION
This PR fixes variable name typo introduced [here](https://github.com/LunarVim/LunarVim/pull/2330/files#diff-f8eb0b418c92b4d7f4f76654d1ed676ec9ff9124561c6a8cf6e6b1db63a43388R325) that made backup being skipped. 
