### PR TITLE
refactor(whichkey): use vim.keymap.set directly

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -41,7 +41,6 @@ M.config = function()
     -- lvim.builtin.terminal.execs[#lvim.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
     execs = {
       { "lazygit", "<leader>gg", "LazyGit", "float" },
-      { "lazygit", "<c-\\><c-g>", "LazyGit", "float" },
     },
   }
 end
@@ -76,23 +75,9 @@ M.add_exec = function(opts)
     return
   end
 
-  local exec_func = string.format(
-    "<cmd>lua require('lvim.core.terminal')._exec_toggle({ cmd = '%s', count = %d, direction = '%s'})<CR>",
-    opts.cmd,
-    opts.count,
-    opts.direction
-  )
-
-  require("lvim.keymappings").load {
-    normal_mode = { [opts.keymap] = exec_func },
-    term_mode = { [opts.keymap] = exec_func },
-  }
-
-  local wk_status_ok, wk = pcall(require, "which-key")
-  if not wk_status_ok then
-    return
-  end
-  wk.register({ [opts.keymap] = { opts.label } }, { mode = "n" })
+  vim.keymap.set({ "n", "t" }, opts.keymap, function()
+    M._exec_toggle { cmd = opts.cmd, count = opts.count, direction = opts.direction }
+  end, { desc = opts.label, noremap = true, silent = true })
 end
 
 M._exec_toggle = function(opts)

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -10,21 +10,10 @@ local function add_lsp_buffer_keybindings(bufnr)
     visual_mode = "v",
   }
 
-  if lvim.builtin.which_key.active then
-    -- Remap using which_key
-    local status_ok, wk = pcall(require, "which-key")
-    if not status_ok then
-      return
-    end
-    for mode_name, mode_char in pairs(mappings) do
-      wk.register(lvim.lsp.buffer_mappings[mode_name], { mode = mode_char, buffer = bufnr })
-    end
-  else
-    -- Remap using nvim api
-    for mode_name, mode_char in pairs(mappings) do
-      for key, remap in pairs(lvim.lsp.buffer_mappings[mode_name]) do
-        vim.api.nvim_buf_set_keymap(bufnr, mode_char, key, remap[1], { noremap = true, silent = true })
-      end
+  for mode_name, mode_char in pairs(mappings) do
+    for key, remap in pairs(lvim.lsp.buffer_mappings[mode_name]) do
+      local opts = { buffer = bufnr, desc = remap[2], noremap = true, silent = true }
+      vim.keymap.set(mode_char, key, remap[1], opts)
     end
   end
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

use the `desc` field in `vim.keymap.set` to avoid relying on `which-key`
directly.

<!--- Please list any dependencies that are required for this change. --->

fixes #2752

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
all LSP keymaps should still work _and_ have a description.

