### PR TITLE
refactor: smaller timeout for packer

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -23,7 +23,7 @@ function plugin_loader.init(opts)
     max_jobs = 100,
     log = { level = "warn" },
     git = {
-      clone_timeout = 300,
+      clone_timeout = 120,
     },
     display = {
       open_fn = function()


### PR DESCRIPTION
I don't think anyone wants to wait 5 minutes for a git clone to fail. I think one minute is more than enough

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Reduce the timeout of packer for git clone

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

I don't think it is required, but CI should test this already