### PR TITLE
docs(windows): update example config for nvim-tree

### DIFF
--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -79,14 +79,14 @@ lvim.builtin.terminal.active = false
 -- lvim.builtin.terminal.shell = "pwsh.exe -NoLogo"
 
 -- nvim-tree has some performance issues on windows, see kyazdani42/nvim-tree.lua#549
-lvim.builtin.nvimtree.setup.diagnostics.enable = false
-lvim.builtin.nvimtree.setup.filters.custom = false
-lvim.builtin.nvimtree.setup.git.enable = false
-lvim.builtin.nvimtree.setup.update_cwd = false
-lvim.builtin.nvimtree.setup.update_focused_file.update_cwd = false
+lvim.builtin.nvimtree.setup.diagnostics.enable = nil
+lvim.builtin.nvimtree.setup.filters.custom = nil
+lvim.builtin.nvimtree.setup.git.enable = nil
+lvim.builtin.nvimtree.setup.update_cwd = nil
+lvim.builtin.nvimtree.setup.update_focused_file.update_cwd = nil
 lvim.builtin.nvimtree.setup.view.side = "left"
-lvim.builtin.nvimtree.setup.renderer.highlight_git = false
-lvim.builtin.nvimtree.setup.renderer.icons.show.git = false
+lvim.builtin.nvimtree.setup.renderer.highlight_git = nil
+lvim.builtin.nvimtree.setup.renderer.icons.show.git = nil
 
 -- if you don't want all the parsers change this to a table of the ones you want
 lvim.builtin.treesitter.ensure_installed = {


### PR DESCRIPTION
LunarVim had an issue on windows where it displayed nvim-tree error messages on start up

![image](https://user-images.githubusercontent.com/20222391/175808772-6a5da982-824c-4e72-8a0f-f10bd69821cf.png)

the was to edit the config.lua file and change all the nvim-tree settings from `false` to `nil`

from this
![image](https://user-images.githubusercontent.com/20222391/175808787-f8f6fdc8-8c34-4c4f-872e-c4fa68696edc.png)

to this:
![image](https://user-images.githubusercontent.com/20222391/175808822-abcfe54f-089a-4435-b530-64f91b9b6999.png)

This results with no error messages on start up on windows
![image](https://user-images.githubusercontent.com/20222391/175808849-35aa67c7-339d-46cc-addd-88456dc8eab9.png)
