### PR TITLE
refactor(keymaps)!: don't hijack H/L by default

### DIFF
--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -61,10 +61,6 @@ local defaults = {
     ["<C-Left>"] = ":vertical resize -2<CR>",
     ["<C-Right>"] = ":vertical resize +2<CR>",
 
-    -- Tab switch buffer
-    ["<S-l>"] = ":BufferLineCycleNext<CR>",
-    ["<S-h>"] = ":BufferLineCyclePrev<CR>",
-
     -- Move current line / block with Alt-j/k a la vscode.
     ["<A-j>"] = ":m .+1<CR>==",
     ["<A-k>"] = ":m .-2<CR>==",

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -19,6 +19,8 @@ lvim.colorscheme = "onedarker"
 lvim.leader = "space"
 -- add your own keymapping
 lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
+-- lvim.keys.normal_mode["<S-l>"] = ":BufferLineCycleNext<CR>"
+-- lvim.keys.normal_mode["<S-h>"] = ":BufferLineCyclePrev<CR>"
 -- unmap a default keymapping
 -- vim.keymap.del("n", "<C-Up>")
 -- override a default keymapping


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Buffer cycling keymaps should be delegated to which-key. These keymaps fulfil the same role and are therefore redunant.

<!--- Please list any dependencies that are required for this change. --->

part of https://github.com/LunarVim/LunarVim/issues/2872#issuecomment-1201616659

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Buffer cycling is implemented and tested here https://github.com/LunarVim/LunarVim/pull/2873/commits/5f9f711c93c79ef63410390f8b47a0fc3cf0ea5f

