### PR TITLE
refactor: remove redundant ftdetects

### DIFF
--- a/ftdetect/bicep.lua
+++ b/ftdetect/bicep.lua
@@ -1,3 +1,0 @@
-vim.cmd [[
- au BufRead,BufNewFile *.bicep set filetype=bicep
-]]

--- a/ftdetect/fish.lua
+++ b/ftdetect/fish.lua
@@ -1,3 +1,0 @@
-vim.cmd [[
- au BufRead,BufNewFile *.fish set filetype=fish
-]]

--- a/ftdetect/fsautocomplete.lua
+++ b/ftdetect/fsautocomplete.lua
@@ -1,3 +1,0 @@
-vim.cmd [[
-  au BufNewFile,BufRead *.fs,*.fsx,*.fsi set filetype=fsharp
-]]

--- a/ftdetect/julia.lua
+++ b/ftdetect/julia.lua
@@ -1,1 +1,0 @@
-vim.cmd [[ au BufRead,BufNewFile *.jl set filetype=julia ]]

--- a/ftdetect/nix.lua
+++ b/ftdetect/nix.lua
@@ -1,1 +1,0 @@
-vim.cmd [[ au BufRead,BufNewFile *.nix set filetype=nix ]]

--- a/ftdetect/sol.lua
+++ b/ftdetect/sol.lua
@@ -1,3 +1,0 @@
-vim.cmd [[
- au BufRead,BufNewFile *.sol set filetype=solidity
-]]

--- a/ftdetect/zig.lua
+++ b/ftdetect/zig.lua
@@ -1,4 +1,3 @@
 vim.cmd [[
-  au BufRead,BufNewFile *.zig set filetype=zig
   au BufRead,BufNewFile *.zir set filetype=zir
 ]]


### PR DESCRIPTION
These filetypes are already detected in neovim by default so there's no
need to do it in lunarvim as well.
