### PR TITLE
fix(bufferline): add an additional space before diagnostics

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -9,7 +9,7 @@ local function diagnostics_indicator(_, _, diagnostics)
   local symbols = { error = "", warning = "", info = "" }
   for name, count in pairs(diagnostics) do
     if symbols[name] and count > 0 then
-      table.insert(result, symbols[name] .. count)
+      table.insert(result, symbols[name] .. " " .. count)
     end
   end
   result = table.concat(result, " ")


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I think there should be a space between icon and the diagnostics count. See below for screenshots. Let me know if this issue is specific to my terminal emulator.

## How Has This Been Tested?

- Use `alacritty`
- Open a project with LSP
- Open a second buffer to show the bufferline
- Make a mistake in your code

## Currently

![image](https://user-images.githubusercontent.com/34583604/159139258-49bb5d26-ab54-42ea-81a0-1a913c2d08fd.png)

## With this change

![image](https://user-images.githubusercontent.com/34583604/159139261-9d557724-028d-41b7-8691-5da50eaea7f4.png)


