### PR TITLE
fix(peek): print error if lsp is unable to get file contents

### DIFF
--- a/lua/lvim/lsp/peek.lua
+++ b/lua/lvim/lsp/peek.lua
@@ -32,6 +32,10 @@ local function create_floating_file(location, opts)
     math.min(range["end"].line + 1 + (opts.context or 10), range.start.line + (opts.max_height or 15)), -- Don't let the window be more that 15 lines long(height)
     false
   )
+  if next(contents) == nil then
+    print "peek: Unable to get contents of the file!"
+    return
+  end
   local width, height = vim.lsp.util._make_floating_popup_size(contents, opts)
   local if_nil = vim.F.if_nil
   opts = vim.lsp.util.make_floating_popup_options(if_nil(width, 30), if_nil(height, 10), opts)

--- a/lua/lvim/lsp/peek.lua
+++ b/lua/lvim/lsp/peek.lua
@@ -33,7 +33,7 @@ local function create_floating_file(location, opts)
     false
   )
   if next(contents) == nil then
-    print "peek: Unable to get contents of the file!"
+    vim.notify("peek: Unable to get contents of the file!", vim.log.levels.WARN)
     return
   end
   local width, height = vim.lsp.util._make_floating_popup_size(contents, opts)
@@ -86,7 +86,7 @@ function M.open_file()
   local filepath = vim.fn.expand "%:."
 
   if not filepath then
-    print "peek: Unable to open the file!"
+    vim.notify("peek: Unable to open the file!", vim.log.levels.ERROR)
     return
   end
 
@@ -119,7 +119,7 @@ function M.Peek(what)
   if vim.tbl_contains(vim.api.nvim_list_wins(), M.floating_win) then
     local success_1, _ = pcall(vim.api.nvim_set_current_win, M.floating_win)
     if not success_1 then
-      print "peek: You cannot edit the current file in a preview!"
+      vim.notify("peek: You cannot edit the current file in a preview!", vim.log.levels.ERROR)
       return
     end
 
@@ -139,8 +139,9 @@ function M.Peek(what)
     local preview_callback = preview_location_callback_new_signature
     local success, _ = pcall(vim.lsp.buf_request, 0, "textDocument/" .. what, params, preview_callback)
     if not success then
-      print(
-        'peek: Error calling LSP method "textDocument/' .. what .. '". The current language lsp might not support it.'
+      vim.notify(
+        'peek: Error calling LSP method "textDocument/' .. what .. '". The current language lsp might not support it.',
+        vim.log.levels.ERROR
       )
     end
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Print an error in case LSP is unable to get contents

Fixes #2369
