### PR TITLE
fix: use pcall for setting up project.nvim 

### DIFF
--- a/lua/lvim/core/project.lua
+++ b/lua/lvim/core/project.lua
@@ -41,7 +41,10 @@ function M.config()
 end
 
 function M.setup()
-  local project = require "project_nvim"
+  local status_ok, project = pcall(require, "project_nvim")
+  if not status_ok then
+    return
+  end
 
   project.setup(lvim.builtin.project)
   if lvim.builtin.project.on_config_done then


### PR DESCRIPTION
I set `lvim.builtin.project.active = false` in my configuration and caused a lot of errors because project_nvim was being called nonetheless

