### PR TITLE
fix: load notify's telescope extension properly

### DIFF
--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -130,6 +130,12 @@ function M.setup()
     end)
   end
 
+  if lvim.builtin.notify.active then
+    pcall(function()
+      require("telescope").load_extension "notify"
+    end)
+  end
+
   if lvim.builtin.telescope.on_config_done then
     lvim.builtin.telescope.on_config_done(telescope)
   end

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -234,6 +234,7 @@ M.config = function()
           },
           P = { "<cmd>edit $LUNARVIM_CACHE_DIR/packer.nvim.log<cr>", "Open the Packer logfile" },
         },
+        n = { "<cmd>Telescope notify<cr>", "View Notifications" },
         r = { "<cmd>LvimReload<cr>", "Reload LunarVim's configuration" },
         u = { "<cmd>LvimUpdate<cr>", "Update LunarVim" },
       },

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -24,7 +24,6 @@ local core_plugins = {
   },
   {
     "rcarriga/nvim-notify",
-
     config = function()
       require("lvim.core.notify").setup()
     end,
@@ -38,7 +37,6 @@ local core_plugins = {
   -- Telescope
   {
     "nvim-telescope/telescope.nvim",
-
     config = function()
       require("lvim.core.telescope").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Running `Telescope notify` doesn't have effect

## How Has This Been Tested?

There are two workaround.

1. manually load `notify`'s telescope extension if `notify` actived, as this pr
2. lazy-load `notify` by `event` or `after` key of `packer` provided:
```lua
  {
    "rcarriga/nvim-notify",
    -- by event
    event = "BufWinEnter",
    -- by after
    after = "telescope.nvim"
  },
```

In the second workaround, I prefer to `after` because I could use `notify` in the startup of nvim. But `after` key may be buggy as described in #1729.