### PR TITLE
fix(installer): create profile.ps1 if nonexistent

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -264,6 +264,13 @@ function create_alias {
         return
     }
 
+    try {
+        Get-Content $PROFILE -ErrorAction Stop
+    }
+    catch {
+        New-Item -Path $profile -ItemType "file" -Force
+    }
+
     Add-Content -Path $PROFILE -Value $("`r`nSet-Alias lvim $lvim_bin")
 
     Write-Host 'To use the new alias in this window reload your profile with: `. $PROFILE`' -ForegroundColor Green

--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -268,7 +268,7 @@ function create_alias {
         Get-Content $PROFILE -ErrorAction Stop
     }
     catch {
-        New-Item -Path $profile -ItemType "file" -Force
+        New-Item -Path $PROFILE -ItemType "file" -Force
     }
 
     Add-Content -Path $PROFILE -Value $("`r`nSet-Alias lvim $lvim_bin")


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
By default PowerShell does not create the file associated with `$PROFILE` during the installation. [MS Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-item?view=powershell-7.2#:~:text=By%20default%2C%20the%20profile%20does%20not%20exist%2C%20even%20though%20PowerShell%20stores%20a%20path%20and%20file%20name%20for%20it.)
The Windows installer script throws an error when trying to add the `lvim` alias to the user profile.

- added a check to create the file if nonexistent

<!--- Please list any dependencies that are required for this change. --->

fixes #2758 and partly #2805 

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run `utils/installer/install.ps1` on fresh vm / without a user profile.ps1

