### PR TITLE
docs(windows): use lvim.builtin.alpha in config_win.example.lua

### DIFF
--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -70,7 +70,8 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- }
 
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile
-lvim.builtin.dashboard.active = true
+lvim.builtin.alpha.active = true
+lvim.builtin.alpha.mode = "dashboard"
 lvim.builtin.notify.active = true
 lvim.builtin.terminal.active = false
 -- lvim.builtin.terminal.shell = "pwsh.exe -NoLogo"


### PR DESCRIPTION
# Description
Avoid the deprecation warning upon installation by changing lvim.builtin.dashboard to lvim.builtin.alpha, following the changes to config.example.lua

## How Has This Been Tested?
Relaunch Lunarvim, deprecation message is gone.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
