### PR TITLE
refactor(lsp): decouple the installer setup-hook

### DIFF
--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -149,7 +149,7 @@ function M.setup()
     append_default_schemas = true,
   }
 
-  require("nvim-lsp-installer").settings {
+  require("nvim-lsp-installer").setup {
     -- use the default nvim_data_dir, since the server binaries are independent
     install_root_dir = utils.join_paths(vim.call("stdpath", "data"), "lsp_servers"),
   }

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -16,29 +16,27 @@ function M.init_defaults(languages)
   end
 end
 
----Resolve the configuration for a server based on both common and user configuration
----@param name string
----@param user_config table [optional]
+---Resolve the configuration for a server by merging with the default config
+---@param server_name string
+---@vararg any config table [optional]
 ---@return table
-local function resolve_config(name, user_config)
-  local config = {
+local function resolve_config(server_name, ...)
+  local defaults = {
     on_attach = require("lvim.lsp").common_on_attach,
     on_init = require("lvim.lsp").common_on_init,
     on_exit = require("lvim.lsp").common_on_exit,
     capabilities = require("lvim.lsp").common_capabilities(),
   }
 
-  local has_custom_provider, custom_config = pcall(require, "lvim/lsp/providers/" .. name)
+  local has_custom_provider, custom_config = pcall(require, "lvim/lsp/providers/" .. server_name)
   if has_custom_provider then
-    Log:debug("Using custom configuration for requested server: " .. name)
-    config = vim.tbl_deep_extend("force", config, custom_config)
+    Log:debug("Using custom configuration for requested server: " .. server_name)
+    defaults = vim.tbl_deep_extend("force", defaults, custom_config)
   end
 
-  if user_config then
-    config = vim.tbl_deep_extend("force", config, user_config)
-  end
+  defaults = vim.tbl_deep_extend("force", defaults, ...)
 
-  return config
+  return defaults
 end
 
 -- manually start the server and don't wait for the usual filetype trigger from lspconfig
@@ -62,47 +60,52 @@ local function client_is_configured(server_name, ft)
   return false
 end
 
+local function launch_server(server_name, config)
+  pcall(function()
+    require("lspconfig")[server_name].setup(config)
+    buf_try_add(server_name)
+  end)
+end
+
 ---Setup a language server by providing a name
 ---@param server_name string name of the language server
----@param user_config table [optional] when available it will take predence over any default configurations
+---@param user_config table? when available it will take predence over any default configurations
 function M.setup(server_name, user_config)
   vim.validate { name = { server_name, "string" } }
+  user_config = user_config or {}
 
   if lvim_lsp_utils.is_client_active(server_name) or client_is_configured(server_name) then
     return
   end
 
-  local config = resolve_config(server_name, user_config)
-
   local servers = require "nvim-lsp-installer.servers"
-  local server_available, requested_server = servers.get_server(server_name)
+  local server_available, server = servers.get_server(server_name)
 
   if not server_available then
-    pcall(function()
-      require("lspconfig")[server_name].setup(config)
-      buf_try_add(server_name)
-    end)
+    local config = resolve_config(server_name, user_config)
+    launch_server(server_name, config)
     return
   end
 
-  local install_notification = false
+  local install_in_progress = false
 
-  if not requested_server:is_installed() then
+  if not server:is_installed() then
     if lvim.lsp.automatic_servers_installation then
       Log:debug "Automatic server installation detected"
-      requested_server:install()
-      install_notification = true
+      server:install()
+      install_in_progress = true
     else
-      Log:debug(requested_server.name .. " is not managed by the automatic installer")
+      Log:debug(server.name .. " is not managed by the automatic installer")
     end
   end
 
-  requested_server:on_ready(function()
-    if install_notification then
-      vim.notify(string.format("Installation complete for [%s] server", requested_server.name), vim.log.levels.INFO)
+  server:on_ready(function()
+    if install_in_progress then
+      vim.notify(string.format("Installation complete for [%s] server", server.name), vim.log.levels.INFO)
     end
-    install_notification = false
-    requested_server:setup(config)
+    install_in_progress = false
+    local config = resolve_config(server_name, server:get_default_options(), user_config)
+    launch_server(server_name, config)
   end)
 end
 

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -42,10 +42,10 @@
     "commit": "18a07f7"
   },
   "nlsp-settings.nvim": {
-    "commit": "114e2ff"
+    "commit": "fc3007e"
   },
   "null-ls.nvim": {
-    "commit": "a887bd6"
+    "commit": "d871b41"
   },
   "nvim-autopairs": {
     "commit": "38d486a"
@@ -57,10 +57,10 @@
     "commit": "d6d8317"
   },
   "nvim-lsp-installer": {
-    "commit": "d86aad8"
+    "commit": "090c8a8"
   },
   "nvim-lspconfig": {
-    "commit": "ad9903c"
+    "commit": "86df1c8"
   },
   "nvim-notify": {
     "commit": "2c8f744"

--- a/tests/minimal_lsp.lua
+++ b/tests/minimal_lsp.lua
@@ -87,7 +87,7 @@ _G.load_config = function()
       server:install()
     end
     local default_opts = server:get_default_options()
-    setup_opts.cmd_env = default_opts.cmd_env
+    setup_opts = vim.tbl_deep_extend("force", setup_opts, default_opts)
   end
 
   if not name then


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

remove the usage of the deprecated setup-hook from `nvim-lsp-installer`, see https://github.com/williamboman/nvim-lsp-installer/pull/631


## How Has This Been Tested?

custom setup works fine

```lua
vim.list_extend(lvim.lsp.automatic_configuration.skipped_servers, { "clangd", "pyright" })

local opts = {
  cmd = { clangd_bin, unpack(clangd_flags) },
  on_attach = custom_on_attach,
}

require("lvim.lsp.manager").setup("clangd", opts)
-- require("lvim.lsp.manager").setup("clangd") --- this also works now, since opts has been made actually optional :)
```

