### PR TITLE
fix: disable nvim-tree plugin

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -148,10 +148,13 @@ function M.config()
       },
     },
   }
-  lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 end
 
 function M.setup()
+  if not lvim.builtin.nvimtree.active then
+    return
+  end
+
   local status_ok, nvim_tree = pcall(require, "nvim-tree")
   if not status_ok then
     Log:error "Failed to load nvim-tree"
@@ -162,6 +165,9 @@ function M.setup()
     Log:debug "ignoring repeated setup call for nvim-tree, see kyazdani42/nvim-tree.lua#1308"
     return
   end
+
+  -- Add which_key mapping
+  lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
 
   lvim.builtin.nvimtree._setup_called = true
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Do not setup `nvim-tree` plugin if the flag
`lvim.builtin.nvimtree.active` is set to `false`.

<!--- Please list any dependencies that are required for this change. --->

fixes #2720

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Fetch and checkout branch cladera/fix/disable-nvimtree
- Open `config.lua` file
- Add the line following line `lvim.builtin.nvimtree.active = false`
- Restart lvim
- Try to open NvimTree

