### PR TITLE
fix(plugins): bring back original folke repos

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -102,8 +102,7 @@ local core_plugins = {
     "hrsh7th/cmp-path",
   },
   {
-    -- NOTE: Temporary fix till folke comes back
-    "max397574/lua-dev.nvim",
+    "folke/lua-dev.nvim",
     module = "lua-dev",
   },
 
@@ -153,7 +152,7 @@ local core_plugins = {
 
   -- Whichkey
   {
-    "max397574/which-key.nvim",
+    "folke/which-key.nvim",
     config = function()
       require("lvim.core.which-key").setup()
     end,

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -12,7 +12,7 @@
     "commit": "09e5374"
   },
   "bufferline.nvim": {
-    "commit": "13a532e"
+    "commit": "0b4b863"
   },
   "cmp-buffer": {
     "commit": "3022dbc"
@@ -36,7 +36,7 @@
     "commit": "d7e0bcb"
   },
   "lua-dev.nvim": {
-    "commit": "54149d1"
+    "commit": "9381ad0"
   },
   "lualine.nvim": {
     "commit": "3cf4540"
@@ -111,6 +111,6 @@
     "commit": "7abb25e"
   },
   "which-key.nvim": {
-    "commit": "f03a259"
+    "commit": "439637d"
   }
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

[folke is back](https://github.com/LunarVim/LunarVim/pull/2538#issuecomment-1238668560), so we don't need to use the alternative repos anymore

cc: @danielo515 

