### PR TITLE
feat(lsp): bind formatexpr and omnifunc by default

### DIFF
--- a/lua/lvim/config/defaults.lua
+++ b/lua/lvim/config/defaults.lua
@@ -8,7 +8,7 @@ return {
     ---@usage timeout number timeout in ms for the format request (Default: 1000)
     timeout = 1000,
     ---@usage filter func to select client
-    filter = require("lvim.lsp.handlers").format_filter,
+    filter = require("lvim.lsp.utils").format_filter,
   },
   keys = {},
 

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -121,6 +121,12 @@ return {
     insert_mode = {},
     visual_mode = {},
   },
+  buffer_options = {
+    --- enable completion triggered by <c-x><c-o>
+    omnifunc = "v:lua.vim.lsp.omnifunc",
+    --- use gq for formatting
+    formatexpr = "v:lua.vim.lsp.formatexpr(#{timeout_ms:500})",
+  },
   ---@usage list of settings of nvim-lsp-installer
   installer = {
     setup = {

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -3,6 +3,12 @@ local Log = require "lvim.core.log"
 local utils = require "lvim.utils"
 local autocmds = require "lvim.core.autocmds"
 
+local function add_lsp_buffer_options(bufnr)
+  for k, v in pairs(lvim.lsp.buffer_options) do
+    vim.api.nvim_buf_set_option(bufnr, k, v)
+  end
+end
+
 local function add_lsp_buffer_keybindings(bufnr)
   local mappings = {
     normal_mode = "n",
@@ -67,6 +73,7 @@ function M.common_on_attach(client, bufnr)
     lu.setup_codelens_refresh(client, bufnr)
   end
   add_lsp_buffer_keybindings(bufnr)
+  add_lsp_buffer_options(bufnr)
 end
 
 function M.get_common_opts()

--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -132,18 +132,20 @@ end
 ---filter passed to vim.lsp.buf.format
 ---always selects null-ls if it's available and caches the value per buffer
 ---@param client table client attached to a buffer
----@return table chosen clients
+---@return boolean if client matches
 function M.format_filter(client)
   local filetype = vim.bo.filetype
   local n = require "null-ls"
   local s = require "null-ls.sources"
   local method = n.methods.FORMATTING
-  local avalable_sources = s.get_available(filetype, method)
+  local avalable_formatters = s.get_available(filetype, method)
 
-  if #avalable_sources > 0 then
+  if #avalable_formatters > 0 then
     return client.name == "null-ls"
-  else
+  elseif client.supports_method "textDocument/formatting" then
     return true
+  else
+    return false
   end
 end
 
@@ -159,6 +161,7 @@ function M.format(opts)
 
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
 
+  ---@type table|nil
   local clients = vim.lsp.get_active_clients {
     id = opts.id,
     bufnr = bufnr,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- feat(lsp): bind formatexpr and omnifunc by default
- fix: pass filter correctly to format-on-save

<!--- Please list any dependencies that are required for this change. --->

fixes: #2741, #2866

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- press `gqap` to format a paragraph
- use `<c-x><c-o>` to trigger native omni completion

