### PR TITLE
fix(lvim/lsp/manager): make client_is_configured more reliable

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -37,9 +37,9 @@ end
 -- which seems to occur only when attaching to single-files
 local function client_is_configured(server_name, ft)
   ft = ft or vim.bo.filetype
-  local active_autocmds = vim.split(vim.fn.execute("autocmd FileType " .. ft), "\n")
+  local active_autocmds = vim.api.nvim_get_autocmds { event = "FileType", pattern = ft }
   for _, result in ipairs(active_autocmds) do
-    if result:match(server_name) then
+    if result.command:match(server_name) then
       Log:debug(string.format("[%q] is already configured", server_name))
       return true
     end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

A server_name can be the same as its filetype, which will match the given pattern if you set any filetype autocmd for it. This might prevent a server from attaching.

Consider the html lsp. Its server_name is simply `html`. This might prevent a user from setting up plugins like `nvim-colorizer`, `nvim-ts-autotag` or using the emmet lsp in tandem.

Solution:

Use the lua API so we can match the specific command string, which contains only the manager's setup call, instead of trying to match/parse the result of `:autocmd`. 
## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Set a 'html' filetype autocommand.
- Check `:LvimInfo`. 
- Lsp should be attached.

