### PR TITLE
fix(lsp): create a proper way of removing items from skipped_servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ lvim.lsp.diagnostics.virtual_text = false
 -- See the full default list `:lua print(vim.inspect(lvim.lsp.override))`
 vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "pyright" })
 
+-- remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
+-- LvimInfo` lists which server(s) are skiipped for the current filetype
+local tbl = require "lvim.utils.table"
+tbl.remove(lvim.lsp.automatic_configuration.skipped_servers, "tailwindcss")
+
 -- set a formatter, this will override the language server formatting capabilities (if it exists)
 local formatters = require "lvim.lsp.null-ls.formatters"
 formatters.setup {

--- a/lua/lvim/utils/table.lua
+++ b/lua/lvim/utils/table.lua
@@ -21,4 +21,18 @@ function Table.contains(t, predicate)
   return Table.find_first(t, predicate) ~= nil
 end
 
+-- Remove item from table by it's value
+-- @param t The table
+-- @param value The item to remove
+-- @return True if item was removed, false otherwise
+function Table.remove(t, value)
+  for i, v in ipairs(t) do
+    if v == value then
+      table.remove(t, i)
+      return true
+    end
+  end
+  return false
+end
+
 return Table

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -93,9 +93,8 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
 -- ---`:LvimInfo` lists which server(s) are skiipped for the current filetype
--- vim.tbl_map(function(server)
---   return server ~= "emmet_ls"
--- end, lvim.lsp.automatic_configuration.skipped_servers)
+-- local tbl = require "lvim.utils.table"
+-- tbl.remove(lvim.lsp.automatic_configuration.skipped_servers, "emmet_ls")
 
 -- -- you can set a custom on_attach function that will be used for all the language servers
 -- -- See <https://github.com/neovim/nvim-lspconfig#keybindings-and-completion>

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -108,9 +108,8 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
 -- ---`:LvimInfo` lists which server(s) are skiipped for the current filetype
--- vim.tbl_map(function(server)
---   return server ~= "emmet_ls"
--- end, lvim.lsp.automatic_configuration.skipped_servers)
+-- local tbl = require "lvim.utils.table"
+-- tbl.remove(lvim.lsp.automatic_configuration.skipped_servers, "emmet_ls")
 
 -- -- you can set a custom on_attach function that will be used for all the language servers
 -- -- See <https://github.com/neovim/nvim-lspconfig#keybindings-and-completion>


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`vim.tbl_map` is unreliable (especially on mac), so just provide a simple function to remove item from map

for example you can add this to your `config.lua`
```lua
local tbl = require "lvim.utils.table"
tbl.remove(lvim.lsp.automatic_configuration.skipped_servers, "tailwindcss")
```

Fixes #2501