### PR TITLE
fix(installer) comment causes antivirus false positives

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -217,9 +217,6 @@ function setup_lvim() {
     $exampleConfig = "$env:LUNARVIM_BASE_DIR\utils\installer\config_win.example.lua"
     Copy-Item -Force "$exampleConfig" "$env:LUNARVIM_CONFIG_DIR\config.lua"
 
-    # FIXME: this has never worked
-    # Invoke-Expression "$INSTALL_PREFIX\bin\lvim.ps1 --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'"
-
     Write-Host "Make sure to run `:PackerSync` at first launch" -ForegroundColor Green
 
     create_alias


### PR DESCRIPTION
`install.ps1` gets flagged by antivirus software due to Invoke-Expression even though it's commented out.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Deleting the comment apparently fixes the problem.
The commented lines didn't seem useful in any way, therefore I think removing them is justified.

<!--- Please list any dependencies that are required for this change. --->

fixes #2817

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Fixed the problem on my machine with Bitdefender Total Security antivirus installed.

