### PR TITLE
[Feature]: Keyboard shortcut for quickfix in Telescope

### DIFF
--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -168,6 +168,7 @@ M.config = function()
           "<cmd>Telescope lsp_dynamic_workspace_symbols<cr>",
           "Workspace Symbols",
         },
+        e = { "<cmd>Telescope quickfix<cr>", "Telescope Quickfix" },
       },
       L = {
         name = "+LunarVim",


### PR DESCRIPTION
Lunarvim has keyboard shortcuts for various LSP searches, that feeds results to quickfix list.

It is useful then to have a quick way to inspect LSP results in quickfix via Telescope.

# Description

New keyboard shortcut for Telescope quickfix

See issue #1985

## How Has This Been Tested?

- Clicked `gr` on a symbol
- Pressed `Space l e` to see results in Telescope

