### PR TITLE
Add telescope ui select

### DIFF
--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -87,6 +87,9 @@ function M.config()
         override_file_sorter = true, -- override the file sorter
         case_mode = "smart_case", -- or "ignore_case" or "respect_case"
       },
+      ["ui-select"] = {
+        require("telescope.themes").get_dropdown {},
+      }
     },
   })
 end
@@ -138,6 +141,10 @@ function M.setup()
     pcall(function()
       require("telescope").load_extension "fzf"
     end)
+  end
+
+  if lvim.builtin.telescope.extensions and lvim.builtin.telescope.extensions["ui-select"] then
+    pcall(function() require("telescope").load_extension "ui-select" end)
   end
 end
 

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -45,6 +45,11 @@ local core_plugins = {
     disable = not lvim.builtin.telescope.active,
   },
   {
+    "nvim-telescope/telescope-ui-select.nvim",
+    requires = { "nvim-telescope/telescope.nvim" },
+    disable = not lvim.builtin.telescope.active,
+  },
+  {
     "nvim-telescope/telescope-fzf-native.nvim",
     requires = { "nvim-telescope/telescope.nvim" },
     run = "make",

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -104,6 +104,9 @@
   "telescope.nvim": {
     "commit": "23e28d0"
   },
+  "telescope-ui-select.nvim": {
+    "commit": "62ea5e5"
+  },
   "toggleterm.nvim": {
     "commit": "6c7f5db"
   },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adds [telescope-ui-select.nvim](https://github.com/nvim-telescope/telescope-ui-select.nvim) that returns code actions UI.

---
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/45895290/166414702-e220242a-5da5-4d56-9d89-4a2cf9d34b21.png">
