### PR TITLE
feat(telecope): set show_untracked by default

### DIFF
--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -79,6 +79,9 @@ function M.config()
         --@usage don't include the filename in the search results
         only_sort_text = true,
       },
+      git_files = {
+        show_untracked = true,
+      },
     },
     extensions = {
       fzf = {

--- a/lua/lvim/core/telescope/custom-finders.lua
+++ b/lua/lvim/core/telescope/custom-finders.lua
@@ -90,11 +90,10 @@ end
 -- contained in a Git repo.
 function M.find_project_files(opts)
   opts = opts or {}
-  local show_untracked = vim.F.if_nil(opts.show_untracked, false)
-  local ok = pcall(builtin.git_files, { show_untracked = show_untracked })
+  local ok = pcall(builtin.git_files, opts)
 
   if not ok then
-    builtin.find_files()
+    builtin.find_files(opts)
   end
 end
 

--- a/lua/lvim/core/telescope/custom-finders.lua
+++ b/lua/lvim/core/telescope/custom-finders.lua
@@ -88,8 +88,10 @@ end
 
 -- Smartly opens either git_files or find_files, depending on whether the working directory is
 -- contained in a Git repo.
-function M.find_project_files()
-  local ok = pcall(builtin.git_files)
+function M.find_project_files(opts)
+  opts = opts or {}
+  local show_untracked = vim.F.if_nil(opts.show_untracked, false)
+  local ok = pcall(builtin.git_files, { show_untracked = show_untracked })
 
   if not ok then
     builtin.find_files()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- add the ability to display untracked files by default when invoking `find_project_files`
- can be turned off by setting the `show_untracked` to `false`.

## How Has This Been Tested?

```lua
-- show untracked files
require('lvim.core.telescope.custom-finders').find_project_files()

-- skip untracked files
require('lvim.core.telescope.custom-finders').find_project_files({show_untracked = false})
```
