### PR TITLE
revert: do not run packer.sync() on every reload

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -108,6 +108,7 @@ M.toggle_log_view = function(logfile)
   if vim.fn.executable(log_viewer) ~= 1 then
     log_viewer = "less +F"
   end
+  Log:debug("attempting to open: " .. logfile)
   log_viewer = log_viewer .. " " .. logfile
   local term_opts = vim.tbl_deep_extend("force", lvim.builtin.terminal, {
     cmd = log_viewer,

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -214,10 +214,10 @@ M.config = function()
           },
           N = { "<cmd>edit $NVIM_LOG_FILE<cr>", "Open the Neovim logfile" },
           p = {
-            "<cmd>lua require('lvim.core.terminal').toggle_log_view('packer.nvim')<cr>",
+            "<cmd>lua require('lvim.core.terminal').toggle_log_view(get_cache_dir() .. '/packer.nvim.log')<cr>",
             "view packer log",
           },
-          P = { "<cmd>exe 'edit '.stdpath('cache').'/packer.nvim.log'<cr>", "Open the Packer logfile" },
+          P = { "<cmd>edit $LUNARVIM_CACHE_DIR/packer.nvim.log<cr>", "Open the Packer logfile" },
         },
         r = { "<cmd>LvimReload<cr>", "Reload LunarVim's configuration" },
         u = { "<cmd>LvimUpdate<cr>", "Update LunarVim" },

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -35,7 +35,7 @@ function plugin_loader.init(opts)
     init_opts.display = nil
   end
 
-  if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
+  if not utils.is_directory(install_path) then
     vim.fn.system { "git", "clone", "--depth", "1", "https://github.com/wbthomason/packer.nvim", install_path }
     vim.cmd "packadd packer.nvim"
     -- IMPORTANT: we only set this the very first time to avoid constantly triggering the rollback function
@@ -86,7 +86,7 @@ function plugin_loader.reload(configurations)
   end
   plugin_loader.load(configurations)
 
-  pcall_packer_command "sync"
+  plugin_loader.ensure_plugins()
 end
 
 function plugin_loader.load(configurations)
@@ -140,8 +140,25 @@ function plugin_loader.sync_core_plugins()
   -- problem: rollback() will get stuck if a plugin directory doesn't exist
   -- solution: call sync() beforehand
   -- see https://github.com/wbthomason/packer.nvim/issues/862
-  vim.cmd [[autocmd User PackerComplete ++once lua require("lvim.plugin-loader").load_snapshot() ]]
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "PackerComplete",
+    once = true,
+    callback = require("lvim.plugin-loader").load_snapshot,
+  })
   pcall_packer_command "sync"
+end
+
+function plugin_loader.ensure_plugins()
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "PackerComplete",
+    once = true,
+    callback = function()
+      Log:debug "calling packer.clean()"
+      pcall_packer_command "clean"
+    end,
+  })
+  Log:debug "calling packer.install()"
+  pcall_packer_command "install"
 end
 
 return plugin_loader

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -13,7 +13,7 @@ end
 
 function M.run_on_packer_complete()
   Log:debug "Packer operation complete"
-  vim.cmd [[doautocmd User PackerComplete]]
+  vim.api.nvim_exec_autocmds("User", { pattern = "PackerComplete" })
 
   vim.g.colors_name = lvim.colorscheme
   pcall(vim.cmd, "colorscheme " .. lvim.colorscheme)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

make use of the lua-autocmds API to run `packer.clean()` right after `packer.install()` instead

Fixes #2547

## How Has This Been Tested?

Only adding/removing some plugin from `lvim.plugins` in `config.lua` should open packer.display

```lua
table.insert(lvim.plugins, {
  "norcalli/nvim-colorizer.lua",
  config = function()
    require("colorizer").setup({ "css", "scss", "html", "javascript" }, {})
  end,
})
```
