### PR TITLE
fix(core/autocmds): do not check for existence on clear_augroup

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -155,19 +155,11 @@ end
 ---@param name string the augroup name
 function M.clear_augroup(name)
   -- defer the function in case the autocommand is still in-use
-  local exists, _ = pcall(vim.api.nvim_get_autocmds, { group = name })
-  if not exists then
-    Log:debug("ignoring request to clear autocmds from non-existent group " .. name)
-    return
-  end
+  Log:debug("request to clear autocmds  " .. name)
   vim.schedule(function()
-    local status_ok, _ = xpcall(function()
+    pcall(function()
       vim.api.nvim_clear_autocmds { group = name }
-    end, debug.traceback)
-    if not status_ok then
-      Log:warn("problems detected while clearing autocmds from " .. name)
-      Log:debug(debug.traceback())
-    end
+    end)
   end)
 end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

<!--- Please list any dependencies that are required for this change. --->

fixes #2952

## How Has This Been Tested?

- Run `:LspStop` after attaching.
- Run `:autocmd CursorHold`, `lsp_document_highlight` should not be there.

See also https://github.com/LunarVim/LunarVim/pull/2953