### PR TITLE
fix(lsp): delete documentHighlight/codelens autocmds on LspDetach

### DIFF
--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -94,16 +94,28 @@ function M.setup_document_highlight(client, bufnr)
   if not augroup_exist then
     vim.api.nvim_create_augroup("lsp_document_highlight", {})
   end
-  vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+  local aucmd = vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
     group = "lsp_document_highlight",
     buffer = bufnr,
     callback = vim.lsp.buf.document_highlight,
   })
-  vim.api.nvim_create_autocmd("CursorMoved", {
+  local aucmd2 = vim.api.nvim_create_autocmd("CursorMoved", {
     group = "lsp_document_highlight",
     buffer = bufnr,
     callback = vim.lsp.buf.clear_references,
   })
+
+  if vim.fn.has "nvim-0.8" > 0 then
+    vim.api.nvim_create_autocmd("LspDetach", {
+      group = "lsp_document_highlight",
+      buffer = bufnr,
+      callback = function()
+        for _, v in pairs { aucmd, aucmd2 } do
+          pcall(vim.api.nvim_del_autocmd, v)
+        end
+      end,
+    })
+  end
 end
 
 function M.setup_codelens_refresh(client, bufnr)
@@ -119,11 +131,21 @@ function M.setup_codelens_refresh(client, bufnr)
   if not augroup_exist then
     vim.api.nvim_create_augroup("lsp_code_lens_refresh", {})
   end
-  vim.api.nvim_create_autocmd({ "BufEnter", "InsertLeave" }, {
+  local aucmd = vim.api.nvim_create_autocmd({ "BufEnter", "InsertLeave" }, {
     group = "lsp_code_lens_refresh",
     buffer = bufnr,
     callback = vim.lsp.codelens.refresh,
   })
+
+  if vim.fn.has "nvim-0.8" > 0 then
+    vim.api.nvim_create_autocmd("LspDetach", {
+      group = "lsp_code_lens_refresh",
+      buffer = bufnr,
+      callback = function()
+        pcall(vim.api.nvim_del_autocmd, aucmd)
+      end,
+    })
+  end
 end
 
 ---filter passed to vim.lsp.buf.format


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

<!--- Please list any dependencies that are required for this change. --->

fixes #2952

## How Has This Been Tested?

- Run `:LspStop` after attaching.
- Run `:autocmd CursorHold`, `lsp_document_highlight` should not be there.