### PR TITLE
feat: warn user when setting un-installed colorscheme

### DIFF
--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -100,7 +100,7 @@ M.setup = function()
   local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)
   if #colors == 0 then
     Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
-    return
+    lvim.colorscheme = "tokyonight"
   end
 
   vim.g.colors_name = lvim.colorscheme

--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -1,3 +1,5 @@
+local Log = require "lvim.core.log"
+
 local M = {}
 
 M.config = function()
@@ -85,20 +87,26 @@ end
 M.setup = function()
   -- avoid running in headless mode since it's harder to detect failures
   if #vim.api.nvim_list_uis() == 0 then
-    local Log = require "lvim.core.log"
     Log:debug "headless mode detected, skipping running setup for lualine"
     return
   end
 
   local status_ok, theme = pcall(require, "tokyonight")
-  if not status_ok then
+  if status_ok and theme then
+    theme.setup(lvim.builtin.theme.options)
+  end
+
+  -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
+  local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)
+  if #colors == 0 then
+    Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
     return
   end
 
-  theme.setup(lvim.builtin.theme.options)
+  vim.g.colors_name = lvim.colorscheme
+  vim.cmd("colorscheme " .. lvim.colorscheme)
 
   require("lvim.core.lualine").setup()
-
   require("lvim.core.lir").icon_setup()
 end
 

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -106,13 +106,19 @@ function plugin_loader.load(configurations)
         end
       end
     end)
-    -- colorscheme must get called after plugins are loaded or it will break new installs.
-    vim.g.colors_name = lvim.colorscheme
-    vim.cmd("colorscheme " .. lvim.colorscheme)
   end, debug.traceback)
+
   if not status_ok then
     Log:warn "problems detected while loading plugins' configurations"
     Log:trace(debug.traceback())
+  end
+
+  -- colorscheme must get called after plugins are loaded or it will break new installs.
+  vim.g.colors_name = lvim.colorscheme
+  local set_colorscheme_ok, _ = pcall(vim.cmd, "colorscheme " .. lvim.colorscheme)
+
+  if not set_colorscheme_ok then
+    Log:warn(string.format("problem detected: could not find '%s' colorscheme", lvim.colorscheme))
   end
 end
 

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -113,13 +113,14 @@ function plugin_loader.load(configurations)
     Log:trace(debug.traceback())
   end
 
-  -- colorscheme must get called after plugins are loaded or it will break new installs.
-  vim.g.colors_name = lvim.colorscheme
-  local set_colorscheme_ok, _ = pcall(vim.cmd, "colorscheme " .. lvim.colorscheme)
-
-  if not set_colorscheme_ok then
-    Log:warn(string.format("problem detected: could not find '%s' colorscheme", lvim.colorscheme))
+  -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
+  local colors = vim.api.nvim_get_runtime_file(("colors/%s*"):format(lvim.colorscheme), false)
+  if #colors == 0 then
+    Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
+    return
   end
+  vim.g.colors_name = lvim.colorscheme
+  vim.cmd("colorscheme " .. lvim.colorscheme)
 end
 
 function plugin_loader.get_core_plugins()

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -112,15 +112,6 @@ function plugin_loader.load(configurations)
     Log:warn "problems detected while loading plugins' configurations"
     Log:trace(debug.traceback())
   end
-
-  -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
-  local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)
-  if #colors == 0 then
-    Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
-    return
-  end
-  vim.g.colors_name = lvim.colorscheme
-  vim.cmd("colorscheme " .. lvim.colorscheme)
 end
 
 function plugin_loader.get_core_plugins()

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -114,7 +114,7 @@ function plugin_loader.load(configurations)
   end
 
   -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
-  local colors = vim.api.nvim_get_runtime_file(("colors/%s*"):format(lvim.colorscheme), false)
+  local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)
   if #colors == 0 then
     Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
     return


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The two colorscheme lines below inside `xpcall` function couldn't take any advantage of the `debug.traceback` function.

https://github.com/LunarVim/LunarVim/blob/6ab3e8a73920e3d2e02e57f7dd3a1f3d8e54ee63/lua/lvim/plugin-loader.lua#L109-L111

So when users set colorscheme that hasn't been installed, they will be warned with

> "problems detected while loading plugins' configurations" 

without knowing what happen inside their config. We should move it outside and handle its own error instead.

~~Also clear core plugins' caches on saving `config.lua` file. So that the change will instantly load without exiting and entering `lvim` again.~~

fixes #2856

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Set `lvim.colorscheme="something"`
- Should be warned with 

<img width="525" alt="Screenshot 2022-09-01 at 22 13 13" src="https://user-images.githubusercontent.com/42694704/187949700-97f2f3ed-ccb0-403f-b72c-759f6c379b37.png">


