### PR TITLE
docs(README): change forgotten breaking change in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- lvim.builtin.which_key.mappings["P"] = { "<cmd>Telescope projects<CR>", "Projects" }
 
 -- Configure builtin plugins
-lvim.builtin.dashboard.active = true
+lvim.builtin.alpha.active = true
 lvim.builtin.notify.active = true
 lvim.builtin.terminal.active = true
 


### PR DESCRIPTION
> See #1906  and the Note under the `Breaking changes` section in the README

Was probably forgotten in [here](https://github.com/LunarVim/LunarVim/commit/c946ddda812c5c2d217061a9016eb8001970d659)