### PR TITLE
refactor!: migrate to mason.nvim

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -99,6 +99,13 @@ local function handle_deprecated_settings()
       "Use vim.api.nvim_create_autocmd instead or check LunarVim#2592 to learn about the new syntax"
     )
   end
+
+  if lvim.lsp.automatic_servers_installation then
+    deprecation_notice(
+      "lvim.lsp.automatic_servers_installation",
+      "Use `lvim.lsp.installer.setup.automatic_installation` instead"
+    )
+  end
 end
 
 --- Override the configuration with a user provided one

--- a/lua/lvim/core/builtins/init.lua
+++ b/lua/lvim/core/builtins/init.lua
@@ -16,6 +16,7 @@ local builtins = {
   "lvim.core.notify",
   "lvim.core.lualine",
   "lvim.core.alpha",
+  "lvim.core.mason",
 }
 
 function M.config(config)

--- a/lua/lvim/core/info.lua
+++ b/lua/lvim/core/info.lua
@@ -111,9 +111,9 @@ local function make_auto_lsp_info(ft)
     return info_lines
   end
 
-  local available = lsp_utils.get_supported_servers_per_filetype(ft)
+  local supported = lsp_utils.get_supported_servers(ft)
   local skipped = vim.tbl_filter(function(name)
-    return vim.tbl_contains(available, name)
+    return vim.tbl_contains(supported, name)
   end, skipped_servers)
 
   if #skipped == 0 then

--- a/lua/lvim/core/mason.lua
+++ b/lua/lvim/core/mason.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+function M.config()
+  lvim.builtin.mason = {
+    ui = {
+      keymaps = {
+        toggle_package_expand = "<CR>",
+        install_package = "i",
+        update_package = "u",
+        check_package_version = "c",
+        update_all_packages = "U",
+        check_outdated_packages = "C",
+        uninstall_package = "X",
+        cancel_installation = "<C-c>",
+        apply_language_filter = "<C-f>",
+      },
+    },
+    log_level = vim.log.levels.INFO,
+    max_concurrent_installers = 4,
+
+    github = {
+      -- The template URL to use when downloading assets from GitHub.
+      -- The placeholders are the following (in order):
+      -- 1. The repository (e.g. "rust-lang/rust-analyzer")
+      -- 2. The release version (e.g. "v0.3.0")
+      -- 3. The asset name (e.g. "rust-analyzer-v0.3.0-x86_64-unknown-linux-gnu.tar.gz")
+      download_url_template = "https://github.com/%s/releases/download/%s/%s",
+    },
+  }
+end
+
+function M.setup()
+  local status_ok, mason = pcall(require, "mason")
+  if not status_ok then
+    return
+  end
+
+  mason.setup(lvim.builtin.mason)
+end
+
+return M

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -160,7 +160,7 @@ M.config = function()
         w = { "<cmd>Telescope diagnostics<cr>", "Diagnostics" },
         f = { require("lvim.lsp.utils").format, "Format" },
         i = { "<cmd>LspInfo<cr>", "Info" },
-        I = { "<cmd>LspInstallInfo<cr>", "Installer Info" },
+        I = { "<cmd>Mason<cr>", "Mason Info" },
         j = {
           vim.diagnostic.goto_next,
           "Next Diagnostic",

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -151,5 +151,5 @@ return {
   ---@deprecated use lvim.lsp.automatic_configuration.skipped_servers instead
   override = {},
   ---@deprecated use lvim.lsp.installer.setup.automatic_installation instead
-  automatic_servers_installation = true,
+  automatic_servers_installation = nil,
 }

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -88,7 +88,6 @@ return {
   },
   on_attach_callback = nil,
   on_init_callback = nil,
-  automatic_servers_installation = true,
   automatic_configuration = {
     ---@usage list of servers that the automatic installer will skip
     skipped_servers = skipped_servers,
@@ -131,6 +130,9 @@ return {
   installer = {
     setup = {
       ensure_installed = {},
+      automatic_installation = {
+        exclude = {},
+      },
     },
   },
   nlsp_settings = {
@@ -146,6 +148,8 @@ return {
     setup = {},
     config = {},
   },
-  ---@deprecated use automatic_configuration.skipped_servers instead
+  ---@deprecated use lvim.lsp.automatic_configuration.skipped_servers instead
   override = {},
+  ---@deprecated use lvim.lsp.installer.setup.automatic_installation instead
+  automatic_servers_installation = true,
 }

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -131,13 +131,6 @@ return {
   installer = {
     setup = {
       ensure_installed = {},
-      ui = {
-        icons = {
-          server_installed = "✓",
-          server_pending = "",
-          server_uninstalled = "✗",
-        },
-      },
     },
   },
   nlsp_settings = {

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -112,6 +112,7 @@ function M.setup()
   pcall(function()
     require("mason-lspconfig").setup(lvim.lsp.installer.setup)
     local util = require "lspconfig.util"
+    -- automatic_installation is handled by lsp-manager
     util.on_setup = nil
   end)
 

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -110,7 +110,9 @@ function M.setup()
   end)
 
   pcall(function()
-    require("nvim-lsp-installer").setup(lvim.lsp.installer.setup)
+    local automatic_installation = lvim.lsp.automatic_servers_installation
+      and { exclude = lvim.lsp.automatic_configuration.skipped_servers }
+    require("mason-lspconfig").setup { automatic_installation = automatic_installation }
   end)
 
   require("lvim.lsp.null-ls").setup()

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -110,9 +110,9 @@ function M.setup()
   end)
 
   pcall(function()
-    local automatic_installation = lvim.lsp.automatic_servers_installation
-      and { exclude = lvim.lsp.automatic_configuration.skipped_servers }
-    require("mason-lspconfig").setup { automatic_installation = automatic_installation }
+    require("mason-lspconfig").setup(lvim.lsp.installer.setup)
+    local util = require "lspconfig.util"
+    util.on_setup = nil
   end)
 
   require("lvim.lsp.null-ls").setup()

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -65,35 +65,8 @@ function M.setup(server_name, user_config)
     return
   end
 
-  local servers = require "nvim-lsp-installer.servers"
-  local server_available, server = servers.get_server(server_name)
-
-  if not server_available then
-    local config = resolve_config(server_name, user_config)
-    launch_server(server_name, config)
-    return
-  end
-
-  local install_in_progress = false
-
-  if not server:is_installed() then
-    if lvim.lsp.automatic_servers_installation then
-      Log:debug "Automatic server installation detected"
-      server:install()
-      install_in_progress = true
-    else
-      Log:debug(server.name .. " is not managed by the automatic installer")
-    end
-  end
-
-  server:on_ready(function()
-    if install_in_progress then
-      vim.notify(string.format("Installation complete for [%s] server", server.name), vim.log.levels.INFO)
-    end
-    install_in_progress = false
-    local config = resolve_config(server_name, server:get_default_options(), user_config)
-    launch_server(server_name, config)
-  end)
+  local config = resolve_config(server_name, user_config)
+  launch_server(server_name, config)
 end
 
 return M

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -98,8 +98,14 @@ function M.setup(server_name, user_config)
     return
   end
 
+  local should_auto_install = function()
+    local installer_settings = lvim.lsp.installer.setup
+    return installer_settings.automatic_installation
+      and not vim.tbl_contains(installer_settings.automatic_installation.exclude, server_name)
+  end
+
   if not registry.is_installed(pkg_name) then
-    if lvim.lsp.automatic_servers_installation then
+    if should_auto_install(server_name) then
       Log:debug "Automatic server installation detected"
       vim.notify_once(string.format("Installation in progoress for [%s] server", server_name), vim.log.levels.INFO)
       local pkg = registry.get_package(pkg_name)

--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -56,20 +56,11 @@ end
 ---The files are generated to a runtimepath: "$LUNARVIM_RUNTIME_DIR/site/after/ftplugin/template.lua"
 ---@param servers_names? table list of servers to be enabled. Will add all by default
 function M.generate_templates(servers_names)
-  servers_names = servers_names or {}
+  servers_names = servers_names or lvim_lsp_utils.get_supported_servers()
 
   Log:debug "Templates installation in progress"
 
   M.remove_template_files()
-
-  if vim.tbl_isempty(servers_names) then
-    local available_servers = require("nvim-lsp-installer.servers").get_available_servers()
-
-    for _, server in pairs(available_servers) do
-      table.insert(servers_names, server.name)
-      table.sort(servers_names)
-    end
-  end
 
   -- create the directory if it didn't exist
   if not utils.is_directory(lvim.lsp.templates_dir) then

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -7,8 +7,12 @@ local core_plugins = {
     "jose-elias-alvarez/null-ls.nvim",
   },
   { "antoinemadec/FixCursorHold.nvim" }, -- Needed while issue https://github.com/neovim/neovim/issues/12587 is still open
+  { "williamboman/mason-lspconfig.nvim" },
   {
-    "williamboman/nvim-lsp-installer",
+    "williamboman/mason.nvim",
+    config = function()
+      require("lvim.core.mason").setup()
+    end,
   },
   {
     "lunarvim/onedarker.nvim",

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -41,6 +41,12 @@
   "lualine.nvim": {
     "commit": "8d956c1"
   },
+  "mason-lspconfig.nvim": {
+    "commit": "e48a41e"
+  },
+  "mason.nvim": {
+    "commit": "6fa15d7"
+  },
   "nlsp-settings.nvim": {
     "commit": "6c4e1a4"
   },
@@ -55,9 +61,6 @@
   },
   "nvim-dap": {
     "commit": "c0f43f4"
-  },
-  "nvim-lsp-installer": {
-    "commit": "45571e1"
   },
   "nvim-lspconfig": {
     "commit": "3479473"

--- a/tests/specs/lsp_spec.lua
+++ b/tests/specs/lsp_spec.lua
@@ -53,10 +53,14 @@ a.describe("lsp workflow", function()
   a.it("should only include one server per generated template", function()
     require("lvim.lsp").setup()
 
+    local allowed_dupes = { "tailwindcss" }
     for _, file in ipairs(vim.fn.glob(lvim.lsp.templates_dir .. "/*.lua", 1, 1)) do
       local content = {}
       for entry in io.lines(file) do
-        table.insert(content, entry)
+        local server_name = entry:match [[.*setup%("(.*)"%)]]
+        if not vim.tbl_contains(allowed_dupes, server_name) then
+          table.insert(content, server_name)
+        end
       end
       local err_msg = ""
       if #content > 1 then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

> `mason.nvim` is the next generation version of `nvim-lsp-installer`. It builds on
> top of the very same foundation as `nvim-lsp-installer`, but with a majority of
> internals refactored to improve extensibility and testability.

fixes #2850

### TODOs

- [x] replace `nvim-lsp-installer` completely
- [x] ensure that template generation still works
- [x] fix data-race on server install (on_server_ready has been removed..)
- [ ] make sure no deprecated/outdated commands exist (how to replace `LspInstallInfo`?)
- [ ] add null-ls integration (requires a separate PR)
- [ ] add DAP integration (requires a separate PR)

