### PR TITLE
fix: small fixes on telescope pickers & breadcrumbs

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -70,6 +70,7 @@ M.winbar_filetype_exclude = {
   "startify",
   "dashboard",
   "packer",
+  "neo-tree",
   "neogitstatus",
   "NvimTree",
   "Trouble",
@@ -141,7 +142,6 @@ end
 
 local excludes = function()
   if vim.tbl_contains(M.winbar_filetype_exclude, vim.bo.filetype) then
-    vim.opt_local.winbar = nil
     return true
   end
   return false

--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -163,7 +163,6 @@ function M.setup()
         ["dd"] = require("telescope.actions").delete_buffer,
       },
     },
-    pickers = pickers,
   }, lvim.builtin.telescope)
 
   local telescope = require "telescope"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- see: https://github.com/LunarVim/LunarVim/commit/552197499cb1ca0b858d24c8d035bc6404f41148#r84561561
- add `neo-tree` filetype to breadcrumbs excludes
- neo-tree has it's own winbar, remove unnecessary setting winbar to `nil` on excludes check

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Tested this on my local

![image](https://user-images.githubusercontent.com/20012970/191649016-f0b30843-b30e-480a-8e85-7e9b8f9dbfe6.png)
