### PR TITLE
fix(lualine): set icon color according to the status of treesitter

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -70,13 +70,13 @@ return {
   },
   treesitter = {
     function()
-      local b = vim.api.nvim_get_current_buf()
-      if next(vim.treesitter.highlighter.active[b]) then
-        return ""
-      end
-      return ""
+      return ""
     end,
-    color = { fg = colors.green },
+    color = function()
+      local buf = vim.api.nvim_get_current_buf()
+      local ts = vim.treesitter.highlighter.active[buf]
+      return { fg = ts and not vim.tbl_isempty(ts) and colors.green or colors.red }
+    end,
     cond = conditions.hide_in_width,
   },
   lsp = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

set icon color according to the status of treesitter

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->L

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/54089360/175476996-d741980c-b635-4300-a2e1-7de863b41f07.png">

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/54089360/175477099-616417ad-0cc9-474e-ad63-4a4c636971db.png">



