### PR TITLE
fix(lsp): pass name arg to should_auto_install

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -98,10 +98,10 @@ function M.setup(server_name, user_config)
     return
   end
 
-  local should_auto_install = function()
+  local should_auto_install = function(name)
     local installer_settings = lvim.lsp.installer.setup
     return installer_settings.automatic_installation
-      and not vim.tbl_contains(installer_settings.automatic_installation.exclude, server_name)
+      and not vim.tbl_contains(installer_settings.automatic_installation.exclude, name)
   end
 
   if not registry.is_installed(pkg_name) then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The predicate function of the lsp manager should accept one argument to make it more clear and portable

<!--- Please list any dependencies that are required for this change. --->


## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- It is just a minor style correction

