### PR TITLE
feat(luasnip):  lazy-load all user snippets by default

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -70,6 +70,8 @@ local core_plugins = {
     "L3MON4D3/LuaSnip",
     config = function()
       require("luasnip/loaders/from_vscode").lazy_load()
+      require("luasnip/loaders/from_snipmate").lazy_load()
+
     end,
   },
   {

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -69,9 +69,15 @@ local core_plugins = {
   {
     "L3MON4D3/LuaSnip",
     config = function()
-      require("luasnip/loaders/from_vscode").lazy_load()
-      require("luasnip/loaders/from_snipmate").lazy_load()
-
+      local utils = require "lvim.utils"
+      require("luasnip.loaders.from_lua").lazy_load()
+      require("luasnip.loaders.from_vscode").lazy_load {
+        paths = {
+          utils.join_paths(get_config_dir(), "snippets"),
+          utils.join_paths(get_runtime_dir(), "site", "pack", "packer", "start", "friendly-snippets"),
+        },
+      }
+      require("luasnip.loaders.from_snipmate").lazy_load()
     end,
   },
   {


### PR DESCRIPTION
just add snipmate loading, so users don't have to add it to their own config.lua

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Just call the function to load snipmate snippets

## How Has This Been Tested?

I use it in my own config


