### PR TITLE
fix(indentblankline): make sure to use the new syntax for all options

### DIFF
--- a/lua/lvim/core/indentlines.lua
+++ b/lua/lvim/core/indentlines.lua
@@ -1,27 +1,26 @@
 local M = {}
 
 M.config = function()
-  vim.g.indent_blankline_buftype_exclude = { "terminal", "nofile" }
-  vim.g.indent_blankline_filetype_exclude = {
-    "help",
-    "startify",
-    "dashboard",
-    "packer",
-    "neogitstatus",
-    "NvimTree",
-    "Trouble",
-    "text",
-  }
-  vim.g.indentLine_enabled = 1
-  vim.g.indent_blankline_char = "▏"
-  vim.g.indent_blankline_show_trailing_blankline_indent = false
-  vim.g.indent_blankline_show_first_indent_level = true
-  vim.g.indent_blankline_use_treesitter = false
-  vim.g.indent_blankline_show_current_context = true
   lvim.builtin.indentlines = {
     active = true,
     on_config_done = nil,
     options = {
+      enabled = true,
+      buftype_exclude = { "terminal", "nofile" },
+      filetype_exclude = {
+        "help",
+        "startify",
+        "dashboard",
+        "packer",
+        "neogitstatus",
+        "NvimTree",
+        "Trouble",
+        "text",
+      },
+      char = "▏",
+      show_trailing_blankline_indent = false,
+      show_first_indent_level = false,
+      use_treesitter = true,
       show_current_context = true,
     },
   }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

instead of using `vim.g` use the normal setup for [indent_blankline](https://github.com/lukas-reineke/indent-blankline.nvim#setup)
