### PR TITLE
perf(cmp): remove redundant check for emmet-ls

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -22,20 +22,6 @@ local function feedkeys(key, mode)
 end
 M.methods.feedkeys = feedkeys
 
----checks if emmet_ls is available and active in the buffer
----@return boolean true if available, false otherwise
-local is_emmet_active = function()
-  local clients = vim.lsp.buf_get_clients()
-
-  for _, client in pairs(clients) do
-    if client.name == "emmet_ls" then
-      return true
-    end
-  end
-  return false
-end
-M.methods.is_emmet_active = is_emmet_active
-
 ---when inside a snippet, seeks to the nearest luasnip field if possible, and checks if it is jumpable
 ---@param dir number 1 for forward, -1 for backward; defaults to 1
 ---@return boolean true if a jumpable luasnip field is found while inside a snippet
@@ -257,7 +243,6 @@ M.config = function()
       ["<C-j>"] = cmp.mapping.select_next_item(),
       ["<C-d>"] = cmp.mapping.scroll_docs(-4),
       ["<C-f>"] = cmp.mapping.scroll_docs(4),
-      -- TODO: potentially fix emmet nonsense
       ["<Tab>"] = cmp.mapping(function(fallback)
         if cmp.visible() then
           cmp.select_next_item()
@@ -267,8 +252,6 @@ M.config = function()
           luasnip.jump(1)
         elseif check_backspace() then
           fallback()
-        elseif is_emmet_active() then
-          return vim.fn["cmp#complete"]()
         else
           fallback()
         end


### PR DESCRIPTION
…etion.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Removes emmet logic from cmp.lua   We were performing a check to see if emmet was active on every completion request.  This slows down completion regardless of the filetype you're editing.  Additionally, the emmet logic no longer works and is no longer required to get emmet running in lunarvim.  

## How Has This Been Tested?

If a user wants to run emmet, they can configure it like so:

```lua
lvim.plugins = {
  {
    "aca/emmet-ls",
    ft = {
      "html",
      "typescriptreact",
      "javascriptreact",
      "css",
      "sass",
      "scss",
      "less",
    },
  },
  {
    "jackieaskins/cmp-emmet",
    run = "npm run release",
  },
}

table.insert(lvim.builtin.cmp.sources, { name = "emmet" })
lvim.builtin.cmp.formatting.source_names["emmet"] = "(Emmet)"
```
