### PR TITLE
fix: adding max_jobs = 40; to :PackerSync

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -20,6 +20,7 @@ function plugin_loader.init(opts)
     package_root = opts.package_root or join_paths(vim.fn.stdpath "data", "site", "pack"),
     compile_path = compile_path,
     snapshot_path = snapshot_path,
+    max_jobs = 40,
     log = { level = "warn" },
     git = {
       clone_timeout = 300,


### PR DESCRIPTION
fixing :PackerSync on large config from being stuck while syncing

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

add max_jobs to make large configs work. sometimes `packersync` stuck 
recommendation is from @abzcoding mentioned in https://github.com/abzcoding/lvim/issues/67#issuecomment-1172866361
i don't see any downsides.. 
from the official repo:
`max_jobs = nil, -- Limit the number of simultaneous jobs. nil means no limit`
<!--- Please list any dependencies that are required for this change. --->

fixes #(https://github.com/abzcoding/lvim/issues/67)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:PackerSync`

