### PR TITLE
feat(installer): handle INSTALL_PREFIX not on PATH

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -299,7 +299,6 @@ function __validate_node_installation() {
   fi
 
   if [ ! -d "$manager_home" ] || [ ! -w "$manager_home" ]; then
-    echo "[ERROR] Unable to install using [$pkg_manager] without administrative privileges."
     return 1
   fi
 
@@ -314,21 +313,21 @@ function install_nodejs_deps() {
       return
     fi
   done
-  print_missing_dep_msg "${pkg_managers[@]}"
-  exit 1
+  echo "[WARN]: skipping installing optional nodejs dependencies due to insufficient permissions."
+  echo "check how to solve it: https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally"
 }
 
 function install_python_deps() {
   echo "Verifying that pip is available.."
-  if ! python3 -m ensurepip &>/dev/null; then
+  if ! python3 -m ensurepip >/dev/null; then
     if ! python3 -m pip --version &>/dev/null; then
-      print_missing_dep_msg "pip"
-      exit 1
+      echo "[WARN]: skipping installing optional python dependencies"
+      return 1
     fi
   fi
   echo "Installing with pip.."
   for dep in "${__pip_deps[@]}"; do
-    python3 -m pip install --user "$dep"
+    python3 -m pip install --user "$dep" || return 1
   done
   echo "All Python dependencies are successfully installed"
 }

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -26,6 +26,7 @@ declare ARGS_LOCAL=0
 declare ARGS_OVERWRITE=0
 declare ARGS_INSTALL_DEPENDENCIES=1
 declare INTERACTIVE_MODE=1
+declare ADDITIONAL_WARNINGS=""
 
 declare -a __lvim_dirs=(
   "$LUNARVIM_CONFIG_DIR"
@@ -148,6 +149,7 @@ function main() {
 
   setup_lvim
 
+  msg "$ADDITIONAL_WARNINGS"
   msg "Thank you for installing LunarVim!!"
   echo "You can start it by running: $INSTALL_PREFIX/bin/lvim"
   echo "Do not forget to use a font with glyphs (icons) support [https://github.com/ryanoasis/nerd-fonts]"
@@ -226,7 +228,25 @@ function validate_lunarvim_files() {
   fi
 }
 
+function validate_install_prefix() {
+  local prefix="$1"
+  case $PATH in
+    *"$prefix/bin"*)
+      return
+      ;;
+  esac
+  local profile="$HOME/.profile"
+  test -z "$ZSH_VERSION" && profile="$HOME/.zshenv"
+  ADDITIONAL_WARNINGS="[WARN] the folder $prefix/bin is not on PATH, consider adding 'export PATH=$prefix/bin:\$PATH' to your $profile"
+
+  # avoid problems when calling any verify_* function
+  export PATH="$prefix/bin:$PATH"
+}
+
 function check_system_deps() {
+
+  validate_install_prefix "$INSTALL_PREFIX"
+
   if ! command -v git &>/dev/null; then
     print_missing_dep_msg "git"
     exit 1


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- feat(installer): handle INSTALL_PREFIX not on PATH
- feat: skip optional deps on permission errors

<!--- Please list any dependencies that are required for this change. --->

fixes #2905

## How Has This Been Tested?

add this rule to Makefile

```make
install-local:
	@echo starting LunarVim local test installer
	@env \
		INSTALL_PREFIX=/tmp/p2 \
		NPM_HOME=/usr/local \
		LUNARVIM_CONFIG_DIR=/tmp/p2/xdg/config \
		LUNARVIM_RUNTIME_DIR=/tmp/p2/xdg/data \
		LUNARVIM_BASE_DIR=/tmp/p2/xdg/data/lvim \
		bash ./utils/installer/install.sh --local
```
