### PR TITLE
fix(lualine): conditional theme loading

### DIFF
--- a/lua/lvim/core/lualine/styles.lua
+++ b/lua/lvim/core/lualine/styles.lua
@@ -127,9 +127,6 @@ end
 
 function M.update()
   local style = M.get_style(lvim.builtin.lualine.style)
-  if lvim.builtin.lualine.options.theme == nil then
-    lvim.builtin.lualine.options.theme = lvim.colorscheme
-  end
 
   lvim.builtin.lualine = vim.tbl_deep_extend("keep", lvim.builtin.lualine, style)
 end

--- a/lua/lvim/core/lualine/utils.lua
+++ b/lua/lvim/core/lualine/utils.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.validate_theme()
-  local theme = lvim.builtin.lualine.options.theme
+  local theme = lvim.builtin.lualine.options.theme or "auto"
   if type(theme) == "table" then
     return
   end

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -55,6 +55,7 @@ return {
     "lunarvim/onedarker.nvim",
     config = function()
       require("onedarker").setup()
+      lvim.builtin.lualine.options.theme = "onedarker"
     end,
     disable = lvim.colorscheme ~= "onedarker",
   },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Only assign lualine's theme to onedarker after the plugin has been enabled and installed.

```lua
lvim.builtin.lualine.options.theme = "onedarker"
```

## How Has This Been Tested?

Should pass the CI more consistently now.
