### PR TITLE
refactor(config): tell the users which config file is exactly failing

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -116,7 +116,7 @@ function M:load(config_path)
   local ok, err = pcall(dofile, config_path)
   if not ok then
     if utils.is_file(user_config_file) then
-      Log:warn("Invalid configuration: " .. err)
+      Log:warn(string.format("Invalid configuration(%s): %s", user_config_file, err))
     else
       vim.notify_once(string.format("Unable to find configuration file [%s]", config_path), vim.log.levels.WARN)
     end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I find frustrating that, when something fails, I just get the error message and a log message pointing to init.lua, which is not very helpful. This adds the path of the failing config file to be super explicit to the user

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run lvim with anything wrong at userland config
- Check logs and see the file that fails is being pointed out

