### PR TITLE
fix(installer): fix syntax error with powershell installer

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -231,7 +231,7 @@ function setup_lvim() {
 function validate_lunarvim_files() {
     Set-Alias lvim "$INSTALL_PREFIX\bin\lvim.ps1"
     try {
-        $verify_version_cmd='if v:errmsg != "" | cquit | else | quit | endif'
+        $verify_version_cmd="if v:errmsg != \`"\`" | cquit | else | quit | endif"
         Invoke-Command -ScriptBlock { lvim --headless -c 'LvimUpdate' -c "$verify_version_cmd" } -ErrorAction SilentlyContinue
     }
     catch {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes the following error message when verifying the version in the powershell script:
```
Error detected while processing command line:
E114: Missing quote: " | cquit | else | quit | endif
```

## How Has This Been Tested?

Manually executed to confirm that there are no longer any error messages. Script now completes with:
```
Your LunarVim installation is now up to date!
```

