### PR TITLE
fix(windows): specify required powershell version for the installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ To run the install script without any interaction you can pass the `-y` flag to 
 
 The same way, you can use `--no-install-dependencies` to skip the dependency installation.
 
-### Windows (Powershell):
+### Windows (Powershell 7+):
+
+Powershell v7+ is required for this script. For instructions on how to install, [click here.](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2)
 
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The default version of PowerShell installed on most people's computers is v5, however the script only works on v7+. It would be good to have some indicator of this in the readme. I edited the readme and included a link on how to install too.