### PR TITLE
fix(ts_context_commentstring): block comment match new api

### DIFF
--- a/lua/lvim/core/comment.lua
+++ b/lua/lvim/core/comment.lua
@@ -3,8 +3,24 @@ local M = {}
 function M.config()
   local pre_hook = nil
   if lvim.builtin.treesitter.context_commentstring.enable then
-    pre_hook = function(_ctx)
-      return require("ts_context_commentstring.internal").calculate_commentstring()
+    pre_hook = function(ctx)
+      local U = require "Comment.utils"
+
+      -- Determine whether to use linewise or blockwise commentstring
+      local type = ctx.ctype == U.ctype.linewise and "__default" or "__multiline"
+
+      -- Determine the location where to calculate commentstring from
+      local location = nil
+      if ctx.ctype == U.ctype.blockwise then
+        location = require("ts_context_commentstring.utils").get_cursor_location()
+      elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
+        location = require("ts_context_commentstring.utils").get_visual_start_location()
+      end
+
+      return require("ts_context_commentstring.internal").calculate_commentstring {
+        key = type,
+        location = location,
+      }
     end
   end
   lvim.builtin.comment = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`Ctrl` + `/` now works for block comments. Visual select something, press `Ctrl` + `/` and it should NOT comment out the whole line but only the selection.

<!--- Please list any dependencies that are required for this change. --->

fixes #2937 