### PR TITLE
feat(cmp): `documentation` is deprecated in favor of `window.documentation`

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -232,8 +232,9 @@ M.config = function()
         require("luasnip").lsp_expand(args.body)
       end,
     },
-    documentation = {
-      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    window = {
+      completion = cmp.config.window.bordered(),
+      documentation = cmp.config.window.bordered(),
     },
     sources = {
       { name = "nvim_lsp" },

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -51,7 +51,7 @@
     "commit": "6fb0479"
   },
   "nvim-cmp": {
-    "commit": "3192a0c"
+    "commit": "dbc7229"
   },
   "nvim-dap": {
     "commit": "10b5781"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Make sure we are using the latest cmp changes
also gets rid of this error message
<img width="496" alt="Screen Shot 2022-04-14 at 2 03 27 AM" src="https://user-images.githubusercontent.com/10992695/163274173-d6a1a425-67bc-4a6e-ac6b-d4aff97a8aab.png">
