### PR TITLE
feat(lsp): add option to override default `nvim-lsp-installer` settings

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -119,6 +119,8 @@ return {
     insert_mode = {},
     visual_mode = {},
   },
+  ---@usage list of settings of nvim-lsp-installer
+  installer = {},
   null_ls = {
     setup = {},
     config = {},

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -121,18 +121,16 @@ return {
   },
   ---@usage list of settings of nvim-lsp-installer
   installer = {
-    ensure_installed = {
-      "sumneko_lua",
-      "jsonls",
-    },
-    ui = {
-      icons = {
-        server_installed = "✓",
-        server_pending = "",
-        server_uninstalled = "✗",
+    setup = {
+      ensure_installed = {},
+      ui = {
+        icons = {
+          server_installed = "✓",
+          server_pending = "",
+          server_uninstalled = "✗",
+        },
       },
     },
-    log_level = lvim.log and lvim.log.level or vim.log.levels.INFO,
   },
   null_ls = {
     setup = {},

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -120,7 +120,20 @@ return {
     visual_mode = {},
   },
   ---@usage list of settings of nvim-lsp-installer
-  installer = {},
+  installer = {
+    ensure_installed = {
+      "sumneko_lua",
+      "jsonls",
+    },
+    ui = {
+      icons = {
+        server_installed = "✓",
+        server_pending = "",
+        server_uninstalled = "✗",
+      },
+    },
+    log_level = lvim.log and lvim.log.level or vim.log.levels.INFO,
+  },
   null_ls = {
     setup = {},
     config = {},

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -122,11 +122,7 @@ function M.setup()
     append_default_schemas = true,
   }
 
-  require("nvim-lsp-installer").setup(vim.tbl_extend("force", lvim.lsp.installer, {
-
-    -- use the default nvim_data_dir, since the server binaries are independent
-    install_root_dir = utils.join_paths(vim.call("stdpath", "data"), "lsp_servers"),
-  }))
+  require("nvim-lsp-installer").setup(lvim.lsp.installer)
 
   require("lvim.lsp.null-ls").setup()
 

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -122,7 +122,7 @@ function M.setup()
     append_default_schemas = true,
   }
 
-  require("nvim-lsp-installer").setup(lvim.lsp.installer)
+  require("nvim-lsp-installer").setup(lvim.lsp.installer.setup)
 
   require("lvim.lsp.null-ls").setup()
 

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -122,10 +122,11 @@ function M.setup()
     append_default_schemas = true,
   }
 
-  require("nvim-lsp-installer").setup {
+  require("nvim-lsp-installer").setup(vim.tbl_extend("force", lvim.lsp.installer, {
+
     -- use the default nvim_data_dir, since the server binaries are independent
     install_root_dir = utils.join_paths(vim.call("stdpath", "data"), "lsp_servers"),
-  }
+  }))
 
   require("lvim.lsp.null-ls").setup()
 

--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -17,13 +17,22 @@ end
 
 local skipped_filetypes = lvim.lsp.automatic_configuration.skipped_filetypes
 local skipped_servers = lvim.lsp.automatic_configuration.skipped_servers
+local ensure_installed_servers = lvim.lsp.installer.setup.ensure_installed
 
 ---Generates an ftplugin file based on the server_name in the selected directory
 ---@param server_name string name of a valid language server, e.g. pyright, gopls, tsserver, etc.
 ---@param dir string the full path to the desired directory
 function M.generate_ftplugin(server_name, dir)
   if vim.tbl_contains(skipped_servers, server_name) then
-    return
+    if not vim.tbl_contains(ensure_installed_servers, server_name) then
+      return
+    else
+      -- ensure_installed should take priority over skipped_servers
+      -- remove server from skipped_servers list if it is ensured install
+      lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_filter(function(s)
+        return s ~= server_name
+      end, lvim.lsp.automatic_configuration.skipped_servers)
+    end
   end
 
   -- get the supported filetypes and remove any ignored ones

--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -19,20 +19,19 @@ local skipped_filetypes = lvim.lsp.automatic_configuration.skipped_filetypes
 local skipped_servers = lvim.lsp.automatic_configuration.skipped_servers
 local ensure_installed_servers = lvim.lsp.installer.setup.ensure_installed
 
+---Check if we should skip generating an ftplugin file based on the server_name
+---@param server_name string name of a valid language server
+local function should_skip(server_name)
+  -- ensure_installed_servers should take priority over skipped_servers
+  return vim.tbl_contains(skipped_servers, server_name) and not vim.tbl_contains(ensure_installed_servers, server_name)
+end
+
 ---Generates an ftplugin file based on the server_name in the selected directory
 ---@param server_name string name of a valid language server, e.g. pyright, gopls, tsserver, etc.
 ---@param dir string the full path to the desired directory
 function M.generate_ftplugin(server_name, dir)
-  if vim.tbl_contains(skipped_servers, server_name) then
-    if not vim.tbl_contains(ensure_installed_servers, server_name) then
-      return
-    else
-      -- ensure_installed should take priority over skipped_servers
-      -- remove server from skipped_servers list if it is ensured install
-      lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_filter(function(s)
-        return s ~= server_name
-      end, lvim.lsp.automatic_configuration.skipped_servers)
-    end
+  if should_skip(server_name) then
+    return
   end
 
   -- get the supported filetypes and remove any ignored ones

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -84,6 +84,20 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- generic LSP settings
 
+-- -- make sure server will always be installed even if the server is in skipped_servers list
+-- lvim.lsp.installer.setup.ensure_installed = {
+--     "sumeko_lua",
+--     "jsonls",
+-- }
+-- -- change UI setting of `LspInstallInfo`
+-- -- see <https://github.com/williamboman/nvim-lsp-installer#default-configuration>
+-- lvim.lsp.installer.setup.ui.check_outdated_servers_on_open = false
+-- lvim.lsp.installer.setup.ui.border = "rounded"
+-- lvim.lsp.installer.setup.ui.keymaps = {
+--     uninstall_server = "d",
+--     toggle_server_expand = "o",
+-- }
+
 -- ---@usage disable automatic installation of servers
 -- lvim.lsp.automatic_servers_installation = false
 
@@ -94,7 +108,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- require("lvim.lsp.manager").setup("pyright", opts)
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
--- ---`:LvimInfo` lists which server(s) are skiipped for the current filetype
+-- ---`:LvimInfo` lists which server(s) are skipped for the current filetype
 -- vim.tbl_map(function(server)
 --   return server ~= "emmet_ls"
 -- end, lvim.lsp.automatic_configuration.skipped_servers)

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -99,6 +99,20 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- generic LSP settings
 
+-- -- make sure server will always be installed even if the server is in skipped_servers list
+-- lvim.lsp.installer.setup.ensure_installed = {
+--     "sumeko_lua",
+--     "jsonls",
+-- }
+-- -- change UI setting of `LspInstallInfo`
+-- -- see <https://github.com/williamboman/nvim-lsp-installer#default-configuration>
+-- lvim.lsp.installer.setup.ui.check_outdated_servers_on_open = false
+-- lvim.lsp.installer.setup.ui.border = "rounded"
+-- lvim.lsp.installer.setup.ui.keymaps = {
+--     uninstall_server = "d",
+--     toggle_server_expand = "o",
+-- }
+
 -- ---@usage disable automatic installation of servers
 -- lvim.lsp.automatic_servers_installation = false
 
@@ -109,7 +123,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- require("lvim.lsp.manager").setup("pyright", opts)
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
--- ---`:LvimInfo` lists which server(s) are skiipped for the current filetype
+-- ---`:LvimInfo` lists which server(s) are skipped for the current filetype
 -- vim.tbl_map(function(server)
 --   return server ~= "emmet_ls"
 -- end, lvim.lsp.automatic_configuration.skipped_servers)


### PR DESCRIPTION
# Description

Allow user to change default settings of `nvim-lsp-installer`

## How Has This Been Tested?

User can use `lvim.lsp.installer` to change setting of `nvim-lsp-installer`, accepts the same values as [original default configuration](https://github.com/williamboman/nvim-lsp-installer#default-configuration)

```lua
lvim.lsp.installer = {
        ensure_installed = {
            "rust_analyzer",
            "sumneko_lua",
            "taplo",
            "tsserver",
            "cssls",
            "jsonls",
        },
        ui = {
            border = "rounded",
            icons = {
                server_installed = "✓",
                server_pending = "➜",
                server_uninstalled = "✗",
            },
            keymaps = {
                toggle_server_expand = "<CR>",
                install_server = "i",
                update_server = "u",
                uninstall_server = "d",
            },
        },
}
```

