### PR TITLE
fix(statusline): display null-ls linters properly

### DIFF
--- a/lua/lvim/lsp/null-ls/linters.lua
+++ b/lua/lvim/lsp/null-ls/linters.lua
@@ -6,9 +6,19 @@ local null_ls = require "null-ls"
 local services = require "lvim.lsp.null-ls.services"
 local method = null_ls.methods.DIAGNOSTICS
 
+local alternative_methods = {
+  null_ls.methods.DIAGNOSTICS,
+  null_ls.methods.DIAGNOSTICS_ON_OPEN,
+  null_ls.methods.DIAGNOSTICS_ON_SAVE,
+}
+
 function M.list_registered(filetype)
   local registered_providers = services.list_registered_providers_names(filetype)
-  return registered_providers[method] or {}
+  local providers_for_methods = vim.tbl_flatten(vim.tbl_map(function(m)
+    return registered_providers[m] or {}
+  end, alternative_methods))
+
+  return providers_for_methods
 end
 
 function M.list_supported(filetype)


### PR DESCRIPTION


<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

null-ls linters may have either `DIAGNOSTIC`, `DIAGNOSTIC_ON_OPEN`, or `DIAGNOSTIC_ON_SAVE` as its method parameter. e.g., https://github.com/jose-elias-alvarez/null-ls.nvim/blob/8914051a3d399e9715833ad76bbf5fe69ea7faf0/lua/null-ls/builtins/diagnostics/buf.lua#L12

Currently, only linters with `DIAGNOSTIC` are shown in the lsp component on the statusline regardless of whether the linters are registered and work properly.

This is due to `lvim.lsp.null-ls.linters.list_registers` returning only linters with `DIAGNOSTIC`.

This PR makes that function retrieve the linters with all three method types and return the merged list.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Register `buf` null-ls linter, which is set to `DIAGNOSTIC_ON_SAVE`, open a supported file (i.e., proto file), then check if `buf` linter is shown in the statusline.

