### PR TITLE
feat: prompt when closing modified/term buffers

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -142,26 +142,42 @@ M.setup = function()
   end
 end
 
+--stylua: ignore
+
 -- Common kill function for bdelete and bwipeout
 -- credits: based on bbye and nvim-bufdel
----@param kill_command string defaults to "bd"
+---@param kill_command? string defaults to "bd"
 ---@param bufnr? number defaults to the current buffer
 ---@param force? boolean defaults to false
 function M.buf_kill(kill_command, bufnr, force)
+  kill_command = kill_command or "bd"
+
   local bo = vim.bo
   local api = vim.api
+  local fmt = string.format
+  local fnamemodify = vim.fn.fnamemodify
 
   if bufnr == 0 or bufnr == nil then
     bufnr = api.nvim_get_current_buf()
   end
 
-  kill_command = kill_command or "bd"
+  local bufname = api.nvim_buf_get_name(bufnr)
 
-  -- If buffer is modified and force isn't true, print error and abort
-  if not force and bo[bufnr].modified then
-    return api.nvim_err_writeln(
-      string.format("No write since last change for buffer %d (set force to true to override)", bufnr)
-    )
+  if not force then
+    local warning
+    if bo[bufnr].modified then
+      warning = fmt([[No write since last change for (%s)]], fnamemodify(bufname, ":t"))
+    elseif api.nvim_buf_get_option(bufnr, "buftype") == "terminal" then
+      warning = fmt([[Terminal %s will be killed]], bufname)
+    end
+    if warning then
+      vim.ui.input({
+        prompt = string.format([[%s. Close it anyway? [y]es or [n]o (default: no): ]], warning),
+      }, function(choice)
+        if choice:match "ye?s?" then force = true end
+      end)
+      if not force then return end
+    end
   end
 
   -- Get list of windows IDs with the buffer to close
@@ -169,9 +185,7 @@ function M.buf_kill(kill_command, bufnr, force)
     return api.nvim_win_get_buf(win) == bufnr
   end, api.nvim_list_wins())
 
-  if #windows == 0 then
-    return
-  end
+  if #windows == 0 then return end
 
   if force then
     kill_command = kill_command .. "!"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`:BufferKill` command will now prompt to use force to close a modified or a term buffer.

<!--- Please list any dependencies that are required for this change. --->

fixes #2642

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- modify some buffer
- run `:BufferKill`
- pressing enter should abort by default, while typing `y` or `yes` will force quit the buffer

