### PR TITLE
feat: lock nvim <0.7 to a specific tag

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-if vim.fn.has "nvim-0.6.1" ~= 1 then
-  vim.notify("Please upgrade your Neovim base installation. Lunarvim requires v0.6.1+", vim.log.levels.WARN)
+if vim.fn.has "nvim-0.7" ~= 1 then
+  vim.notify("Please upgrade your Neovim base installation. Lunarvim requires v0.7+", vim.log.levels.WARN)
   vim.wait(5000, function()
     return false
   end)
@@ -115,8 +115,10 @@ end
 ---pulls the latest changes from github and, resets the startup cache
 function M:update()
   require_clean("lvim.utils.hooks").run_pre_update()
-  require_clean("lvim.utils.git").update_base_lvim()
-  require_clean("lvim.utils.hooks").run_post_update()
+  local ret = require_clean("lvim.utils.git").update_base_lvim()
+  if ret then
+    require_clean("lvim.utils.hooks").run_post_update()
+  end
 end
 
 return M

--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -72,6 +72,8 @@ function M.update_base_lvim()
     Log:error "Update failed! Please pull the changes manually instead."
     return
   end
+
+  return true
 end
 
 ---Switch Lunarvim to the specified development branch
@@ -80,11 +82,19 @@ function M.switch_lvim_branch(branch)
   if not safe_deep_fetch() then
     return
   end
-  local ret = git_cmd { args = { "switch", branch } }
+  local args = { "switch", branch }
+
+  if branch:match "^[0-9]" then
+    -- avoids producing an error for tags
+    vim.list_extend(args, { "--detach" })
+  end
+
+  local ret = git_cmd { args = args }
   if ret ~= 0 then
     Log:error "Unable to switch branches! Check the log for further information"
     return
   end
+  return true
 end
 
 ---Get the current Lunarvim development branch

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -51,6 +51,23 @@ end
 
 function M.run_post_update()
   Log:debug "Starting post-update hook"
+
+  if vim.fn.has "nvim-0.7" ~= 1 then
+    local compat_tag = "1.1.3"
+    vim.notify(
+      "Please upgrade your Neovim base installation. Newer version of Lunarvim requires v0.7+",
+      vim.log.levels.WARN
+    )
+    vim.wait(1000, function()
+      return false
+    end)
+    local ret = require_clean("lvim.utils.git").switch_lvim_branch(compat_tag)
+    if ret then
+      vim.notify("Reverted to the last known compatibile version: " .. compat_tag, vim.log.levels.WARN)
+    end
+    return
+  end
+
   M.reset_cache()
 
   Log:debug "Syncing core plugins"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- require v0.7+ for starting lunarvim (prevent issues with manual update)
- running `:LvimUpdate` when using a neovim <0.7 should switch to the tag `1.1.3` automatically and print a warning message 

Related #2476

## How Has This Been Tested?

- startup requirement: modify `~/.local/bin/lvim` to use a `nvim-0.6.1` appimage
- `LvimUpdate`: see https://github.com/LunarVim/LunarVim/issues/2476#issuecomment-1100859112

