### PR TITLE
feat(peek): make sure max width and height are customizable

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -78,6 +78,11 @@ return {
     style = "minimal",
     border = "rounded",
   },
+  peek = {
+    max_height = 15,
+    max_width = 30,
+    context = 10,
+  },
   on_attach_callback = nil,
   on_init_callback = nil,
   automatic_servers_installation = true,

--- a/lua/lvim/lsp/peek.lua
+++ b/lua/lvim/lsp/peek.lua
@@ -29,7 +29,10 @@ local function create_floating_file(location, opts)
   local contents = vim.api.nvim_buf_get_lines(
     bufnr,
     range.start.line,
-    math.min(range["end"].line + 1 + (opts.context or 10), range.start.line + (opts.max_height or 15)), -- Don't let the window be more that 15 lines long(height)
+    math.min(
+      range["end"].line + 1 + (opts.context or lvim.lsp.peek.max_height),
+      range.start.line + (opts.max_height or lvim.lsp.peek.max_height)
+    ),
     false
   )
   if next(contents) == nil then
@@ -38,7 +41,11 @@ local function create_floating_file(location, opts)
   end
   local width, height = vim.lsp.util._make_floating_popup_size(contents, opts)
   local if_nil = vim.F.if_nil
-  opts = vim.lsp.util.make_floating_popup_options(if_nil(width, 30), if_nil(height, 10), opts)
+  opts = vim.lsp.util.make_floating_popup_options(
+    if_nil(width, lvim.lsp.peek.max_width),
+    if_nil(height, lvim.lsp.peek.max_height),
+    opts
+  )
   -- Don't make it minimal as it is meant to be fully featured
   opts["style"] = nil
 
@@ -65,7 +72,7 @@ local function preview_location_callback(result)
 
   local opts = {
     border = "rounded",
-    context = 10,
+    context = lvim.lsp.peek.context,
   }
 
   if vim.tbl_islist(result) then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes #2489 

@danielo515 can you check if this helps you?
you can customize it using
```lua
lvim.lsp.peek.max_height = 15
lvim.lsp.peek.max_width = 30
lvim.lsp.peek.context = 10
```