### PR TITLE
fix(installer): latest and specified release version for neovim have different urls

### DIFF
--- a/utils/installer/install-neovim-from-release
+++ b/utils/installer/install-neovim-from-release
@@ -23,7 +23,11 @@ else
   exit 1
 fi
 
-declare -r RELEASE_URL="https://github.com/neovim/neovim/releases/$RELEASE_VER/download/$ARCHIVE_NAME.tar.gz"
+if [[ "${RELEASE_VER}" == "latest" ]]; then
+  declare -r RELEASE_URL="https://github.com/neovim/neovim/releases/${RELEASE_VER}/download/${ARCHIVE_NAME}.tar.gz"
+else
+  declare -r RELEASE_URL="https://github.com/neovim/neovim/releases/download/${RELEASE_VER}/${ARCHIVE_NAME}.tar.gz"
+fi
 declare -r CHECKSUM_URL="$RELEASE_URL.sha256sum"
 
 DOWNLOAD_DIR="$(mktemp -d)"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

the URL used to download neovim are different if a version is specified vs if we leave it to default to the latest build.

Fixes #(issue)

## How Has This Been Tested?

This script has been tested as follows:

RELEASE_VER=v0.6.1 bash /scripts/install-neovim-from-release
bash /scripts/install-neovim-from-release

and the nvim version verified after the installation.
