### PR TITLE
chore(lsp): notify format request failed once when there is no client

### DIFF
--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -176,7 +176,7 @@ function M.format(opts)
   end, clients)
 
   if #clients == 0 then
-    vim.notify "[LSP] Format request failed, no matching language servers."
+    vim.notify_once "[LSP] Format request failed, no matching language servers."
   end
 
   local timeout_ms = opts.timeout_ms or 1000


### PR DESCRIPTION
# Description
The notification message is too noisy when there are no matching language server each time we save with `format_on_save` is on. That's enough if it notifies only once.

<div align = "center">
 <img width="500" alt="Screen Shot 2022-06-07 at 14 56 59" src="https://user-images.githubusercontent.com/42694704/172327542-03786bec-25ef-44a8-a993-14a0559a5568.png">
</div>