### PR TITLE
fix(alpha): globalstatus after openning files from dashboard

### DIFF
--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -46,6 +46,26 @@ local function resolve_config(theme_name)
   return selected_theme.config
 end
 
+local function configure_additional_autocmds()
+  local aucmds = {
+    {
+      "FileType",
+      "alpha",
+      "set showtabline=0 | autocmd BufLeave <buffer> set showtabline=" .. vim.opt.showtabline._value,
+    },
+  }
+  if not lvim.builtin.lualine.options.globalstatus then
+    aucmds[#aucmds + 1] =
+      -- https://github.com/goolord/alpha-nvim/issues/42
+      {
+        "FileType",
+        "alpha",
+        "set laststatus=0 | autocmd BufUnload <buffer> set laststatus=" .. vim.opt.laststatus._value,
+      }
+  end
+  require("lvim.core.autocmds").define_augroups { _alpha = aucmds }
+end
+
 function M.setup()
   local alpha = require "alpha"
   local mode = lvim.builtin.alpha.mode
@@ -57,6 +77,7 @@ function M.setup()
   end
 
   alpha.setup(config)
+  configure_additional_autocmds()
 end
 
 return M

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -53,19 +53,6 @@ function M.load_augroups()
     _general_lsp = {
       { "FileType", "lspinfo,lsp-installer,null-ls-info", "nnoremap <silent> <buffer> q :close<CR>" },
     },
-    _alpha = {
-      {
-        "FileType",
-        "alpha",
-        "set showtabline=0 | autocmd BufLeave <buffer> set showtabline=" .. vim.opt.showtabline._value,
-      },
-      -- https://github.com/goolord/alpha-nvim/issues/42
-      {
-        "FileType",
-        "alpha",
-        "set laststatus=0 | autocmd BufUnload <buffer> set laststatus=" .. vim.opt.laststatus._value,
-      },
-    },
     custom_groups = {},
   }
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

do not set laststatus if globalstatus is activated

Fixes #2365

