### PR TITLE
fix(comment): add extended mappings

### DIFF
--- a/lua/lvim/core/comment.lua
+++ b/lua/lvim/core/comment.lua
@@ -26,9 +26,12 @@ function M.config()
       ---operator-pending mapping
       ---Includes `gcc`, `gcb`, `gc[count]{motion}` and `gb[count]{motion}`
       basic = true,
-      ---extended mapping
+      ---Extra mapping
+      ---Includes `gco`, `gcO`, `gcA`
+      extra = true,
+      ---Extended mapping
       ---Includes `g>`, `g<`, `g>[count]{motion}` and `g<[count]{motion}`
-      extra = false,
+      extended = false,
     },
 
     ---LHS of line and block comment toggle mapping in NORMAL/VISUAL mode


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Comment default config was set with extra = false with a comment
suggesting this was for `g>`, `g<`, etc. mappings. However, the `extra`
argument is for the `gco`, `gcO`, and `gcA` mappings which should be enabled
by default and, in my opinion are very useful. The extended mappings are
still disabled by default.

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

Try the mappings.
