### PR TITLE
revert: fix Packer instead of hard-coding config

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -49,13 +49,6 @@ M.config = function()
       depth_limit_indicator = "..",
     },
   }
-  local status_ok, navic = pcall(require, "nvim-navic")
-  if not status_ok then
-    return
-  end
-
-  navic.setup(lvim.builtin.breadcrumbs.options)
-  M.create_winbar()
 end
 
 M.setup = function()
@@ -64,6 +57,7 @@ M.setup = function()
     return
   end
 
+  M.create_winbar()
   navic.setup(lvim.builtin.breadcrumbs.options)
 
   if lvim.builtin.breadcrumbs.on_config_done then

--- a/lua/lvim/core/illuminate.lua
+++ b/lua/lvim/core/illuminate.lua
@@ -4,58 +4,59 @@ M.config = function()
   lvim.builtin.illuminate = {
     active = true,
     on_config_done = nil,
+    options = {
+      -- providers: provider used to get references in the buffer, ordered by priority
+      providers = {
+        "lsp",
+        "treesitter",
+        "regex",
+      },
+      -- delay: delay in milliseconds
+      delay = 120,
+      -- filetypes_denylist: filetypes to not illuminate, this overrides filetypes_allowlist
+      filetypes_denylist = {
+        "dirvish",
+        "fugitive",
+        "alpha",
+        "NvimTree",
+        "packer",
+        "neogitstatus",
+        "Trouble",
+        "lir",
+        "Outline",
+        "spectre_panel",
+        "toggleterm",
+        "DressingSelect",
+        "TelescopePrompt",
+      },
+      -- filetypes_allowlist: filetypes to illuminate, this is overriden by filetypes_denylist
+      filetypes_allowlist = {},
+      -- modes_denylist: modes to not illuminate, this overrides modes_allowlist
+      modes_denylist = {},
+      -- modes_allowlist: modes to illuminate, this is overriden by modes_denylist
+      modes_allowlist = {},
+      -- providers_regex_syntax_denylist: syntax to not illuminate, this overrides providers_regex_syntax_allowlist
+      -- Only applies to the 'regex' provider
+      -- Use :echom synIDattr(synIDtrans(synID(line('.'), col('.'), 1)), 'name')
+      providers_regex_syntax_denylist = {},
+      -- providers_regex_syntax_allowlist: syntax to illuminate, this is overriden by providers_regex_syntax_denylist
+      -- Only applies to the 'regex' provider
+      -- Use :echom synIDattr(synIDtrans(synID(line('.'), col('.'), 1)), 'name')
+      providers_regex_syntax_allowlist = {},
+      -- under_cursor: whether or not to illuminate under the cursor
+      under_cursor = true,
+    },
   }
+end
 
+M.setup = function()
   local status_ok, illuminate = pcall(require, "illuminate")
   if not status_ok then
     return
   end
 
-  illuminate.configure {
-    -- providers: provider used to get references in the buffer, ordered by priority
-    providers = {
-      "lsp",
-      "treesitter",
-      "regex",
-    },
-    -- delay: delay in milliseconds
-    delay = 120,
-    -- filetypes_denylist: filetypes to not illuminate, this overrides filetypes_allowlist
-    filetypes_denylist = {
-      "dirvish",
-      "fugitive",
-      "alpha",
-      "NvimTree",
-      "packer",
-      "neogitstatus",
-      "Trouble",
-      "lir",
-      "Outline",
-      "spectre_panel",
-      "toggleterm",
-      "DressingSelect",
-      "TelescopePrompt",
-    },
-    -- filetypes_allowlist: filetypes to illuminate, this is overriden by filetypes_denylist
-    filetypes_allowlist = {},
-    -- modes_denylist: modes to not illuminate, this overrides modes_allowlist
-    modes_denylist = {},
-    -- modes_allowlist: modes to illuminate, this is overriden by modes_denylist
-    modes_allowlist = {},
-    -- providers_regex_syntax_denylist: syntax to not illuminate, this overrides providers_regex_syntax_allowlist
-    -- Only applies to the 'regex' provider
-    -- Use :echom synIDattr(synIDtrans(synID(line('.'), col('.'), 1)), 'name')
-    providers_regex_syntax_denylist = {},
-    -- providers_regex_syntax_allowlist: syntax to illuminate, this is overriden by providers_regex_syntax_denylist
-    -- Only applies to the 'regex' provider
-    -- Use :echom synIDattr(synIDtrans(synID(line('.'), col('.'), 1)), 'name')
-    providers_regex_syntax_allowlist = {},
-    -- under_cursor: whether or not to illuminate under the cursor
-    under_cursor = true,
-  }
-end
+  illuminate.configure(lvim.builtin.illuminate.options)
 
-M.setup = function()
   if lvim.builtin.illuminate.on_config_done then
     lvim.builtin.illuminate.on_config_done()
   end

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -265,7 +265,7 @@ local core_plugins = {
     config = function()
       require("lvim.core.illuminate").setup()
     end,
-    -- disable = not lvim.builtin.illuminate.active,
+    disable = not lvim.builtin.illuminate.active,
   },
   {
     "lunarvim/onedarker.nvim",

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -395,7 +395,7 @@ function backup_old_config() {
 function clone_lvim() {
   msg "Cloning LunarVim configuration"
   if ! git clone --branch "$LV_BRANCH" \
-    --depth 1 "https://github.com/${LV_REMOTE}" "$LUNARVIM_BASE_DIR"; then
+    "https://github.com/${LV_REMOTE}" "$LUNARVIM_BASE_DIR"; then
     echo "Failed to clone repository. Installation failed."
     exit 1
   fi


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description


- revert: suggest using PackerCompile and instead of hard-coding config
- fix(installer): remove useless shallow clone

## How Has This Been Tested?

- `rm ~/.config/lvim/plugin/packer_compiled.lua`
- `lvim +PackerSync`
- check that winbar works :rocket:

