### PR TITLE
Remove "black" from linting section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ formatters.setup {
 -- set additional linters
 local linters = require "lvim.lsp.null-ls.linters"
 linters.setup {
-  { command = "black" },
   {
     command = "eslint_d",
     ---@usage specify which filetypes to enable. By default a providers will attach to all the filetypes it supports.


### PR DESCRIPTION
The "black" utility does not include linting functionality.  So
including it in that section of the example configuration file,
leads to an error message on startup.
