### PR TITLE
refactor: re-enable packer.sync() in LvimReload

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -124,18 +124,20 @@ end
 --- Override the configuration with a user provided one
 -- @param config_path The path to the configuration overrides
 function M:reload()
-  require_clean("lvim.utils.hooks").run_pre_reload()
+  vim.schedule(function()
+    require_clean("lvim.utils.hooks").run_pre_reload()
 
-  M:init()
-  M:load()
+    M:init()
+    M:load()
 
-  require("lvim.core.autocmds").configure_format_on_save()
+    require("lvim.core.autocmds").configure_format_on_save()
 
-  local plugins = require "lvim.plugins"
-  local plugin_loader = require "lvim.plugin-loader"
+    local plugins = require "lvim.plugins"
+    local plugin_loader = require "lvim.plugin-loader"
 
-  plugin_loader.load { plugins, lvim.plugins }
-  require_clean("lvim.utils.hooks").run_post_reload()
+    plugin_loader.reload { plugins, lvim.plugins }
+    require_clean("lvim.utils.hooks").run_post_reload()
+  end)
 end
 
 return M

--- a/lua/lvim/core/info.lua
+++ b/lua/lvim/core/info.lua
@@ -120,7 +120,7 @@ local function make_override_info(ft)
 end
 
 function M.toggle_popup(ft)
-  local clients = vim.lsp.get_active_clients(ft)
+  local clients = vim.lsp.get_active_clients()
   local client_names = {}
   local bufnr = vim.api.nvim_get_current_buf()
   local ts_active_buffers = vim.tbl_keys(vim.treesitter.highlighter.active)

--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -19,6 +19,9 @@ function Log:init()
     return nil
   end
 
+  package.loaded["packer.log"] = nil
+  require("packer.log").new { level = lvim.log.level }
+
   local log_level = Log.levels[(lvim.log.level):upper() or "WARN"]
   local lvim_log = {
     lvim = {

--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -2,7 +2,7 @@ local opts = {
   settings = {
     Lua = {
       diagnostics = {
-        globals = { "vim", "lvim" },
+        globals = { "vim", "lvim", "packer_plugins" },
       },
       workspace = {
         library = {

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -23,10 +23,6 @@ function plugin_loader.init(opts)
     log = { level = "warn" },
     git = {
       clone_timeout = 300,
-      subcommands = {
-        -- this is more efficient than what Packer is using
-        fetch = "fetch --no-tags --no-recurse-submodules --update-shallow --progress",
-      },
     },
     display = {
       open_fn = function()

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -40,8 +40,6 @@ function plugin_loader.init(opts)
 
     -- NOTE: `lvim.log.level` may not be loaded from the user's config yet
     init_opts.log.level = lvim.log and lvim.log.level or "info"
-  else
-    vim.cmd [[autocmd User PackerComplete lua require('lvim.utils.hooks').run_on_packer_complete()]]
   end
 
   if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
@@ -54,6 +52,9 @@ function plugin_loader.init(opts)
 
   local status_ok, packer = pcall(require, "packer")
   if status_ok then
+    packer.on_complete = vim.schedule_wrap(function()
+      require("lvim.utils.hooks").run_on_packer_complete()
+    end)
     packer.init(init_opts)
   end
 end
@@ -81,6 +82,18 @@ function plugin_loader.recompile()
   if utils.is_file(compile_path) then
     Log:debug "generated packer_compiled.lua"
   end
+end
+
+function plugin_loader.reload(configurations)
+  _G.packer_plugins = _G.packer_plugins or {}
+  for k, v in pairs(_G.packer_plugins) do
+    if k ~= "packer.nvim" then
+      _G.packer_plugins[v] = nil
+    end
+  end
+  plugin_loader.load(configurations)
+
+  pcall_packer_command "sync"
 end
 
 function plugin_loader.load(configurations)
@@ -120,31 +133,20 @@ function plugin_loader.get_core_plugins()
   return list
 end
 
-function plugin_loader.sync_core_plugins(opts)
-  opts = opts or {}
-  Log:debug(string.format("Syncing core plugins with snapshot file [%s]", default_snapshot))
-  local packer = require "packer"
-  local a = require "packer.async"
-  local async = a.sync
-  local await = a.wait
-  local main = a.main
+function plugin_loader.load_snapshot(snapshot_file)
+  snapshot_file = snapshot_file or default_snapshot
+  vim.notify("Syncing core plugins is in progress..", vim.log.levels.INFO, { title = "lvim" })
+  Log:debug(string.format("Using snapshot file [%s]", snapshot_file))
   local core_plugins = plugin_loader.get_core_plugins()
-  async(function()
-    await(packer.rollback(default_snapshot, unpack(core_plugins)))
-      :map_ok(function(ok) --NOTE: these may not be doing anything, use PackerComplete for now
-        await(main)
-        Log:debug(string.format("Rollback snapshot file [%s] completed", default_snapshot))
-        if next(ok.failed) then
-          Log:warn(string.format("Couldn't rollback %s", vim.inspect(ok.failed)))
-        end
-        pcall(opts.on_complete, ok)
-      end)
-      :map_err(function(err)
-        await(main)
-        Log:error(err)
-        pcall(opts.on_error, err)
-      end)
-  end)()
+  require("packer").rollback(snapshot_file, unpack(core_plugins))
+end
+
+function plugin_loader.sync_core_plugins()
+  -- problem: rollback() will get stuck if a plugin directory doesn't exist
+  -- solution: call sync() beforehand
+  -- see https://github.com/wbthomason/packer.nvim/issues/862
+  vim.cmd [[autocmd User PackerComplete ++once lua require("lvim.plugin-loader").load_snapshot() ]]
+  pcall_packer_command "sync"
 end
 
 return plugin_loader

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -3,6 +3,7 @@ local plugin_loader = {}
 local utils = require "lvim.utils"
 local Log = require "lvim.core.log"
 local join_paths = utils.join_paths
+local in_headless = #vim.api.nvim_list_uis() == 0
 
 -- we need to reuse this outside of init()
 local compile_path = join_paths(get_config_dir(), "plugin", "packer_compiled.lua")
@@ -34,7 +35,6 @@ function plugin_loader.init(opts)
     },
   }
 
-  local in_headless = #vim.api.nvim_list_uis() == 0
   if in_headless then
     init_opts.display = nil
 
@@ -135,7 +135,9 @@ end
 
 function plugin_loader.load_snapshot(snapshot_file)
   snapshot_file = snapshot_file or default_snapshot
-  vim.notify("Syncing core plugins is in progress..", vim.log.levels.INFO, { title = "lvim" })
+  if not in_headless then
+    vim.notify("Syncing core plugins is in progress..", vim.log.levels.INFO, { title = "lvim" })
+  end
   Log:debug(string.format("Using snapshot file [%s]", snapshot_file))
   local core_plugins = plugin_loader.get_core_plugins()
   require("packer").rollback(snapshot_file, unpack(core_plugins))

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -33,9 +33,6 @@ function plugin_loader.init(opts)
 
   if in_headless then
     init_opts.display = nil
-
-    -- NOTE: `lvim.log.level` may not be loaded from the user's config yet
-    init_opts.log.level = lvim.log and lvim.log.level or "info"
   end
 
   if vim.fn.empty(vim.fn.glob(install_path)) > 0 then

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -13,8 +13,12 @@ local core_plugins = {
   {
     "lunarvim/onedarker.nvim",
     config = function()
-      require("onedarker").setup()
-      lvim.builtin.lualine.options.theme = "onedarker"
+      pcall(function()
+        if lvim and lvim.colorscheme == "onedarker" then
+          require("onedarker").setup()
+          lvim.builtin.lualine.options.theme = "onedarker"
+        end
+      end)
     end,
     disable = lvim.colorscheme ~= "onedarker",
   },

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -12,25 +12,22 @@ function M.run_pre_reload()
 end
 
 function M.run_on_packer_complete()
-  vim.schedule(function()
-    if not in_headless then
-      -- colorscheme must get called after plugins are loaded or it will break new installs.
-      vim.g.colors_name = lvim.colorscheme
-      vim.cmd("colorscheme " .. lvim.colorscheme)
-    else
-      Log:debug "Packer operation complete"
-    end
-  end)
+  Log:debug "Packer operation complete"
+  vim.cmd [[doautocmd User PackerComplete]]
+
+  -- NOTE: disabled for now, but might be needed again..
+  -- vim.cmd [[doautocmd ColorScheme]]
+
+  if M._reload_triggered then
+    Log:info "Reloaded configuration"
+    M._reload_triggered = nil
+  end
 end
 
 function M.run_post_reload()
   Log:debug "Starting post-reload hook"
   M.reset_cache()
-  vim.schedule(function()
-    if not in_headless then
-      Log:info "Reloaded configuration"
-    end
-  end)
+  M._reload_triggered = true
 end
 
 ---Reset any startup cache files used by Packer and Impatient

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -15,8 +15,8 @@ function M.run_on_packer_complete()
   Log:debug "Packer operation complete"
   vim.cmd [[doautocmd User PackerComplete]]
 
-  -- NOTE: disabled for now, but might be needed again..
-  -- vim.cmd [[doautocmd ColorScheme]]
+  vim.g.colors_name = lvim.colorscheme
+  pcall(vim.cmd, "colorscheme " .. lvim.colorscheme)
 
   if M._reload_triggered then
     Log:info "Reloaded configuration"

--- a/tests/specs/config_loader_spec.lua
+++ b/tests/specs/config_loader_spec.lua
@@ -21,25 +21,31 @@ a.describe("config-loader", function()
     local test_path = "/tmp/lvim"
     os.execute(string.format([[echo "vim.opt.undodir = '%s'" >> %s]], test_path, user_config_path))
     config:reload()
-    assert.equal(vim.opt.undodir:get()[1], test_path)
+    vim.schedule(function()
+      assert.equal(vim.opt.undodir:get()[1], test_path)
+    end)
   end)
 
   a.it("should not get interrupted by errors in user-config", function()
     local test_path = "/tmp/lunarvim"
     os.execute(string.format([[echo "vim.opt.undodir = '%s'" >> %s]], test_path, user_config_path))
     config:reload()
-    assert.equal(vim.opt.undodir:get()[1], test_path)
+    vim.schedule(function()
+      assert.equal(vim.opt.undodir:get()[1], test_path)
+    end)
     os.execute(string.format("echo 'bad_string_test' >> %s", user_config_path))
     local error_handler = function(msg)
       return msg
     end
     local err = xpcall(config:reload(), error_handler)
     assert.falsy(err)
-    assert.equal(vim.opt.undodir:get()[1], test_path)
-    local errmsg = vim.fn.eval "v:errmsg"
-    local exception = vim.fn.eval "v:exception"
-    assert.equal("", errmsg) -- v:errmsg was not updated.
-    assert.equal("", exception)
-    os.execute(string.format("echo '' > %s", user_config_path))
+    vim.schedule(function()
+      assert.equal(vim.opt.undodir:get()[1], test_path)
+      local errmsg = vim.fn.eval "v:errmsg"
+      local exception = vim.fn.eval "v:exception"
+      assert.equal("", errmsg) -- v:errmsg was not updated.
+      assert.equal("", exception)
+      os.execute(string.format("echo '' > %s", user_config_path))
+    end)
   end)
 end)

--- a/tests/specs/plugins_load_spec.lua
+++ b/tests/specs/plugins_load_spec.lua
@@ -57,8 +57,8 @@ a.describe("plugin-loader", function()
         _G.completed = true
       end
     end
-    vim.cmd [[autocmd User PackerComplete lua _G.verify_sha()]]
-    loader.sync_core_plugins()
+    vim.cmd [[autocmd User PackerComplete ++once lua _G.verify_sha()]]
+    loader.load_snapshot()
     local ret = vim.wait(30 * 10 * 1000, function()
       return _G.completed == true
     end, 200)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- refactor: re-enable `packer.sync()` in `LvimReload` (was removed earlier for being too unstable)
- perf: remove `LvimSyncCorePlugins` from always getting called in `LvimReload` (too slow)
- fix: handle missing plugins in `LvimSyncCorePlugins` (`packer.rollack()` is currently getting stuck if a plugin doesn't exist)
- fix: wrap `LvimReload` with `vim.schedule()` to fix a data-race condition on `BufWritePost` (probably something new with nvim-tree)
- fix: override packer's log level correctly

Fixes #2408

## How Has This Been Tested?

A restart of lvim is probably still required tho

```lua
lvim.colorscheme = "tokyonight"
table.insert(lvim.plugins, {
  "folke/tokyonight.nvim",
})
```
