### PR TITLE
fix(terminal): weird lazygit commit message bug

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -93,7 +93,6 @@ M.add_exec = function(opts)
     return
   end
   wk.register({ [opts.keymap] = { opts.label } }, { mode = "n" })
-  wk.register({ [opts.keymap] = { opts.label } }, { mode = "t" })
 end
 
 M._exec_toggle = function(opts)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Basically if you use `<space>` as your leader and keep the removed line in this commit
you would face some weird behavior if you try to use lazygit commit message ( hitting `<space>c` and then using space in your commit message)

