### PR TITLE
fix(lsp): undo stdpath overload to avoid datarace

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -70,14 +70,11 @@ function M:init(base_dir)
   self.packer_install_dir = join_paths(self.runtime_dir, "site", "pack", "packer", "start", "packer.nvim")
   self.packer_cache_path = join_paths(self.config_dir, "plugin", "packer_compiled.lua")
 
-  ---@meta overridden to use LUNARVIM_x_DIR instead, since a lot of plugins call this function interally
+  ---@meta overridden to use LUNARVIM_CACHE_DIR instead, since a lot of plugins call this function interally
+  ---NOTE: changes to "data" are currently unstable, see #2507
   vim.fn.stdpath = function(what)
     if what == "cache" then
       return _G.get_cache_dir()
-    elseif what == "data" then
-      return _G.get_runtime_dir()
-    elseif what == "config" then
-      return _G.get_config_dir()
     end
     return vim.call("stdpath", what)
   end

--- a/lua/lvim/impatient/profile.lua
+++ b/lua/lvim/impatient/profile.lua
@@ -5,6 +5,8 @@ local api, uv = vim.api, vim.loop
 local std_data = vim.fn.stdpath "data"
 local std_config = vim.fn.stdpath "config"
 local vimruntime = os.getenv "VIMRUNTIME"
+local lvim_runtime = get_runtime_dir()
+local lvim_config = get_config_dir()
 
 local function load_buffer(title, lines)
   local bufnr = api.nvim_create_buf(false, false)
@@ -25,6 +27,8 @@ local function mod_path(path)
   path = path:gsub(std_data .. "/", "<STD_DATA>/")
   path = path:gsub(std_config .. "/", "<STD_CONFIG>/")
   path = path:gsub(vimruntime .. "/", "<VIMRUNTIME>/")
+  path = path:gsub(lvim_runtime .. "/", "<LVIM_RUNTIME>/")
+  path = path:gsub(lvim_config .. "/", "<LVIM_CONFIG>/")
   return path
 end
 

--- a/lua/lvim/lsp/null-ls/init.lua
+++ b/lua/lvim/lsp/null-ls/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 local Log = require "lvim.core.log"
 
-function M:setup()
+function M.setup()
   local status_ok, null_ls = pcall(require, "null-ls")
   if not status_ok then
     Log:error "Missing null-ls dependency"

--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -46,7 +46,7 @@ end
 
 ---Generates ftplugin files based on a list of server_names
 ---The files are generated to a runtimepath: "$LUNARVIM_RUNTIME_DIR/site/after/ftplugin/template.lua"
----@param servers_names table list of servers to be enabled. Will add all by default
+---@param servers_names? table list of servers to be enabled. Will add all by default
 function M.generate_templates(servers_names)
   servers_names = servers_names or {}
 

--- a/tests/specs/bootstrap_spec.lua
+++ b/tests/specs/bootstrap_spec.lua
@@ -12,9 +12,7 @@ a.describe("initial start", function()
     assert.falsy(package.loaded["lvim.impatient"])
   end)
 
-  a.it("should be able to use lunarvim directories using vim.fn", function()
-    assert.equal(lvim_runtime_path, vim.fn.stdpath "data")
-    assert.equal(lvim_config_path, vim.fn.stdpath "config")
+  a.it("should be able to use lunarvim cache directory using vim.fn", function()
     assert.equal(lvim_cache_path, vim.fn.stdpath "cache")
   end)
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

~~Changes to "data" are currently unstable~~

- fix(lsp): undo stdpath overload to avoid datarace
- chore(linting): minor fixes

If the user adds an LSP setup call in their `config.lua`

```lua 
require("lvim.lsp.manager").setup("ccls", {})
```
then that will be executed before we've had a chance to call `require("nvim-lsp-installer").setup {}`, which happens in `require("lvim.lsp").setup()` which in turns relies on values from `config.lua`.. 

so it seems currently difficult to allow for both, instead, we'll revert the stdpath overload to keep things consistent with the old settings 😞 

Fixes #2507

## How Has This Been Tested?

It's already the default behavior, and having this in `config.lua` no longer throws an error

```lua
require("lvim.lsp.manager").setup("emmet_ls", {})
```
