### PR TITLE
fix(autocmds): disable commentstring_calc on cursor-hold

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -12,11 +12,12 @@ M.config = function()
     },
     highlight = {
       enable = true, -- false will disable the whole extension
-      additional_vim_regex_highlighting = true,
+      additional_vim_regex_highlighting = false,
       disable = { "latex" },
     },
     context_commentstring = {
       enable = true,
+      enable_autocmd = false,
       config = {
         -- Languages that have a single comment style
         typescript = "// %s",
@@ -28,9 +29,7 @@ M.config = function()
         json = "",
       },
     },
-    -- indent = {enable = true, disable = {"python", "html", "javascript"}},
-    -- TODO seems to be broken
-    indent = { enable = true, disable = { "yaml" } },
+    indent = { enable = true, disable = { "yaml", "python" } },
     autotag = { enable = false },
     textobjects = {
       swap = {

--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -158,7 +158,7 @@ function M.format(opts)
   opts = opts or { filter = M.format_filter }
 
   if vim.lsp.buf.format then
-    vim.lsp.buf.format(opts)
+    return vim.lsp.buf.format(opts)
   end
 
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- (fix) the autocmd on CursorHold for commentstring is redundant since`comment.nvim` already has a `pre_hook` doing the same thing.
- (fix) run the format function once: we should just return if `vim.lsp.buf.format` exists :sweat_smile:
