### PR TITLE
feat(logger): add open command

### DIFF
--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -65,6 +65,12 @@ M.defaults = {
       print(require("lvim.utils.git").get_lvim_version())
     end,
   },
+  {
+    name = "LvimOpenlog",
+    fn = function()
+      vim.fn.execute("edit " .. require("lvim.core.log").get_path())
+    end,
+  },
 }
 
 function M.load(collection)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This adds two new commands, as suggested in #2708. One for open the lunarvim log as a file, and another to just open lunarvim log.
They follow a similar naming as they which-key counterparts, one being named after open and the other after edit:

- `LvimOpenlog`
- ~~`LvimEditlog`~~

fixes #2708 

## How Has This Been Tested?

I tested it on my config and it works fine

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- ~~`:LvimEditlog`~~
- See logs
- `:LvimOpenlog`

