### PR TITLE
feat(autocmds): make sure all autocmds are modifiable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -19,5 +19,3 @@ local commands = require "lvim.core.commands"
 commands.load(commands.defaults)
 
 require("lvim.lsp").setup()
-
-vim.opt.laststatus = 3

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -32,35 +32,6 @@ function M.load_defaults()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "FileType" }, {
-    pattern = {
-      "alpha",
-    },
-    callback = function()
-      vim.cmd [[
-      nnoremap <silent> <buffer> q :qa<CR>
-      nnoremap <silent> <buffer> <esc> :qa<CR>
-      set nobuflisted
-    ]]
-    end,
-  })
-
-  vim.api.nvim_create_autocmd({ "FileType" }, {
-    pattern = { "lir" },
-    callback = function()
-      vim.opt_local.number = false
-      vim.opt_local.relativenumber = false
-    end,
-  })
-
-  -- TODO: figure out what keeps overriding laststatus
-  vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
-    pattern = { "*" },
-    callback = function()
-      vim.opt.laststatus = 3
-    end,
-  })
-
   local definitions = {
     {
       "TextYankPost",
@@ -122,6 +93,42 @@ function M.load_defaults()
         group = "_auto_resize",
         pattern = "*",
         command = "tabdo wincmd =",
+      },
+    },
+    {
+      "FileType",
+      {
+        group = "_filetype_settings",
+        pattern = "alpha",
+        callback = function()
+          vim.cmd [[
+            nnoremap <silent> <buffer> q :qa<CR>
+            nnoremap <silent> <buffer> <esc> :qa<CR>
+            set nobuflisted
+          ]]
+        end,
+      },
+    },
+    {
+      "FileType",
+      {
+        group = "_filetype_settings",
+        pattern = "lir",
+        callback = function()
+          vim.opt_local.number = false
+          vim.opt_local.relativenumber = false
+        end,
+      },
+    },
+    -- TODO: figure out what keeps overriding laststatus
+    {
+      "BufWinEnter",
+      {
+        group = "_last_status",
+        pattern = "*",
+        callback = function()
+          vim.opt.laststatus = 3
+        end,
       },
     },
   }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I want to be able remove or change all of the autocommands defined in lunarvim

e.g:
```lua
  pcall(function()
    vim.api.nvim_del_augroup_by_name "_last_status"
  end)
  vim.api.nvim_clear_autocmds { pattern = "lir", group = "_filetype_settings" }
```