### PR TITLE
fix(lualine): color theme gaps in some components

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -29,7 +29,6 @@ return {
   },
   filename = {
     "filename",
-    color = {},
     cond = nil,
   },
   diff = {
@@ -41,7 +40,6 @@ return {
       modified = { fg = colors.yellow },
       removed = { fg = colors.red },
     },
-    color = {},
     cond = nil,
   },
   python_env = {
@@ -67,7 +65,6 @@ return {
     "diagnostics",
     sources = { "nvim_diagnostic" },
     symbols = { error = " ", warn = " ", info = " ", hint = " " },
-    color = {},
     cond = conditions.hide_in_width,
   },
   treesitter = {

--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -29,6 +29,7 @@ return {
   },
   filename = {
     "filename",
+    color = {},
     cond = nil,
   },
   diff = {
@@ -136,7 +137,7 @@ return {
     color = {},
     cond = conditions.hide_in_width,
   },
-  filetype = { "filetype", cond = conditions.hide_in_width, color = {} },
+  filetype = { "filetype", cond = conditions.hide_in_width },
   scrollbar = {
     function()
       local current_line = vim.fn.line "."


### PR DESCRIPTION
# Description
Fix some components on lualine with color theme gaps (diff, filetype, diagnostics)

Fixes #2403

## How Has This Been Tested?
Check if the "diff", "filetype" and "diagnostics" components on lualine respect the current theme.
