### PR TITLE
fix(impatient): avoid get_options in fast handler

### DIFF
--- a/lua/lvim/impatient.lua
+++ b/lua/lvim/impatient.lua
@@ -203,6 +203,10 @@ function M.update_reduced_rtp()
 end
 
 local function load_package_with_cache_reduced_rtp(name)
+  if vim.in_fast_event() then
+    -- Can't set/get options in the fast handler
+    return load_package_with_cache(name, "fast")
+  end
   local orig_rtp = get_option "runtimepath"
   local orig_ei = get_option "eventignore"
 

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -190,6 +190,7 @@ local core_plugins = {
     config = function()
       require("lvim.core.bufferline").setup()
     end,
+    branch = "main",
     event = "BufWinEnter",
     disable = not lvim.builtin.bufferline.active,
   },
@@ -225,6 +226,7 @@ local core_plugins = {
   {
     "akinsho/toggleterm.nvim",
     event = "BufWinEnter",
+    branch = "main",
     config = function()
       require("lvim.core.terminal").setup()
     end,

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -15,7 +15,7 @@
     "commit": "6655228"
   },
   "bufferline.nvim": {
-    "commit": "e62008f"
+    "commit": "bb3ac30"
   },
   "cmp-buffer": {
     "commit": "d66c4c2"
@@ -33,7 +33,7 @@
     "commit": "e302658"
   },
   "gitsigns.nvim": {
-    "commit": "4a68d2a"
+    "commit": "ac5ba87"
   },
   "lua-dev.nvim": {
     "commit": "a0ee777"
@@ -42,13 +42,13 @@
     "commit": "c8e5a69"
   },
   "nlsp-settings.nvim": {
-    "commit": "956c8ad"
+    "commit": "c4afb0f"
   },
   "null-ls.nvim": {
     "commit": "82be4bf"
   },
   "nvim-autopairs": {
-    "commit": "06535b1"
+    "commit": "6fb0479"
   },
   "nvim-cmp": {
     "commit": "3192a0c"
@@ -57,19 +57,19 @@
     "commit": "10b5781"
   },
   "nvim-lsp-installer": {
-    "commit": "a6c2783"
+    "commit": "88f590c"
   },
   "nvim-lspconfig": {
     "commit": "fd7843a"
   },
   "nvim-notify": {
-    "commit": "0d02acf"
+    "commit": "9655936"
   },
   "nvim-tree.lua": {
-    "commit": "6e0e70b"
+    "commit": "9c272b9"
   },
   "nvim-treesitter": {
-    "commit": "d79b169"
+    "commit": "d0fc684"
   },
   "nvim-ts-context-commentstring": {
     "commit": "8834375"
@@ -105,7 +105,7 @@
     "commit": "b7ae91c"
   },
   "toggleterm.nvim": {
-    "commit": "e62008f"
+    "commit": "1a608cc"
   },
   "which-key.nvim": {
     "commit": "a3c19ec"


### PR DESCRIPTION
- chore: bump plugins version
- fix(impatient): avoid get_options in fast handler

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Ported an upstream patch https://github.com/lewis6991/impatient.nvim/commit/c9a54d16776549d8fa6fc49bf5b191f14aab22c3

Fixes #2450
