### PR TITLE
feat(luasnip): add virtual text to snippets and add lunarvim snippets

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -29,18 +29,6 @@ function M:init()
   local lvim_lsp_config = require "lvim.lsp.config"
   lvim.lsp = vim.deepcopy(lvim_lsp_config)
 
-  lvim.builtin.luasnip = {
-    sources = {
-      friendly_snippets = true,
-    },
-    config = {
-      updateevents = "TextChanged,TextChangedI",
-      ext_opts = {
-        -- Will be populated within config function
-      },
-    },
-  }
-
   require("lvim.config._deprecated").handle()
 end
 

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -33,6 +33,12 @@ function M:init()
     sources = {
       friendly_snippets = true,
     },
+    config = {
+      updateevents = "TextChanged,TextChangedI",
+      ext_opts = {
+        -- Will be populated within config function
+      },
+    },
   }
 
   require("lvim.config._deprecated").handle()

--- a/lua/lvim/core/builtins/init.lua
+++ b/lua/lvim/core/builtins/init.lua
@@ -21,6 +21,7 @@ local builtins = {
   "lvim.core.lualine",
   "lvim.core.alpha",
   "lvim.core.mason",
+  "lvim.core.luasnip",
 }
 
 function M.config(config)

--- a/lua/lvim/core/luasnip/init.lua
+++ b/lua/lvim/core/luasnip/init.lua
@@ -6,6 +6,7 @@ function M.config()
       lunarvim = true,
     },
     config = {
+      history = false,
       updateevents = "TextChanged,TextChangedI",
       ext_opts = {
         -- Will be populated within config function
@@ -49,7 +50,7 @@ function M.setup()
     },
   }
   -- Add lunarvim options giving preference to user ones
-  vim.tbl_deep_extend("keep", lvim.builtin.luasnip.config.ext_opts, ext_opts)
+  lvim.builtin.luasnip.config.ext_opts = vim.tbl_deep_extend("keep", lvim.builtin.luasnip.config.ext_opts, ext_opts)
   luasnip.config.set_config(lvim.builtin.luasnip.config)
   if lvim.builtin.luasnip.sources.lunarvim then
     luasnip.add_snippets("lua", require "lvim.core.luasnip.snippets")

--- a/lua/lvim/core/luasnip/init.lua
+++ b/lua/lvim/core/luasnip/init.lua
@@ -1,0 +1,58 @@
+local M = {}
+function M.config()
+  lvim.builtin.luasnip = {
+    sources = {
+      friendly_snippets = true,
+      lunarvim = true,
+    },
+    config = {
+      updateevents = "TextChanged,TextChangedI",
+      ext_opts = {
+        -- Will be populated within config function
+      },
+    },
+  }
+end
+
+function M.setup()
+  local utils = require "lvim.utils"
+  local paths = {}
+  if lvim.builtin.luasnip.sources.friendly_snippets then
+    paths[#paths + 1] = utils.join_paths(get_runtime_dir(), "site", "pack", "packer", "start", "friendly-snippets")
+  end
+  local user_snippets = utils.join_paths(get_config_dir(), "snippets")
+  if utils.is_directory(user_snippets) then
+    paths[#paths + 1] = user_snippets
+  end
+  -- When no paths are provided, luasnip will search in the runtimepath
+  require("luasnip.loaders.from_lua").lazy_load()
+  require("luasnip.loaders.from_vscode").lazy_load {
+    paths = paths,
+  }
+  require("luasnip.loaders.from_snipmate").lazy_load()
+
+  local luasnip = require "luasnip"
+  local types = require "luasnip.util.types"
+
+  local ext_opts = {
+    -- Show virtual text to signal when you are inside an sippets
+    [types.insertNode] = {
+      active = {
+        virt_text = { { "<-- snip insert", "BufferInactiveIndex" } },
+      },
+    },
+    -- Helps to notice when you are within a choice node
+    [types.choiceNode] = {
+      active = {
+        virt_text = { { "<-- choice", "BufferInactiveIndex" } },
+      },
+    },
+  }
+  -- Add lunarvim options giving preference to user ones
+  vim.tbl_deep_extend("keep", lvim.builtin.luasnip.config.ext_opts, ext_opts)
+  luasnip.config.set_config(lvim.builtin.luasnip.config)
+  if lvim.builtin.luasnip.sources.lunarvim then
+    luasnip.add_snippets("lua", require "lvim.core.luasnip.snippets")
+  end
+end
+return M

--- a/lua/lvim/core/luasnip/snippets.lua
+++ b/lua/lvim/core/luasnip/snippets.lua
@@ -1,32 +1,30 @@
----@diagnostic disable: unused-local for convenience is better to have all luasnip methods available
 -- About how to create snippets:
 -- https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md
-local ls = require "luasnip"
-local s = ls.snippet
-local sn = ls.snippet_node
-local isn = ls.indent_snippet_node
-local t = ls.text_node
-local i = ls.insert_node
-local f = ls.function_node
-local c = ls.choice_node
-local d = ls.dynamic_node
-local r = ls.restore_node
-local events = require "luasnip.util.events"
-local ai = require "luasnip.nodes.absolute_indexer"
+-- uncoment nodes as you need them
+-- local sn = ls.snippet_node
+-- local isn = ls.indent_snippet_node
+-- local t = ls.text_node
+-- local f = ls.function_node
+-- local c = ls.choice_node
+-- local d = ls.dynamic_node
+-- local r = ls.restore_node
+-- local m = extras.m
+-- local rep = extras.rep
+-- local postfix = require("luasnip.extras.postfix").postfix
 local fmt = require("luasnip.extras.fmt").fmt
 local extras = require "luasnip.extras"
-local m = extras.m
 local l = extras.l
 local dl = extras.dynamic_lambda
-local rep = extras.rep
-local postfix = require("luasnip.extras.postfix").postfix
+local ls = require "luasnip"
+local s = ls.snippet
+local i = ls.insert_node
 
 return {
   s(
     { trig = "preq", dscr = "Protected require call" },
     fmt(
-      [[ 
-      local ok, {} = pcall(require,'{}') 
+      [[
+      local ok, {} = pcall(require,'{}')
       if not ok then
         return
       end]],

--- a/lua/lvim/core/luasnip/snippets.lua
+++ b/lua/lvim/core/luasnip/snippets.lua
@@ -1,0 +1,36 @@
+---@diagnostic disable: unused-local for convenience is better to have all luasnip methods available
+-- About how to create snippets:
+-- https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md
+local ls = require "luasnip"
+local s = ls.snippet
+local sn = ls.snippet_node
+local isn = ls.indent_snippet_node
+local t = ls.text_node
+local i = ls.insert_node
+local f = ls.function_node
+local c = ls.choice_node
+local d = ls.dynamic_node
+local r = ls.restore_node
+local events = require "luasnip.util.events"
+local ai = require "luasnip.nodes.absolute_indexer"
+local fmt = require("luasnip.extras.fmt").fmt
+local extras = require "luasnip.extras"
+local m = extras.m
+local l = extras.l
+local dl = extras.dynamic_lambda
+local rep = extras.rep
+local postfix = require("luasnip.extras.postfix").postfix
+
+return {
+  s(
+    { trig = "preq", dscr = "Protected require call" },
+    fmt(
+      [[ 
+      local ok, {} = pcall(require,'{}') 
+      if not ok then
+        return
+      end]],
+      { i(1), dl(2, "lvim.core." .. l._1, 1) }
+    )
+  ),
+}

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -58,32 +58,7 @@ local core_plugins = {
   {
     "L3MON4D3/LuaSnip",
     config = function()
-      local utils = require "lvim.utils"
-      local paths = {}
-      if lvim.builtin.luasnip.sources.friendly_snippets then
-        paths[#paths + 1] = utils.join_paths(get_runtime_dir(), "site", "pack", "packer", "start", "friendly-snippets")
-      end
-      local user_snippets = utils.join_paths(get_config_dir(), "snippets")
-      if utils.is_directory(user_snippets) then
-        paths[#paths + 1] = user_snippets
-      end
-      require("luasnip.loaders.from_lua").lazy_load()
-      require("luasnip.loaders.from_vscode").lazy_load {
-        paths = paths,
-      }
-      require("luasnip.loaders.from_snipmate").lazy_load()
-      local luasnip = require "luasnip"
-      local types = require "luasnip.util.types"
-
-      local ext_opts = {
-        [types.insertNode] = {
-          active = {
-            virt_text = { { "<-- snip insert", "BufferInactiveIndex" } },
-          },
-        },
-      }
-      vim.tbl_deep_extend(lvim.builtin.config.ext_opts, ext_opts)
-      luasnip.config.set_config(lvim.builtin.luasnip.config)
+      require("lvim.core.luasnip").setup()
     end,
   },
   {

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -72,6 +72,18 @@ local core_plugins = {
         paths = paths,
       }
       require("luasnip.loaders.from_snipmate").lazy_load()
+      local luasnip = require "luasnip"
+      local types = require "luasnip.util.types"
+
+      local ext_opts = {
+        [types.insertNode] = {
+          active = {
+            virt_text = { { "<-- snip insert", "BufferInactiveIndex" } },
+          },
+        },
+      }
+      vim.tbl_deep_extend(lvim.builtin.config.ext_opts, ext_opts)
+      luasnip.config.set_config(lvim.builtin.luasnip.config)
     end,
   },
   {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This adds virtual text to the current insertion point of lua-snip. It also creates a new entry in the lua-snip dictionary in case anyone wants to configure it through lunar vim. Take a look at the below screenshot to see how it looks like in case of a regular snippet
![image](https://user-images.githubusercontent.com/2270425/187189806-e7af1092-50dd-453b-95c4-4c5c6ed92fcb.png)
below screenshot show how it looks when you are on a choice node within a snippet
![image](https://user-images.githubusercontent.com/2270425/187382556-4260db00-e778-441b-8afa-9903e549237d.png)



## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Execute any luasnip command with insertion points
- See how you get virtual text hints about where the current insertion point is


