### PR TITLE
[Feature] Add option to set maximum cmp menu width

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -170,6 +170,7 @@ M.config = function()
     },
     formatting = {
       fields = { "kind", "abbr", "menu" },
+      max_width = 0,
       kind_icons = {
         Class = " ",
         Color = " ",
@@ -215,6 +216,10 @@ M.config = function()
       },
       duplicates_default = 0,
       format = function(entry, vim_item)
+        local max_width = lvim.builtin.cmp.formatting.max_width
+        if max_width ~= 0 and #vim_item.abbr > max_width then
+          vim_item.abbr = string.sub(vim_item.abbr, 1, max_width - 1) .. "…"
+        end
         vim_item.kind = lvim.builtin.cmp.formatting.kind_icons[vim_item.kind]
         vim_item.menu = lvim.builtin.cmp.formatting.source_names[entry.source.name]
         vim_item.dup = lvim.builtin.cmp.formatting.duplicates[entry.source.name]

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -91,6 +91,7 @@ return {
     "solidity_ls",
     "sorbet",
     "sourcekit",
+    "sourcery",
     "spectral",
     "sqlls",
     "sqls",


### PR DESCRIPTION
# Description
Now users can limit cmp menu width. Sometimes it looks too large when completion entries are too long.


## How Has This Been Tested?
To limit menu width put this line in `config.lua`:
``` lua
lvim.builtin.cmp.formatting.max_width = 50
```
where `50` is the number of columns that aren't exceeded.