### PR TITLE
fix(installer/pwsh): fixes some details on installer and uninstaller

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -267,7 +267,7 @@ function create_alias {
         return
     }
 
-    Add-Content -Path $PROFILE -Value $("Set-Alias lvim $lvim_bin")
+    Add-Content -Path $PROFILE -Value $("`r`nSet-Alias lvim $lvim_bin")
 
     Write-Host 'To use the new alias in this window reload your profile with: `. $PROFILE`' -ForegroundColor Green
 }

--- a/utils/installer/uninstall.ps1
+++ b/utils/installer/uninstall.ps1
@@ -49,9 +49,15 @@ function remove_lvim_dirs($force) {
         if (Test-Path $dir) {
             Remove-Item -Force -Recurse $dir
         }
-        if ($force -eq $true -and (Test-Path "$dir.bak" -or Test-Path "$dir.old")) {
-            Remove-Item -Force -Recurse "$dir.{bak,old}"
+        if ($force -eq $true) {
+            if (Test-Path "$dir.bak") {
+                Remove-Item -Force -Recurse "$dir.bak"
+            }
+            if (Test-Path "$dir.old") {
+                Remove-Item -Force -Recurse "$dir.old"
+            }
         }
     }
 }
 
+main($args)


### PR DESCRIPTION
### Description

This PR fixes and issue that prevents a new line to be correctly added on the Powershell `$Profile` file to set the lvim alias.

This also fixes and issue that prevents the execution of the `uninstall.ps1` script. It was lacking the call to the `main` function. It also fixes some issues when trying to parse the cli args, and also when trying to test some of the old folders to be removed.

## Test process

This was tested on a local install of LunarVim, in a Windows 11 machine with the latest version of Powershell installed.