### PR TITLE
docs(lsp): fix the way of removing items from skipped_servers

### DIFF
--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -109,7 +109,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
 -- ---`:LvimInfo` lists which server(s) are skipped for the current filetype
--- lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_map(function(server)
+-- lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_filter(function(server)
 --   return server ~= "emmet_ls"
 -- end, lvim.lsp.automatic_configuration.skipped_servers)
 

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -109,7 +109,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
 -- ---`:LvimInfo` lists which server(s) are skipped for the current filetype
--- vim.tbl_map(function(server)
+-- lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_map(function(server)
 --   return server ~= "emmet_ls"
 -- end, lvim.lsp.automatic_configuration.skipped_servers)
 

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -124,7 +124,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
 -- ---`:LvimInfo` lists which server(s) are skipped for the current filetype
--- lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_map(function(server)
+-- lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_filter(function(server)
 --   return server ~= "emmet_ls"
 -- end, lvim.lsp.automatic_configuration.skipped_servers)
 

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -124,7 +124,7 @@ lvim.builtin.treesitter.highlight.enabled = true
 
 -- ---remove a server from the skipped list, e.g. eslint, or emmet_ls. !!Requires `:LvimCacheReset` to take effect!!
 -- ---`:LvimInfo` lists which server(s) are skipped for the current filetype
--- vim.tbl_map(function(server)
+-- lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_map(function(server)
 --   return server ~= "emmet_ls"
 -- end, lvim.lsp.automatic_configuration.skipped_servers)
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The currently way to remove items from skipped_servers list doesn't make any effect on the original list `lvim.lsp.automatic_configuration.skipped_servers`:

```lua
vim.tbl_map(function(server)
  return server ~= "emmet_ls"
end, lvim.lsp.automatic_configuration.skipped_servers)
```

The function `vim.tbl_map` only returns a new list with the certain function applied, and doesn't modify the original one. Also, by the example `return server ~= "emmet_ls"`, it doesn't return the list with filtered values, and yes a list with booleans resulted by the function.

The solution for this is just assigning the returned list from the `vim.tbl_map` function inside the original list `lvim.lsp.automatic_configuration.skipped_servers` and also changing the function to `vim.tbl_filter`, because this way makes sense with the function used in the example `return server ~= "emmet_ls"` to recieve a list with filtered values.


```lua
lvim.lsp.automatic_configuration.skipped_servers = vim.tbl_filter(function(server)
  return server ~= "emmet_ls"
end, lvim.lsp.automatic_configuration.skipped_servers)
```

Fixes #2501 