### PR TITLE
fix(lir): warning only if both lir and nvimtree are active

### DIFF
--- a/lua/lvim/core/lir.lua
+++ b/lua/lvim/core/lir.lua
@@ -4,11 +4,12 @@ local Log = require "lvim.core.log"
 
 M.config = function()
   lvim.builtin.lir = {
-    active = true,
+    active = false,
     on_config_done = nil,
   }
 
   local status_ok, lir = pcall(require, "lir")
+
   if not status_ok then
     return
   end
@@ -96,13 +97,14 @@ M.config = function()
 end
 
 function M.setup()
-  if lvim.builtin.nvimtree.active then
-    Log:warn "Unable to configure lir while nvimtree is active! Please set 'lvim.builtin.nvimtree.active=false'"
+  local status_ok, lir = pcall(require, "lir")
+
+  if not status_ok then
     return
   end
 
-  local status_ok, lir = pcall(require, "lir")
-  if not status_ok then
+  if lvim.builtin.nvimtree.active then
+    Log:warn "Unable to configure lir while nvimtree is active! Please set 'lvim.builtin.nvimtree.active=false'"
     return
   end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Make sure `lir` is active before checking conflicting with `nvimtree`

## How Has This Been Tested?

- Set `lvim.builtin.lir.active = false` and `lvim.builtin.nvimtree.active = true`
- See there is no warning about `nvimtree`
