### PR TITLE
chore: update templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -23,7 +23,7 @@ body:
     validations:
       required: true
   - type: input
-    id: lunar-vim-version
+    id: version
     attributes:
       label: LunarVim version
       placeholder: |
@@ -36,30 +36,36 @@ body:
       label: Neovim version (>= 0.7)
       description: "Output of `nvim --version`"
       placeholder: |
-        NVIM v0.7-dev+209-g0603eba6e
-        Build type: Release
-        LuaJIT 2.1.0-beta3
+        NVIM v0.8.0-dev+199-g2875d45e7
     validations:
       required: true
   - type: input
+    id: system-version
     attributes:
       label: "Operating system/version"
       placeholder: "macOS 11.5"
     validations:
       required: true
   - type: textarea
-    id: logs
+    id: steps
     attributes:
-      label: Relevant log output
-      description: |
-        :checkhealth
-        :messages
-        :e $LUNARVIM_CACHE/DIR/lvim.log
+      label: "Steps to reproduce"
+      description: "Steps to reproduce using the minimal config."
       placeholder: |
-      ```
-      paste here
-      ```
-      render: shell
+        1. `nvim -u ~/.local/share/lunarvim/lvim/tests/minimal_lsp.lua`
+        2. ...
+  - type: textarea
+    id: support-info
+    attributes:
+      label: support info
+      description: Information from LspInfo and LvimInfo
+      placeholder: |
+        ```console
+        # :LspInfo
+        ```
+        ```console
+        # :LvimInfo
+        ```
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -51,10 +51,14 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      placeholder: |
+      description: |
         :checkhealth
         :messages
         :e $LUNARVIM_CACHE/DIR/lvim.log
+      placeholder: |
+      ```
+      paste here
+      ```
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
@@ -17,7 +17,7 @@ body:
     validations:
       required: true
   - type: input
-    id: lunar-vim-version
+    id: version
     attributes:
       label: LunarVim version
       placeholder: |
@@ -30,18 +30,18 @@ body:
       label: Neovim version (>= 0.7)
       description: "Output of `nvim --version`"
       placeholder: |
-        NVIM v0.7-dev+209-g0603eba6e
-        Build type: Release
-        LuaJIT 2.1.0-beta3
+        NVIM v0.8.0-dev+199-g2875d45e7
     validations:
       required: true
   - type: input
+    id: system-version
     attributes:
       label: "Operating system/version"
       placeholder: "macOS 11.5"
     validations:
       required: true
   - type: input
+    id: servers
     attributes:
       label: "Affected language servers"
       description: "If this issue is specific to one or more language servers, list them here. If not, write 'all'."
@@ -49,6 +49,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: steps
     attributes:
       label: "Steps to reproduce"
       description: "Steps to reproduce using the minimal config."
@@ -56,30 +57,37 @@ body:
         1. `nvim -u ~/.local/share/lunarvim/lvim/tests/minimal_lsp.lua`
         2. ...
   - type: textarea
+    id: behavior
     attributes:
       label: "Actual behavior"
       description: "Observed behavior."
     validations:
       required: true
   - type: textarea
+    id: expected-behavior
     attributes:
       label: "Expected behavior"
       description: "A description of the behavior you expected."
   - type: textarea
-    id: logs
+    id: support-info
     attributes:
-      label: log and support info
+      label: support info
+      description: Information from LspInfo and LvimInfo
       placeholder: |
-        :LspInfo
-        :LvimInfo
-        :messages
-        :checkhealth
-        :e $LUNARVIM_CACHE/DIR/lsp.log
-        :e $LUNARVIM_CACHE/DIR/lvim.log
-        :e $LUNARVIM_CACHE/DIR/log
-      render: shell
+        ```console
+        # :LspInfo
+        ```
+        ```console
+        # :LvimInfo
+        ```
     validations:
       required: true
+  - type: textarea
+    id: lsp-logs
+    attributes:
+      label: logs
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: console
   - type: textarea
     id: screenshots
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 <!-- This won't be rendered!
 [CHECKLIST]
 I prefixed the title with one of the following tags:
- - [Feature]: For feature addition / improvements
- - [Bugfix]: When fixing a functionality
- - [Refactor]: When moving code without adding any functionality
- - [Doc]: On documentation updates
+ - feature: for feature addition / improvements
+ - fix: when fixing a functionality
+ - refactor: when moving code without adding any functionality
+ - doc: on documentation updates
 
-- I read the contributing guide (CONTRIBUTING.md)
+- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
 - My code follows the style guidelines of this project
 - I have performed a self-review of my code
 - I have commented on my code, particularly in hard-to-understand areas
@@ -15,17 +15,17 @@ I prefixed the title with one of the following tags:
 -->
 # Description
 
-Please include a summary of the change and which issue is fixed. \
-List any dependencies that are required for this change.
+summary of the change
 
-Fixes #(issue)
+<!--- Please list any dependencies that are required for this change. --->
+
+fixes #(issue)
 
 ## How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. \
-Provide instructions so we can reproduce. \
-Please also list any relevant details for your test configuration.
-
+<!--- Please describe the tests that you ran to verify your changes. --->
+<!--- Also list any relevant details for your test configuration. --->
+<!--- Provide instructions so we can reproduce -->
 - Run command `:mycommand`
 - Check logs
 - ...


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This updates the general issue template so the commands to execute to get the relevant logs do not dissapear when you paste the result of the first one. This always frustrates me. Also, the placeholder is not possible to copy, so it is even more work
 
## How Has This Been Tested?

I did not tested, but I don't think it is necessary
