### PR TITLE
fix(nvimtree): rename and move options in setup

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -66,6 +66,8 @@ function M.config()
         signcolumn = "yes",
       },
       renderer = {
+        highlight_git = true,
+        root_folder_modifier = ":t",
         indent_markers = {
           enable = false,
           icons = {
@@ -76,6 +78,32 @@ function M.config()
         },
         icons = {
           webdev_colors = lvim.use_icons,
+          show = {
+            git = true,
+            folder = true,
+            file = true,
+            folder_arrow = true,
+          },
+          glyphs = {
+            default = "",
+            symlink = "",
+            git = {
+              unstaged = "",
+              staged = "S",
+              unmerged = "",
+              renamed = "➜",
+              deleted = "",
+              untracked = "U",
+              ignored = "◌",
+            },
+            folder = {
+              default = "",
+              open = "",
+              empty = "",
+              empty_open = "",
+              symlink = "",
+            },
+          },
         },
       },
       filters = {
@@ -119,35 +147,7 @@ function M.config()
           },
         },
       },
-    },
-    show_icons = {
-      git = vim_show_icons,
-      folders = vim_show_icons,
-      files = vim_show_icons,
-      folder_arrows = vim_show_icons,
-    },
-    git_hl = 1,
-    root_folder_modifier = ":t",
-    icons = {
-      default = "",
-      symlink = "",
-      git = {
-        unstaged = "",
-        staged = "S",
-        unmerged = "",
-        renamed = "➜",
-        deleted = "",
-        untracked = "U",
-        ignored = "◌",
-      },
-      folder = {
-        default = "",
-        open = "",
-        empty = "",
-        empty_open = "",
-        symlink = "",
-      },
-    },
+    }
   }
   lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 end


### PR DESCRIPTION

To fix the following error:
Following options were moved to setup, see bit.ly/3vIpEOJ: nvim_tree_root_folder_modifier, nvim_tree_show_icons, nvim_tree_icons, nvim_tree_git_hl

Some examples applied (from the [migration guide](bit.ly/3vIpEOJ))
```    
g:nvim_tree_icons -> renderer.icons.glyphs
g:nvim_tree_git_hl -> renderer.highlight_git
g:nvim_tree_root_folder_modifier -> renderer.root_folder_modifier
g:nvim_tree_show_icons -> renderer.icons.show
        files -> file
        folders ->folder
        folder_arrows -> folder_arrow
```

fixes #2665 and #2673


Tested in my config
