### PR TITLE
fix(luasnip-cmp): <CR> removes default snip

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -302,7 +302,10 @@ M.config = function()
         else
           fallback()
         end
-      end),
+      end, {
+        "i",
+        "s",
+      }),
     },
   }
 end


### PR DESCRIPTION
# Description

- Tab mapping in luasnip skippes default value if nothing is typed.
- CR mapping does not behave same way. It deletes default value of snippet if nothing is entered. Make CR to behave same way as Tab.



