### PR TITLE
refactor(lsp): replace deprecated ocamllsp with ocamlls

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -78,7 +78,7 @@ return {
     "graphql",
     "jedi_language_server",
     "ltex",
-    "ocamllsp",
+    "ocamlls",
     "phpactor",
     "psalm",
     "pylsp",

--- a/tests/specs/lsp_spec.lua
+++ b/tests/specs/lsp_spec.lua
@@ -31,7 +31,7 @@ a.describe("lsp workflow", function()
     lvim.log.level = "debug"
 
     local plugins = require "lvim.plugins"
-    require("lvim.plugin-loader"):load { plugins, lvim.plugins }
+    require("lvim.plugin-loader").load { plugins, lvim.plugins }
 
     if utils.is_file(logfile) then
       assert.equal(vim.fn.delete(logfile), 0)
@@ -51,8 +51,9 @@ a.describe("lsp workflow", function()
     require("lvim.lsp").setup()
 
     for _, file in ipairs(vim.fn.glob(lvim.lsp.templates_dir .. "/*.lua", 1, 1)) do
-      for _, server in ipairs(lvim.lsp.override) do
-        assert.False(helpers.file_contains(file, server))
+      for _, server_name in ipairs(lvim.lsp.override) do
+        local setup_cmd = string.format([[require("lvim.lsp.manager").setup(%q)]], server_name)
+        assert.False(helpers.file_contains(file, setup_cmd))
       end
     end
   end)


### PR DESCRIPTION
# Description

In this MR https://github.com/LunarVim/LunarVim/pull/2304 "ocamllsp" was added to the lsp servers "override" list
Not long after, "ocamlls" have been deprecated in favor of "ocamllsp", see https://github.com/williamboman/nvim-lsp-installer/pull/498

## How Has This Been Tested?

I replaced it my lvim local copy and cleaned the cache