### PR TITLE
fix(luasnip-cmp):<CR> removes default snip

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -302,7 +302,10 @@ M.config = function()
         else
           fallback()
         end
-      end),
+      end, {
+        "i",
+        "s",
+      }),
     },
   }
 end


### PR DESCRIPTION
# Description

- <Tab> skips default value inside snippet if nothing is typed.
- <CR> mapping does not behave as <Tab>, it deletes default value of snippet if it is skipped. Set <CR> to behave same as <Tab>.



