### PR TITLE
Fix lvim.colorscheme not work

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -99,6 +99,9 @@ function plugin_loader.load(configurations)
         end
       end
     end)
+    -- colorscheme must get called after plugins are loaded or it will break new installs.
+    vim.g.colors_name = lvim.colorscheme
+    vim.cmd("colorscheme " .. lvim.colorscheme)
   end, debug.traceback)
   if not status_ok then
     Log:warn "problems detected while loading plugins' configurations"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix `lvim.colorscheme` not set on lvim start.
