### PR TITLE
feat(installer): ensure correct responses when prompting user

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -85,6 +85,25 @@ function msg() {
   printf "%s\n" "$text"
 }
 
+function confirm() {
+  local question="$1"
+  while true; do
+    msg "$question"
+    read -p "[y]es or [n]o (default: no) : " -r answer
+    case "$answer" in
+      y | Y | yes | YES | Yes)
+        return 0
+        ;;
+      n | N | no | NO | No | *[[:blank:]]* | "")
+        return 1
+        ;;
+      *)
+        msg "Please answer [y]es or [n]o."
+        ;;
+    esac
+  done
+}
+
 function main() {
   parse_arguments "$@"
 
@@ -97,17 +116,15 @@ function main() {
 
   if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
     if [ "$INTERACTIVE_MODE" -eq 1 ]; then
-      msg "Would you like to install LunarVim's NodeJS dependencies?"
-      read -p "[y]es or [n]o (default: no) : " -r answer
-      [ "$answer" != "${answer#[Yy]}" ] && install_nodejs_deps
-
-      msg "Would you like to install LunarVim's Python dependencies?"
-      read -p "[y]es or [n]o (default: no) : " -r answer
-      [ "$answer" != "${answer#[Yy]}" ] && install_python_deps
-
-      msg "Would you like to install LunarVim's Rust dependencies?"
-      read -p "[y]es or [n]o (default: no) : " -r answer
-      [ "$answer" != "${answer#[Yy]}" ] && install_rust_deps
+      if confirm "Would you like to install LunarVim's NodeJS dependencies?"; then
+        install_nodejs_deps
+      fi
+      if confirm "Would you like to install LunarVim's Python dependencies?"; then
+        install_python_deps
+      fi
+      if confirm "Would you like to install LunarVim's Rust dependencies?"; then
+        install_rust_deps
+      fi
     else
       install_nodejs_deps
       install_python_deps


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This makes sure users provide an acceptable answer when being prompted to confirm an action. I was installing LunarVim and accidentally answered `u` instead of `y` to a question, and the script interpreted it as a no and skipped the step.

Figured I'd just create a PR immediately, wdyt? Didn't touch the powershell script because that's scary.

## How Has This Been Tested?

I've ran the install script from my branch directly:

```
$ LV_BRANCH=rolling bash <(curl -s https://raw.githubusercontent.com/williamboman/LunarVim/install-script-ensure-proper-prompt-answer/utils/installer/install.sh)
```