### PR TITLE
refactor: lock new installations to nvim v0.7+

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -33,7 +33,7 @@ body:
   - type: input
     id: nvim-version
     attributes:
-      label: Neovim version (>= 0.6.1)
+      label: Neovim version (>= 0.7)
       description: "Output of `nvim --version`"
       placeholder: |
         NVIM v0.7-dev+209-g0603eba6e

--- a/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
@@ -27,7 +27,7 @@ body:
   - type: input
     id: nvim-version
     attributes:
-      label: Neovim version (>= 0.6.1)
+      label: Neovim version (>= 0.7)
       description: "Output of `nvim --version`"
       placeholder: |
         NVIM v0.7-dev+209-g0603eba6e

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.6.1
+          version: v0.7
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.7
+          version: v0.7.0
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -33,7 +33,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.6.1
+          version: v0.7
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Install In One Command!
 
-Make sure you have the release version of Neovim (0.6.1+).
+Make sure you have the release version of Neovim (0.7+).
 
 ### Linux:
 

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -114,7 +114,6 @@ local core_plugins = {
   -- Treesitter
   {
     "nvim-treesitter/nvim-treesitter",
-    branch = vim.fn.has "nvim-0.6" == 1 and "master" or "0.5-compat",
     -- run = ":TSUpdate",
     config = function()
       require("lvim.core.treesitter").setup()

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -82,7 +82,7 @@ function print_missing_dep_msg($dep) {
     Write-Output "Please install it first and re-run the installer."
 }
 
-$winget_package_matrix=@{"git" = "Git.Git"; "nvim" = "nvim.nvim"; "make" = "GnuWin32.Make"; "node" = "OpenJS.NodeJS"; "pip" = "Python.Python.3"}
+$winget_package_matrix=@{"git" = "Git.Git"; "nvim" = "Neovim.Neovim"; "make" = "GnuWin32.Make"; "node" = "OpenJS.NodeJS"; "pip" = "Python.Python.3"}
 $scoop_package_matrix=@{"git" = "git"; "nvim" = "neovim-nightly"; "make" = "make"; "node" = "nodejs"; "pip" = "python3"}
 
 function install_system_package($dep) {

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -197,11 +197,11 @@ function print_missing_dep_msg() {
 }
 
 function check_neovim_min_version() {
-  local verify_version_cmd='if !has("nvim-0.6.1") | cquit | else | quit | endif'
+  local verify_version_cmd='if !has("nvim-0.7") | cquit | else | quit | endif'
 
   # exit with an error if min_version not found
   if ! nvim --headless -u NONE -c "$verify_version_cmd"; then
-    echo "[ERROR]: LunarVim requires at least Neovim v0.6.1 or higher"
+    echo "[ERROR]: LunarVim requires at least Neovim v0.7 or higher"
     exit 1
   fi
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- require nvim v0.7+ for new installs
- update documentation
- chore: update neovim's moniker for winget

Fixes #2525
