### PR TITLE
fix: suggest the correct gentoo command

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -160,7 +160,7 @@ function detect_platform() {
       elif [ -f "/etc/fedora-release" ] || [ -f "/etc/redhat-release" ]; then
         RECOMMEND_INSTALL="sudo dnf install -y"
       elif [ -f "/etc/gentoo-release" ]; then
-        RECOMMEND_INSTALL="emerge install -y"
+        RECOMMEND_INSTALL="emerge -v"
       else # assume debian based
         RECOMMEND_INSTALL="sudo apt install -y"
       fi


### PR DESCRIPTION
Fixed the Gentoo dependency install from `emerge install -y` (invalid command) to `emerge -v` (A working command with verbose output)

