### PR TITLE
fix(nvimtree): remove `indent_markers` icons trailing space

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -68,9 +68,10 @@ function M.config()
         indent_markers = {
           enable = false,
           icons = {
-            corner = "└ ",
-            edge = "│ ",
-            none = "  ",
+            corner = "└",
+            edge = "│",
+            item = "│",
+            none = " ",
           },
         },
         icons = {


### PR DESCRIPTION
# Description

As commit <https://github.com/kyazdani42/nvim-tree.lua/commit/9a02dedd92fad67b04b2a3fee2de20555956b089>, `nvim-tree` has removed trailing spaces from the default `indent_markers` icons. That would cause an issue when unneeded space was rendered in tree in `LunarVim`. Add all available icons setting, so that this will make more consistent.

# How Has This Been Tested?
- Before:

  <img 
    width="235" 
    alt="before" 
    src="https://user-images.githubusercontent.com/42694704/180992072-8d223eac-8d1f-4260-b462-23bbd198d974.png">
- After:

  <img 
    width="235" 
    alt="after" 
    src="https://user-images.githubusercontent.com/42694704/180991473-9694c73f-abfe-4e69-b391-58e8c109e473.png">
</div>