### PR TITLE
fix(nvimtree): escape the dot character in custom filter

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -68,7 +68,7 @@ function M.config()
       },
       filters = {
         dotfiles = false,
-        custom = { "node_modules", ".cache" },
+        custom = { "node_modules", "\\.cache" },
       },
       trash = {
         cmd = "trash",


### PR DESCRIPTION

# Description

The nvimtree custom filter is a list of vim regex https://github.com/kyazdani42/nvim-tree.lua/blob/0f0f858348aacc94f98ba32880760c5a5440b825/doc/nvim-tree-lua.txt#L453-L457

Escaping the dot character avoids to filter filenames like "acache", "icache" etc



