### PR TITLE
fix: update deprecated methods in example configuration for trouble.nvim

### DIFF
--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -46,10 +46,10 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 --   name = "+Trouble",
 --   r = { "<cmd>Trouble lsp_references<cr>", "References" },
 --   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
---   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnostics" },
+--   d = { "<cmd>Trouble document_diagnostics<cr>", "Diagnostics" },
 --   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
 --   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
---   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnostics" },
+--   w = { "<cmd>Trouble workspace_diagnostics<cr>", "Diagnostics" },
 -- }
 
 -- TODO: User Config for predefined plugins

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -49,7 +49,7 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 --   d = { "<cmd>Trouble document_diagnostics<cr>", "Diagnostics" },
 --   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
 --   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
---   w = { "<cmd>Trouble workspace_diagnostics<cr>", "Diagnostics" },
+--   w = { "<cmd>Trouble workspace_diagnostics<cr>", "Wordspace Diagnostics" },
 -- }
 
 -- TODO: User Config for predefined plugins

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -63,10 +63,10 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 --   name = "+Trouble",
 --   r = { "<cmd>Trouble lsp_references<cr>", "References" },
 --   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
---   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnostics" },
+--   d = { "<cmd>Trouble document_diagnostics<cr>", "Diagnostics" },
 --   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
 --   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
---   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnostics" },
+--   w = { "<cmd>Trouble workspace_diagnostics<cr>", "Diagnostics" },
 -- }
 
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -66,7 +66,7 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 --   d = { "<cmd>Trouble document_diagnostics<cr>", "Diagnostics" },
 --   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
 --   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
---   w = { "<cmd>Trouble workspace_diagnostics<cr>", "Diagnostics" },
+--   w = { "<cmd>Trouble workspace_diagnostics<cr>", "Workspace Diagnostics" },
 -- }
 
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile


### PR DESCRIPTION
# Description

Fixes warnings caused by the use of lsp deprecated diagnostics methods, for document and workspace:
- lsp_document_diagnostics
- lsp_workspace_diagnostics


## How Has This Been Tested?

Warnings are displayed if `trouble document diagnostics` and `trouble workspace diagnostics` keyboard mappings suggested in the `config.example.lua` or `config_win.example.lua` are used.

<img width="849" alt="Screenshot 2022-04-02 at 11 12 14" src="https://user-images.githubusercontent.com/13467494/161377245-28085fab-ba72-4a53-b8bd-43e55bbf105c.png">
<img width="842" alt="Screenshot 2022-04-02 at 11 07 53" src="https://user-images.githubusercontent.com/13467494/161377246-80a52147-7749-49a1-abbf-926099a853e3.png">


