### PR TITLE
fix(autocmds): toggle format-on-save properly

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -118,11 +118,11 @@ function M.configure_format_on_save()
 end
 
 function M.toggle_format_on_save()
-  local exists, _ = pcall(vim.api.nvim_get_autocmds, {
+  local exists, autocmds = pcall(vim.api.nvim_get_autocmds, {
     group = "lsp_format_on_save",
     event = "BufWritePre",
   })
-  if not exists then
+  if not exists or #autocmds == 0 then
     M.enable_format_on_save()
   else
     M.disable_format_on_save()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`LvimToggleFormatOnSave` can disable the format-on-save feature properly, but once the feature is disabled from the enabled state, this command cannot enable it again. This is because `vim.api.nvim_get_autocmds` returns an empty list after disabling the feature.

This commit checks the size of the returned autocmd list when `M.toggle_format_on_save` is called and enables the feature if the size is 0.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
Run `LvimToggleFormatOnSave` several times, and confirm that the code is automatically formatted after running `LvimToggleFormatOnSave` from the disabled state.

