### PR TITLE
fix(cmp): fix cmp select on CR

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -272,19 +272,15 @@ M.config = function()
           if is_insert_mode() then -- prevent overwriting brackets
             confirm_opts.behavior = cmp.ConfirmBehavior.Insert
           end
-          if not cmp.confirm(confirm_opts) then
-            fallback()
+          if cmp.confirm(confirm_opts) then
+            return -- success, exit early
           end
-          return
         end
 
-        if jumpable(1) then
-          if not luasnip.jump(1) then
-            fallback()
-          end
-        else
-          fallback()
+        if jumpable(1) and luasnip.jump(1) then
+          return -- success, exit early
         end
+        fallback() -- if not exited early, always fallback
       end),
     },
   }

--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -272,9 +272,8 @@ M.config = function()
           if is_insert_mode() then -- prevent overwriting brackets
             confirm_opts.behavior = cmp.ConfirmBehavior.Insert
           end
-          cmp.confirm(confirm_opts)
-          if jumpable(1) then
-            luasnip.jump(1)
+          if not cmp.confirm(confirm_opts) then
+            fallback()
           end
           return
         end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When cmp prompt is open and nothing is selected cr did nothing
Also fixes snippets texts being overwritten when you select an option 
<!--- Please list any dependencies that are required for this change. --->

fixes #2977
This PR superseeds #2979 

## How Has This Been Tested?

- Trigger cmp window and do not select anything
- Tap enter and see how it properly inserts a newline
- Expand one snippet using cmp
- check that selecting a cmp item while editing the snippet does not override the snippet text

