### PR TITLE
update keybinds to use defined leader key

### DIFF
--- a/lua/lvim/core/alpha/dashboard.lua
+++ b/lua/lvim/core/alpha/dashboard.lua
@@ -51,13 +51,13 @@ function M.get_sections()
 
   local buttons = {
     entries = {
-      { "SPC f", "  Find File", "<CMD>Telescope find_files<CR>" },
-      { "SPC n", "  New File", "<CMD>ene!<CR>" },
-      { "SPC P", "  Recent Projects ", "<CMD>Telescope projects<CR>" },
-      { "SPC s r", "  Recently Used Files", "<CMD>Telescope oldfiles<CR>" },
-      { "SPC s t", "  Find Word", "<CMD>Telescope live_grep<CR>" },
+      { lvim.leader .. " f", "  Find File", "<CMD>Telescope find_files<CR>" },
+      { lvim.leader .. " n", "  New File", "<CMD>ene!<CR>" },
+      { lvim.leader .. " P", "  Recent Projects ", "<CMD>Telescope projects<CR>" },
+      { lvim.leader .. " s r", "  Recently Used Files", "<CMD>Telescope oldfiles<CR>" },
+      { lvim.leader .. " s t", "  Find Word", "<CMD>Telescope live_grep<CR>" },
       {
-        "SPC L c",
+        lvim.leader .. " L c",
         "  Configuration",
         "<CMD>edit " .. require("lvim.config"):get_user_config_path() .. " <CR>",
       },


### PR DESCRIPTION
Hey!
I love LunarVim but had to override the default buttons to use my leader key as it was bugging me a little bit as all the bindings were incorrect.

I'm not 100% sure this will work because I'm not too familiar with Lua, but the `lvim` table is global, right?

If this works, the loading screen should display the leader you set, instead of the harcoded SPC, but perhaps we need a special case for the SPC, as it probably wouldn't display.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

summary of the change

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:mycommand`
- Check logs
- ...

