### PR TITLE
feat(whichkey) add default keybindings to cycle to next buffer

### DIFF
--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -1,5 +1,4 @@
 local M = {}
-
 M.config = function()
   lvim.builtin.which_key = {
     ---@usage disable which-key completely [not recommended]
@@ -92,6 +91,7 @@ M.config = function()
         j = { "<cmd>BufferLinePick<cr>", "Jump" },
         f = { "<cmd>Telescope buffers<cr>", "Find" },
         b = { "<cmd>BufferLineCyclePrev<cr>", "Previous" },
+        n = { "<cmd>BufferLineCycleNext<cr>", "Next" },
         -- w = { "<cmd>BufferWipeout<cr>", "Wipeout" }, -- TODO: implement this for bufferline
         e = {
           "<cmd>BufferLinePickClose<cr>",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add which-key keybinding to cycle to next buffer

<!--- Please list any dependencies that are required for this change. --->

fixes #2872

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Start LunarVim
- enter the buffer window: `<leader>b`
- find the new option "Next" in the menu
