### PR TITLE
fix(lsp): enforce lvim completion for lua-server

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
   "Lua.diagnostics.disable": [
     "redundant-parameter",
-    "param-type-mismatch"
+    "param-type-mismatch",
+    "missing-parameter"
   ],
   "diagnostics.libraryFiles": "Disable"
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "Lua.diagnostics.disable": [
+    "redundant-parameter",
+    "param-type-mismatch"
+  ],
+  "diagnostics.libraryFiles": "Disable"
+}

--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -1,37 +1,38 @@
-local dev_opts = {
+local default_workspace = {
   library = {
-    vimruntime = true, -- runtime path
-    types = true, -- full signature, docs and completion of vim.api, vim.treesitter, vim.lsp and others
-    -- plugins = true, -- installed opt or start plugins in packpath
-    -- you can also specify the list of plugins to make available as a workspace library
-    plugins = { "plenary.nvim", "telescope.nvim", "nvim-treesitter", "packer.nvim", "LuaSnip" },
+    vim.fn.expand "$VIMRUNTIME",
+    get_lvim_base_dir(),
+    require("lua-dev.sumneko").types(),
   },
-  override = function(root_dir, library)
-    -- workaround for hard-coded lua_dev.util.is_nvim_config()
-    if root_dir == get_config_dir() or root_dir == get_lvim_base_dir() then
-      library.enabled = true
-      library.plugins = { "plenary.nvim", "telescope.nvim", "nvim-treesitter", "packer.nvim", "LuaSnip" }
-    end
-  end,
+
+  maxPreload = 1000,
+  preloadFileSize = 10000,
 }
 
-local lua_dev_loaded, lua_dev = pcall(require, "lua-dev")
-if lua_dev_loaded then
-  lua_dev.setup(dev_opts)
+local add_packages_to_workspace = function(packages, config)
+  -- config.settings.Lua = config.settings.Lua or { workspace = default_workspace }
+  local runtimedirs = vim.api.nvim__get_runtime({ "lua" }, true, { is_lua = true })
+  local workspace = config.settings.Lua.workspace
+  for _, v in pairs(runtimedirs) do
+    for _, pack in ipairs(packages) do
+      if v:match(pack) and not vim.tbl_contains(workspace.library, v) then
+        table.insert(workspace.library, v)
+      end
+    end
+  end
 end
 
 local lspconfig = require "lspconfig"
 
-local make_on_new_config = function(on_new_config)
+local make_on_new_config = function(on_new_config, _)
   return lspconfig.util.add_hook_before(on_new_config, function(new_config, _)
     local server_name = new_config.name
 
     if server_name ~= "sumneko_lua" then
       return
     end
-    -- this is otherwise getting overwritten by lua_dev.lsp.on_new_config()
-    new_config.settings.Lua = new_config.settings.Lua or { workspace = { library = {} } }
-    table.insert(new_config.settings.Lua.workspace.library, get_lvim_base_dir())
+    local plugins = { "plenary", "telescope", "packer", "nvim-treesitter", "LuaSnip" }
+    add_packages_to_workspace(plugins, new_config)
   end)
 end
 
@@ -42,16 +43,11 @@ lspconfig.util.default_config = vim.tbl_extend("force", lspconfig.util.default_c
 local opts = {
   settings = {
     Lua = {
+      telemetry = { enable = false },
       diagnostics = {
         globals = { "vim", "lvim", "packer_plugins" },
       },
-      workspace = {
-        library = {
-          [require("lvim.utils").join_paths(get_runtime_dir(), "lvim", "lua")] = true,
-        },
-        maxPreload = 100000,
-        preloadFileSize = 10000,
-      },
+      workspace = default_workspace,
     },
   },
 }

--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -4,15 +4,40 @@ local dev_opts = {
     types = true, -- full signature, docs and completion of vim.api, vim.treesitter, vim.lsp and others
     -- plugins = true, -- installed opt or start plugins in packpath
     -- you can also specify the list of plugins to make available as a workspace library
-    plugins = { "plenary.nvim" },
+    plugins = { "plenary.nvim", "telescope.nvim", "nvim-treesitter", "packer.nvim", "LuaSnip" },
   },
-  override = nil, -- function(root_dir, options) end,
+  override = function(root_dir, library)
+    -- workaround for hard-coded lua_dev.util.is_nvim_config()
+    if root_dir == get_config_dir() or root_dir == get_lvim_base_dir() then
+      library.enabled = true
+      library.plugins = { "plenary.nvim", "telescope.nvim", "nvim-treesitter", "packer.nvim", "LuaSnip" }
+    end
+  end,
 }
 
 local lua_dev_loaded, lua_dev = pcall(require, "lua-dev")
 if lua_dev_loaded then
   lua_dev.setup(dev_opts)
 end
+
+local lspconfig = require "lspconfig"
+
+local make_on_new_config = function(on_new_config)
+  return lspconfig.util.add_hook_before(on_new_config, function(new_config, _)
+    local server_name = new_config.name
+
+    if server_name ~= "sumneko_lua" then
+      return
+    end
+    -- this is otherwise getting overwritten by lua_dev.lsp.on_new_config()
+    new_config.settings.Lua = new_config.settings.Lua or { workspace = { library = {} } }
+    table.insert(new_config.settings.Lua.workspace.library, get_lvim_base_dir())
+  end)
+end
+
+lspconfig.util.default_config = vim.tbl_extend("force", lspconfig.util.default_config, {
+  on_new_config = make_on_new_config(lspconfig.util.default_config.on_new_config),
+})
 
 local opts = {
   settings = {

--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -31,7 +31,7 @@ local make_on_new_config = function(on_new_config, _)
     if server_name ~= "sumneko_lua" then
       return
     end
-    local plugins = { "plenary", "telescope", "packer", "nvim-treesitter", "LuaSnip" }
+    local plugins = { "plenary.nvim", "telescope.nvim", "nvim-treesitter", "LuaSnip" }
     add_packages_to_workspace(plugins, new_config)
   end)
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`lua-dev` has changed the way it accepts settings, this will now hopefully accommodate those changes!

- fix `lvim.` auto-completion in `config.lua`
- add a select list of plugins by default that should always have auto-completion
  ```lua
  plugins = { "plenary.nvim", "telescope.nvim", "nvim-treesitter", "packer.nvim", "LuaSnip" }
  ```

fixes #3002

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- open `config.lua` start typing `lvim.builtin.telescope.`
- open `config.lua` start typing `require'packer.`

