### PR TITLE
refactor: load the default options once

### DIFF
--- a/.github/workflows/commitlint.config.js
+++ b/.github/workflows/commitlint.config.js
@@ -32,4 +32,15 @@ module.exports = {
       ],
     ],
   },
+  /*
+    add a custom parser to handle exclamation marks in a commit
+    see: https://github.com/conventional-changelog/commitlint/issues/2226#issuecomment-911749509
+  */
+  parserPreset: {
+    parserOpts: {
+      headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+      referenceActions: null,
+      issuePrefixes: ['ISS-'],
+    },
+  },
 };

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -104,7 +104,7 @@ function M:load(config_path)
 
   handle_deprecated_settings()
 
-  autocmds.define_augroups(lvim.autocommands)
+  autocmds.define_autocmds(lvim.autocommands)
 
   vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
 

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -86,6 +86,13 @@ local function handle_deprecated_settings()
   if lvim.builtin.dashboard.active then
     deprecation_notice("lvim.builtin.dashboard", "Use `lvim.builtin.alpha` instead. See LunarVim#1906")
   end
+
+  if lvim.autocommands.custom_groups then
+    deprecation_notice(
+      "lvim.autocommands.custom_groups",
+      "Use vim.api.nvim_create_autocmd instead or check LunarVim#2592 to learn about the new syntax"
+    )
+  end
 end
 
 --- Override the configuration with a user provided one

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -24,7 +24,7 @@ function M:init()
   settings.load_defaults()
 
   local autocmds = require "lvim.core.autocmds"
-  lvim.autocommands = autocmds.load_defaults()
+  autocmds.load_defaults()
 
   local lvim_lsp_config = require "lvim.lsp.config"
   lvim.lsp = vim.deepcopy(lvim_lsp_config)

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -5,26 +5,15 @@ local M = {}
 local user_config_dir = get_config_dir()
 local user_config_file = utils.join_paths(user_config_dir, "config.lua")
 
-local function apply_defaults(configs, defaults)
-  configs = configs or {}
-  return vim.tbl_deep_extend("keep", configs, defaults)
-end
-
 ---Get the full path to the user configuration file
 ---@return string
 function M:get_user_config_path()
   return user_config_file
 end
 
---- Initialize lvim default configuration
--- Define lvim global variable
+--- Initialize lvim default configuration and variables
 function M:init()
-  if vim.tbl_isempty(lvim or {}) then
-    lvim = vim.deepcopy(require "lvim.config.defaults")
-    local home_dir = vim.loop.os_homedir()
-    lvim.vsnip_dir = utils.join_paths(home_dir, ".config", "snippets")
-    lvim.database = { save_location = utils.join_paths(home_dir, ".config", "lunarvim_db"), auto_execute = 1 }
-  end
+  lvim = vim.deepcopy(require "lvim.config.defaults")
 
   require("lvim.keymappings").load_defaults()
 
@@ -32,13 +21,13 @@ function M:init()
   builtins.config { user_config_file = user_config_file }
 
   local settings = require "lvim.config.settings"
-  settings.load_options()
+  settings.load_defaults()
 
   local autocmds = require "lvim.core.autocmds"
-  lvim.autocommands = apply_defaults(lvim.autocommands, autocmds.load_augroups())
+  lvim.autocommands = autocmds.load_defaults()
 
   local lvim_lsp_config = require "lvim.lsp.config"
-  lvim.lsp = apply_defaults(lvim.lsp, vim.deepcopy(lvim_lsp_config))
+  lvim.lsp = vim.deepcopy(lvim_lsp_config)
 
   ---@deprecated replaced with lvim.builtin.alpha
   lvim.builtin.dashboard = {
@@ -51,8 +40,6 @@ function M:init()
     custom_section = {},
     footer = {},
   }
-
-  require("lvim.lsp.manager").init_defaults()
 end
 
 local function handle_deprecated_settings()
@@ -105,13 +92,13 @@ end
 -- @param config_path The path to the configuration overrides
 function M:load(config_path)
   local autocmds = require "lvim.core.autocmds"
-  config_path = config_path or self.get_user_config_path()
+  config_path = config_path or self:get_user_config_path()
   local ok, err = pcall(dofile, config_path)
   if not ok then
     if utils.is_file(user_config_file) then
       Log:warn("Invalid configuration: " .. err)
     else
-      Log:warn(string.format("Unable to find configuration file [%s]", config_path))
+      vim.notify_once(string.format("Unable to find configuration file [%s]", config_path), vim.log.levels.WARN)
     end
   end
 
@@ -134,7 +121,6 @@ function M:reload()
   vim.schedule(function()
     require_clean("lvim.utils.hooks").run_pre_reload()
 
-    M:init()
     M:load()
 
     require("lvim.core.autocmds").configure_format_on_save()

--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -1,7 +1,20 @@
 local M = {}
-local join_paths = require("lvim.utils").join_paths
 
 M.load_default_options = function()
+  local utils = require "lvim.utils"
+  local join_paths = utils.join_paths
+
+  local undodir = join_paths(get_cache_dir(), "undo")
+  local spelldir = join_paths(get_config_dir(), "spell")
+
+  if not utils.is_directory(undodir) then
+    vim.fn.mkdir(undodir, "p")
+  end
+
+  if not utils.is_directory(spelldir) then
+    vim.fn.mkdir(spelldir, "p")
+  end
+
   local default_options = {
     backup = false, -- creates a backup file
     clipboard = "unnamedplus", -- allows neovim to access the system clipboard
@@ -29,7 +42,7 @@ M.load_default_options = function()
     timeoutlen = 250, -- time to wait for a mapped sequence to complete (in milliseconds)
     title = true, -- set the title of window to the value of the titlestring
     -- opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
-    undodir = join_paths(get_cache_dir(), "undo"), -- set an undo directory
+    undodir = undodir, -- set an undo directory
     undofile = true, -- enable persistent undo
     updatetime = 300, -- faster completion
     writebackup = false, -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
@@ -43,8 +56,7 @@ M.load_default_options = function()
     signcolumn = "yes", -- always show the sign column, otherwise it would shift the text each time
     wrap = false, -- display lines as one long line
     spell = false,
-    spelllang = "en",
-    spellfile = join_paths(get_config_dir(), "spell", "en.utf-8.add"),
+    spellfile = join_paths(spelldir, "en.utf-8.add"),
     shadafile = join_paths(get_cache_dir(), "lvim.shada"),
     scrolloff = 8, -- minimal number of screen lines to keep above and below the cursor.
     sidescrolloff = 8, -- minimal number of screen lines to keep left and right of the cursor.
@@ -68,7 +80,7 @@ M.load_headless_options = function()
   vim.opt.swapfile = false -- don't use a swap file
 end
 
-M.load_options = function()
+M.load_defaults = function()
   if #vim.api.nvim_list_uis() == 0 then
     M.load_headless_options()
     return

--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -5,14 +5,9 @@ M.load_default_options = function()
   local join_paths = utils.join_paths
 
   local undodir = join_paths(get_cache_dir(), "undo")
-  local spelldir = join_paths(get_config_dir(), "spell")
 
   if not utils.is_directory(undodir) then
     vim.fn.mkdir(undodir, "p")
-  end
-
-  if not utils.is_directory(spelldir) then
-    vim.fn.mkdir(spelldir, "p")
   end
 
   local default_options = {
@@ -55,8 +50,6 @@ M.load_default_options = function()
     numberwidth = 4, -- set number column width to 2 {default 4}
     signcolumn = "yes", -- always show the sign column, otherwise it would shift the text each time
     wrap = false, -- display lines as one long line
-    spell = false,
-    spellfile = join_paths(spelldir, "en.utf-8.add"),
     shadafile = join_paths(get_cache_dir(), "lvim.shada"),
     scrolloff = 8, -- minimal number of screen lines to keep above and below the cursor.
     sidescrolloff = 8, -- minimal number of screen lines to keep left and right of the cursor.

--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -47,23 +47,21 @@ local function resolve_config(theme_name)
 end
 
 local function configure_additional_autocmds()
-  local aucmds = {
-    {
-      "FileType",
-      "alpha",
-      "set showtabline=0 | autocmd BufLeave <buffer> set showtabline=" .. vim.opt.showtabline._value,
-    },
-  }
+  local group = "_dashboard_settings"
+  vim.api.nvim_create_augroup(group, {})
+  vim.api.nvim_create_autocmd("FileType", {
+    group = group,
+    pattern = "alpha",
+    command = "set showtabline=0 | autocmd BufLeave <buffer> set showtabline=" .. vim.opt.showtabline._value,
+  })
   if not lvim.builtin.lualine.options.globalstatus then
-    aucmds[#aucmds + 1] =
-      -- https://github.com/goolord/alpha-nvim/issues/42
-      {
-        "FileType",
-        "alpha",
-        "set laststatus=0 | autocmd BufUnload <buffer> set laststatus=" .. vim.opt.laststatus._value,
-      }
+    -- https://github.com/goolord/alpha-nvim/issues/42
+    vim.api.nvim_create_autocmd("FileType", {
+      group = group,
+      pattern = "alpha",
+      command = "set laststatus=0 | autocmd BufUnload <buffer> set laststatus=" .. vim.opt.laststatus._value,
+    })
   end
-  require("lvim.core.autocmds").define_augroups { _alpha = aucmds }
 end
 
 function M.setup()

--- a/lua/lvim/core/alpha/dashboard.lua
+++ b/lua/lvim/core/alpha/dashboard.lua
@@ -34,16 +34,7 @@ function M.get_sections()
   }
 
   local text = require "lvim.interface.text"
-  local git_utils = require "lvim.utils.git"
-
-  local current_branch = git_utils.get_lvim_branch()
-
-  local lvim_version
-  if current_branch ~= "HEAD" or "" then
-    lvim_version = current_branch .. "-" .. git_utils.get_lvim_current_sha()
-  else
-    lvim_version = "v" .. git_utils.get_lvim_tag()
-  end
+  local lvim_version = require("lvim.utils.git").get_lvim_version()
 
   local footer = {
     type = "text",
@@ -68,7 +59,7 @@ function M.get_sections()
       {
         "SPC L c",
         "  Configuration",
-        "<CMD>edit " .. require("lvim.config").get_user_config_path() .. " <CR>",
+        "<CMD>edit " .. require("lvim.config"):get_user_config_path() .. " <CR>",
       },
     },
   }

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -2,6 +2,8 @@ local M = {}
 local Log = require "lvim.core.log"
 
 --- Load the default set of autogroups and autocommands.
+-- TODO: adding a description seems to mess with the output of `nvim_get_autocmds`
+-- see https://github.com/mrjones2014/legendary.nvim/issues/39
 function M.load_defaults()
   local user_config_file = require("lvim.config"):get_user_config_path()
 
@@ -11,47 +13,65 @@ function M.load_defaults()
   end
 
   return {
-    _general_settings = {
-      { "FileType", "qf,help,man", "nnoremap <silent> <buffer> q :close<CR>" },
+    {
+      "TextYankPost",
       {
-        "TextYankPost",
-        "*",
-        "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
-      },
-      {
-        "BufWinEnter",
-        "dashboard",
-        "setlocal cursorline signcolumn=yes cursorcolumn number",
-      },
-      { "BufWritePost", user_config_file, "lua require('lvim.config'):reload()" },
-      { "FileType", "qf", "set nobuflisted" },
-      -- { "VimLeavePre", "*", "set title set titleold=" },
-    },
-    _formatoptions = {
-      {
-        "BufWinEnter,BufRead,BufNewFile",
-        "*",
-        "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+        group = "_general_settings",
+        pattern = "*",
+        callback = function()
+          require("vim.highlight").on_yank { higroup = "Search", timeout = 200 }
+        end,
       },
     },
-    _filetypechanges = {},
-    _git = {
-      { "FileType", "gitcommit", "setlocal wrap" },
-      { "FileType", "gitcommit", "setlocal spell" },
+    {
+      "BufWritePost",
+      {
+        group = "_general_settings",
+        pattern = user_config_file,
+        callback = function()
+          require("lvim.config"):reload()
+        end,
+      },
     },
-    _markdown = {
-      { "FileType", "markdown", "setlocal wrap" },
-      { "FileType", "markdown", "setlocal spell" },
+    {
+      "FileType",
+      {
+        group = "_filetype_settings",
+        pattern = "qf",
+        command = "set nobuflisted",
+      },
     },
-    _buffer_bindings = {
-      { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
+    {
+      "FileType",
+      {
+        group = "_filetype_settings",
+        pattern = { "gitcommit", "markdown" },
+        command = "setlocal wrap spell",
+      },
     },
-    _auto_resize = {
-      -- will cause split windows to be resized evenly if main window is resized
-      { "VimResized", "*", "tabdo wincmd =" },
+    {
+      "FileType",
+      {
+        group = "_buffer_mappings",
+        pattern = { "qf", "help", "man", "floaterm", "lspinfo", "lsp-installer", "null-ls-info" },
+        command = "nnoremap <silent> <buffer> q :close<CR>",
+      },
     },
-    _general_lsp = {
-      { "FileType", "lspinfo,lsp-installer,null-ls-info", "nnoremap <silent> <buffer> q :close<CR>" },
+    {
+      { "BufWinEnter", "BufRead", "BufNewFile" },
+      {
+        group = "_format_options",
+        pattern = "*",
+        command = "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+      },
+    },
+    {
+      "VimResized",
+      {
+        group = "_auto_resize",
+        pattern = "*",
+        command = "tabdo wincmd =",
+      },
     },
     custom_groups = {},
   }
@@ -84,7 +104,7 @@ function M.enable_format_on_save()
 end
 
 function M.disable_format_on_save()
-  pcall(vim.api.nvim_del_augroup_by_name, "lsp_format_on_save")
+  M.clear_augroup "lsp_format_on_save"
   Log:debug "disabled format-on-save"
 end
 
@@ -109,47 +129,60 @@ function M.toggle_format_on_save()
 end
 
 function M.enable_transparent_mode()
-  vim.cmd "au ColorScheme * hi Normal ctermbg=none guibg=none"
-  vim.cmd "au ColorScheme * hi SignColumn ctermbg=none guibg=none"
-  vim.cmd "au ColorScheme * hi NormalNC ctermbg=none guibg=none"
-  vim.cmd "au ColorScheme * hi MsgArea ctermbg=none guibg=none"
-  vim.cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
-  vim.cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
-  vim.cmd "au ColorScheme * hi EndOfBuffer ctermbg=none guibg=none"
-  vim.cmd "let &fcs='eob: '"
+  vim.api.nvim_create_autocmd("ColorScheme", {
+    pattern = "*",
+    callback = function()
+      local hl_groups = {
+        "Normal",
+        "SignColumn",
+        "NormalNC",
+        "TelescopeBorder",
+        "NvimTreeNormal",
+        "EndOfBuffer",
+        "MsgArea",
+      }
+      for _, name in ipairs(hl_groups) do
+        vim.cmd(string.format("highlight %s ctermbg=none guibg=none", name))
+      end
+    end,
+  })
+  vim.opt.fillchars = "eob: "
 end
 
---- Disable autocommand groups if it exists
---- This is more reliable than trying to delete the augroup itself
+--- Clean autocommand in a group if it exists
+--- This is safer than trying to delete the augroup itself
 ---@param name string the augroup name
-function M.disable_augroup(name)
+function M.clear_augroup(name)
   -- defer the function in case the autocommand is still in-use
+  if vim.api.nvim_get_autocmds { group = name } then
+    Log:debug("ignoring request to clear autocmds from non-existent group " .. name)
+    return
+  end
   vim.schedule(function()
-    if vim.fn.exists("#" .. name) == 1 then
-      vim.cmd("augroup " .. name)
-      vim.cmd "autocmd!"
-      vim.cmd "augroup END"
+    local status_ok, _ = xpcall(function()
+      vim.api.nvim_clear_autocmds { group = name }
+    end, debug.traceback)
+    if not status_ok then
+      Log:warn("problems detected while clearing autocmds from " .. name)
+      Log:debug(debug.traceback())
     end
   end)
 end
 
 --- Create autocommand groups based on the passed definitions
----@param definitions table contains trigger, pattern and text. The key will be used as a group name
-function M.define_augroups(definitions, buffer)
-  for group_name, definition in pairs(definitions) do
-    vim.cmd("augroup " .. group_name)
-    if buffer then
-      vim.cmd [[autocmd! * <buffer>]]
-    else
-      vim.cmd [[autocmd!]]
+--- Also creates the augroup automatically if it doesn't exist
+---@param definitions table contains a tuple of event, opts, see `:h nvim_create_autocmd`
+function M.define_autocmds(definitions)
+  for _, entry in ipairs(definitions) do
+    local event = entry[1]
+    local opts = entry[2]
+    if type(opts.group) == "string" and opts.group ~= "" then
+      local exists, _ = pcall(vim.api.nvim_get_autocmds, { group = opts.group })
+      if not exists then
+        vim.api.nvim_create_augroup(opts.group, {})
+      end
     end
-
-    for _, def in pairs(definition) do
-      local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")
-      vim.cmd(command)
-    end
-
-    vim.cmd "augroup END"
+    vim.api.nvim_create_autocmd(event, opts)
   end
 end
 

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -2,7 +2,7 @@ local M = {}
 local Log = require "lvim.core.log"
 
 --- Load the default set of autogroups and autocommands.
-function M.load_augroups()
+function M.load_defaults()
   local user_config_file = require("lvim.config"):get_user_config_path()
 
   if vim.loop.os_uname().version:match "Windows" then

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -117,11 +117,11 @@ function M.configure_format_on_save()
 end
 
 function M.toggle_format_on_save()
-  local status, _ = pcall(vim.api.nvim_get_autocmds, {
+  local exists, _ = pcall(vim.api.nvim_get_autocmds, {
     group = "lsp_format_on_save",
     event = "BufWritePre",
   })
-  if not status then
+  if not exists then
     M.enable_format_on_save()
   else
     M.disable_format_on_save()
@@ -154,7 +154,8 @@ end
 ---@param name string the augroup name
 function M.clear_augroup(name)
   -- defer the function in case the autocommand is still in-use
-  if vim.api.nvim_get_autocmds { group = name } then
+  local exists, _ = pcall(vim.api.nvim_get_autocmds, { group = name })
+  if not exists then
     Log:debug("ignoring request to clear autocmds from non-existent group " .. name)
     return
   end

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -2,8 +2,6 @@ local M = {}
 local Log = require "lvim.core.log"
 
 --- Load the default set of autogroups and autocommands.
--- TODO: adding a description seems to mess with the output of `nvim_get_autocmds`
--- see https://github.com/mrjones2014/legendary.nvim/issues/39
 function M.load_defaults()
   local user_config_file = require("lvim.config"):get_user_config_path()
 
@@ -12,12 +10,13 @@ function M.load_defaults()
     user_config_file = user_config_file:gsub("\\", "/")
   end
 
-  return {
+  local definitions = {
     {
       "TextYankPost",
       {
         group = "_general_settings",
         pattern = "*",
+        desc = "Highlight text on yank",
         callback = function()
           require("vim.highlight").on_yank { higroup = "Search", timeout = 200 }
         end,
@@ -28,6 +27,7 @@ function M.load_defaults()
       {
         group = "_general_settings",
         pattern = user_config_file,
+        desc = "Trigger LvimReload on saving " .. vim.fn.expand "%:~",
         callback = function()
           require("lvim.config"):reload()
         end,
@@ -74,6 +74,8 @@ function M.load_defaults()
       },
     },
   }
+
+  M.define_autocmds(definitions)
 end
 
 local get_format_on_save_opts = function()

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -73,7 +73,6 @@ function M.load_defaults()
         command = "tabdo wincmd =",
       },
     },
-    custom_groups = {},
   }
 end
 

--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -144,9 +144,9 @@ end
 
 -- Common kill function for bdelete and bwipeout
 -- credits: based on bbye and nvim-bufdel
----@param kill_command String defaults to "bd"
----@param bufnr Number defaults to the current buffer
----@param force Boolean defaults to false
+---@param kill_command string defaults to "bd"
+---@param bufnr? number defaults to the current buffer
+---@param force? boolean defaults to false
 function M.buf_kill(kill_command, bufnr, force)
   local bo = vim.bo
   local api = vim.api

--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -1,7 +1,6 @@
 local M = {}
 
-M.defaults = {
-  [[
+vim.cmd [[
   function! QuickFixToggle()
     if empty(filter(getwininfo(), 'v:val.quickfix'))
       copen
@@ -9,21 +8,70 @@ M.defaults = {
       cclose
     endif
   endfunction
-  ]],
-  [[ command! BufferKill lua require('lvim.core.bufferline').buf_kill('bd') ]],
-  -- :LvimInfo
-  [[ command! LvimInfo lua require('lvim.core.info').toggle_popup(vim.bo.filetype) ]],
-  [[ command! LvimCacheReset lua require('lvim.utils.hooks').reset_cache() ]],
-  [[ command! LvimUpdate lua require('lvim.bootstrap').update() ]],
-  [[ command! LvimSyncCorePlugins lua require('lvim.plugin-loader'):sync_core_plugins() ]],
-  [[ command! LvimReload lua require('lvim.config'):reload() ]],
-  [[ command! LvimToggleFormatOnSave lua require('lvim.core.autocmds').toggle_format_on_save() ]],
-  [[ command! LvimVersion lua require('lvim.core.telescope.custom-finders').view_lunarvim_changelog() ]],
+]]
+
+M.defaults = {
+  {
+    name = "BufferKill",
+    fn = function()
+      require("lvim.core.bufferline").buf_kill "bd"
+    end,
+  },
+  {
+    name = "LvimToggleFormatOnSave",
+    fn = function()
+      require("lvim.core.autocmds").toggle_format_on_save()
+    end,
+  },
+  {
+    name = "LvimInfo",
+    fn = function()
+      require("lvim.core.info").toggle_popup(vim.bo.filetype)
+    end,
+  },
+  {
+    name = "LvimCacheReset",
+    fn = function()
+      require("lvim.utils.hooks").reset_cache()
+    end,
+  },
+  {
+    name = "LvimReload",
+    fn = function()
+      require("lvim.config"):reload()
+    end,
+  },
+  {
+    name = "LvimUpdate",
+    fn = function()
+      require("lvim.bootstrap"):update()
+    end,
+  },
+  {
+    name = "LvimSyncCorePlugins",
+    fn = function()
+      require("lvim.plugin-loader").sync_core_plugins()
+    end,
+  },
+  {
+    name = "LvimChangelog",
+    fn = function()
+      require("lvim.core.telescope.custom-finders").view_lunarvim_changelog()
+    end,
+  },
+  {
+    name = "LvimVersion",
+    fn = function()
+      print(require("lvim.utils.git").get_lvim_version())
+    end,
+  },
 }
 
-M.load = function(commands)
-  for _, command in ipairs(commands) do
-    vim.cmd(command)
+function M.load(collection)
+  local common_opts = { force = true }
+  for _, cmd in pairs(collection) do
+    local opts = vim.tbl_deep_extend("force", common_opts, cmd.opts or {})
+    vim.api.nvim_create_user_command(cmd.name, cmd.fn, opts)
   end
 end
 

--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -11,14 +11,25 @@ vim.tbl_add_reverse_lookup(Log.levels)
 
 local notify_opts = {}
 
+function Log:set_level(level)
+  -- package.loaded["lvim.core.log"] = nil
+  local log_level = Log.levels[level:upper()]
+  local status_ok, logger = pcall(require("structlog").get_logger, "lvim")
+  if status_ok then
+    for _, s in ipairs(logger.sinks) do
+      s.level = log_level
+    end
+  end
+
+  package.loaded["packer.log"] = nil
+  require("packer.log").new { level = lvim.log.level }
+end
+
 function Log:init()
   local status_ok, structlog = pcall(require, "structlog")
   if not status_ok then
     return nil
   end
-
-  package.loaded["packer.log"] = nil
-  require("packer.log").new { level = lvim.log.level }
 
   local log_level = Log.levels[(lvim.log.level):upper() or "WARN"]
   local lvim_log = {

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -180,10 +180,6 @@ end
 -- Load the default keymappings
 function M.load_defaults()
   M.load(M.get_defaults())
-  lvim.keys = {}
-  for idx, _ in pairs(defaults) do
-    lvim.keys[idx] = {}
-  end
 end
 
 -- Get the default keymappings

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -21,8 +21,15 @@ local mode_adapters = {
   command_mode = "c",
 }
 
+---@class Keys
+---@field insert_mode table
+---@field normal_mode table
+---@field terminal_mode table
+---@field visual_mode table
+---@field visual_block_mode table
+---@field command_mode table
+
 local defaults = {
-  ---@usage change or add keymappings for insert mode
   insert_mode = {
     -- 'jk' for quitting insert mode
     ["jk"] = "<ESC>",
@@ -41,7 +48,6 @@ local defaults = {
     ["<A-Right>"] = "<C-\\><C-N><C-w>l",
   },
 
-  ---@usage change or add keymappings for normal mode
   normal_mode = {
     -- Better window movement
     ["<C-h>"] = "<C-w>h",
@@ -69,7 +75,6 @@ local defaults = {
     ["<C-q>"] = ":call QuickFixToggle()<CR>",
   },
 
-  ---@usage change or add keymappings for terminal mode
   term_mode = {
     -- Terminal window navigation
     ["<C-h>"] = "<C-\\><C-N><C-w>h",
@@ -78,7 +83,6 @@ local defaults = {
     ["<C-l>"] = "<C-\\><C-N><C-w>l",
   },
 
-  ---@usage change or add keymappings for visual mode
   visual_mode = {
     -- Better indenting
     ["<"] = "<gv",
@@ -88,7 +92,6 @@ local defaults = {
     -- ["P"] = '"0P',
   },
 
-  ---@usage change or add keymappings for visual block mode
   visual_block_mode = {
     -- Move selected line / block of text in visual mode
     ["K"] = ":move '<-2<CR>gv-gv",
@@ -99,7 +102,6 @@ local defaults = {
     ["<A-k>"] = ":m '<-2<CR>gv-gv",
   },
 
-  ---@usage change or add keymappings for command mode
   command_mode = {
     -- navigate tab completion with <c-j> and <c-k>
     -- runs conditionally
@@ -180,6 +182,12 @@ end
 -- Load the default keymappings
 function M.load_defaults()
   M.load(M.get_defaults())
+  lvim.keys = lvim.keys or {}
+  for idx, _ in pairs(defaults) do
+    if not lvim.keys[idx] then
+      lvim.keys[idx] = {}
+    end
+  end
 end
 
 -- Get the default keymappings

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -118,16 +118,6 @@ if vim.fn.has "mac" == 1 then
   Log:debug "Activated mac keymappings"
 end
 
--- Append key mappings to lunarvim's defaults for a given mode
--- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
-function M.append_to_defaults(keymaps)
-  for mode, mappings in pairs(keymaps) do
-    for k, v in pairs(mappings) do
-      defaults[mode][k] = v
-    end
-  end
-end
-
 -- Unsets all keybindings defined in keymaps
 -- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
 function M.clear(keymaps)
@@ -137,7 +127,7 @@ function M.clear(keymaps)
     for key, _ in pairs(mappings) do
       -- some plugins may override default bindings that the user hasn't manually overridden
       if default[mode][key] ~= nil or (default[translated_mode] ~= nil and default[translated_mode][key] ~= nil) then
-        pcall(vim.api.nvim_del_keymap, translated_mode, key)
+        pcall(vim.keymap.del, translated_mode, key)
       end
     end
   end
@@ -154,7 +144,7 @@ function M.set_keymaps(mode, key, val)
     val = val[1]
   end
   if val then
-    vim.api.nvim_set_keymap(mode, key, val, opt)
+    vim.keymap.set(mode, key, val, opt)
   else
     pcall(vim.api.nvim_del_keymap, mode, key)
   end

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -50,10 +50,10 @@ end
 
 function M.common_on_exit(_, _)
   if lvim.lsp.document_highlight then
-    pcall(vim.api.nvim_del_augroup_by_name, "lsp_document_highlight")
+    autocmds.clear_augroup "lsp_document_highlight"
   end
   if lvim.lsp.code_lens_refresh then
-    pcall(vim.api.nvim_del_augroup_by_name, "lsp_code_lens_refresh")
+    autocmds.clear_augroup "lsp_code_lens_refresh"
   end
 end
 

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -3,19 +3,6 @@ local M = {}
 local Log = require "lvim.core.log"
 local lvim_lsp_utils = require "lvim.lsp.utils"
 
-function M.init_defaults(languages)
-  languages = languages or lvim_lsp_utils.get_all_supported_filetypes()
-  for _, entry in ipairs(languages) do
-    if not lvim.lang[entry] then
-      lvim.lang[entry] = {
-        formatters = {},
-        linters = {},
-        lsp = {},
-      }
-    end
-  end
-end
-
 ---Resolve the configuration for a server by merging with the default config
 ---@param server_name string
 ---@vararg any config table [optional]

--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -115,6 +115,20 @@ function M.get_lvim_tag()
   return tag
 end
 
+---Get currently running version of Lunarvim
+---@return string
+function M.get_lvim_version()
+  local current_branch = M.get_lvim_branch()
+
+  local lvim_version
+  if current_branch ~= "HEAD" or "" then
+    lvim_version = current_branch .. "-" .. M.get_lvim_current_sha()
+  else
+    lvim_version = "v" .. M.get_lvim_tag()
+  end
+  return lvim_version
+end
+
 ---Get the commit hash of currently checked-out commit of Lunarvim
 ---@return string|nil
 function M.get_lvim_current_sha()

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -20,9 +20,9 @@ lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- unmap a default keymapping
--- vim.keymap.del("n", <C-Up>")
+-- vim.keymap.del("n", "<C-Up>")
 -- override a default keymapping
--- lvim.keys.normal_mode["<C-q>"] = ":q<cr>" -- or vim.keymap.set("n", <C-q>", ":q<cr>" )
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>" -- or vim.keymap.set("n", "<C-q>", ":q<cr>" )
 
 -- Change Telescope navigation to use j and k for navigation and n and p for history in both input and normal mode.
 -- we use protected-mode (pcall) just in case the plugin wasn't loaded yet.

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -20,9 +20,9 @@ lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- unmap a default keymapping
--- lvim.keys.normal_mode["<C-Up>"] = false
--- edit a default keymapping
--- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
+-- vim.keymap.del("n", <C-Up>")
+-- override a default keymapping
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>" -- or vim.keymap.set("n", <C-q>", ":q<cr>" )
 
 -- Change Telescope navigation to use j and k for navigation and n and p for history in both input and normal mode.
 -- we use protected-mode (pcall) just in case the plugin wasn't loaded yet.
@@ -153,6 +153,15 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- }
 
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
--- lvim.autocommands.custom_groups = {
---   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
--- }
+-- vim.api.nvim_create_autocmd("BufEnter", {
+--   pattern = { "*.json", "*.jsonc" },
+--   -- enable wrap mode for json files only
+--   command = "setlocal wrap",
+-- })
+-- vim.api.nvim_create_autocmd("FileType", {
+--   pattern = "zsh",
+--   callback = function()
+--     -- let treesitter use bash highlight for zsh files as well
+--     require("nvim-treesitter.highlight").attach(0, "bash")
+--   end,
+-- })

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -37,9 +37,9 @@ lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- unmap a default keymapping
--- vim.keymap.del("n", <C-Up>")
+-- vim.keymap.del("n", "<C-Up>")
 -- override a default keymapping
--- lvim.keys.normal_mode["<C-q>"] = ":q<cr>" -- or vim.keymap.set("n", <C-q>", ":q<cr>" )
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>" -- or vim.keymap.set("n", "<C-q>", ":q<cr>" )
 
 -- Change Telescope navigation to use j and k for navigation and n and p for history in both input and normal mode.
 -- we use protected-mode (pcall) just in case the plugin wasn't loaded yet.

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -37,9 +37,9 @@ lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- unmap a default keymapping
--- lvim.keys.normal_mode["<C-Up>"] = false
--- edit a default keymapping
--- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
+-- vim.keymap.del("n", <C-Up>")
+-- override a default keymapping
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>" -- or vim.keymap.set("n", <C-q>", ":q<cr>" )
 
 -- Change Telescope navigation to use j and k for navigation and n and p for history in both input and normal mode.
 -- we use protected-mode (pcall) just in case the plugin wasn't loaded yet.
@@ -168,6 +168,15 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- }
 
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
--- lvim.autocommands.custom_groups = {
---   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
--- }
+-- vim.api.nvim_create_autocmd("BufEnter", {
+--   pattern = { "*.json", "*.jsonc" },
+--   -- enable wrap mode for json files only
+--   command = "setlocal wrap",
+-- })
+-- vim.api.nvim_create_autocmd("FileType", {
+--   pattern = "zsh",
+--   callback = function()
+--     -- let treesitter use bash highlight for zsh files as well
+--     require("nvim-treesitter.highlight").attach(0, "bash")
+--   end,
+-- })


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

**BREAKING CHANGE**: modifying the default options for keymaps and autocmds is now done by overwriting them, since they won't be loaded into the global `lvim` table anymore. **Make sure to check the updated structure of `lvim.autocmds` if you intend to use that table.**




- changes to `lvim.keys` in `config.lua` are now persistent after saving the file and/or `:LvimReload`
- ~~`undodir` and `spelldir` are validated and created if they don't exist~~
- `undodir` is validated and created if it doesn't exist
- `spellfile` is left to be handled by neovim which should create the appropriate file and directory on-demand, see `:h spellfile`
- feat: add `Log:set_log_level()`
- refactor: use the lua-commands api
- refactor!: use the lua-autocmds api

Fixes #2166

---

### Examples

use the native neovim-api to create autocmds
```lua
vim.api.nvim_create_autocmd("BufEnter", {
	  pattern = { "*.json", "*.jsonc" },
	  -- enable wrap mode for json files only
	  command = "setlocal wrap",
})
```
use the `lvim.autocmds` table to load a list of autocmds

```lua
lvim.autocmds = {
  { -- first entry
    "BufEnter",
    { -- this is passed directly as opts to `nvim_create_autocmd()`
      pattern = { "*.json", "*.jsonc" },
      -- enable wrap mode for json files only
      command = "setlocal wrap",
    },
  },
  -- add more entries
}
```

you can also use `nvim_del_autocmd()` to delete any of the default autocmds
