### PR TITLE
[Feature] gitsigns yadm support

### DIFF
--- a/lua/lvim/core/gitsigns.lua
+++ b/lua/lvim/core/gitsigns.lua
@@ -73,6 +73,7 @@ M.config = function()
       sign_priority = 6,
       update_debounce = 200,
       status_formatter = nil, -- Use default
+      yadm = { enable = false },
     },
   }
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This exposes gitsigns yadm feature flag to allow user to enable it in their 
config:

```lua
lvim.builtin.gitsigns.opts.yadm.enable = true
```

## How Has This Been Tested?

Tested locally.


## Links

Upstream docs: https://github.com/lewis6991/gitsigns.nvim#usage