### PR TITLE
fix: Move `pickers` key in telescope config

### DIFF
--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -70,14 +70,14 @@ function M.config()
       borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
       color_devicons = true,
       set_env = { ["COLORTERM"] = "truecolor" }, -- default = nil,
-      pickers = {
-        find_files = {
-          hidden = true,
-        },
-        live_grep = {
-          --@usage don't include the filename in the search results
-          only_sort_text = true,
-        },
+    },
+    pickers = {
+      find_files = {
+        hidden = true,
+      },
+      live_grep = {
+        --@usage don't include the filename in the search results
+        only_sort_text = true,
       },
     },
     extensions = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The `pickers` config key was erroneously nested under `defaults`, but should instead be a sibling of it. The correct structure is documented here:

https://github.com/nvim-telescope/telescope.nvim#telescope-setup-structure

<!--- Please list any dependencies that are required for this change. --->

I didn't see any related issues to this in your backlog after a quick search, so no issue is linked here.

## How Has This Been Tested?

I first noticed this problem because `hidden = true` wasn't showing hidden files for me for the `find_files` picker. With this PR, I can now change the `hidden` on and off as expected.

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
To confirm the problem (before this PR):
- run `:Telescope find_files`
- search for a hidden file
- confirm that hidden files don't show in list, even though `hidden = true` is set by default [here](https://github.com/LunarVim/LunarVim/blob/rolling/lua/lvim/core/telescope.lua#L75)

To confirm the fix:
- run the code from this PR
- run `:Telescope find_files`
- search for a hidden file
- confirm that the hidden files now show in list

