### PR TITLE
fix: set `lua-dev.nvim` to a valid commit version.

### DIFF
--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -42,7 +42,7 @@
     "commit": "7d8c6c4"
   },
   "lua-dev.nvim": {
-    "commit": "6ff40c0"
+    "commit": "9da602d"
   },
   "lualine.nvim": {
     "commit": "a52f078"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When trying to install (either `stable` or `rolling` release) by following the instructions I was getting the following error:

```
[DEBUG 23:01:44] update.lua:102: Failed to update folke/lua-dev.nvim: {
  data = {
    data = {
      data = {
        exit_code = 128,
        signal = 0
      },
      msg = "Error checking out commit 6ff40c0 for folke/lua-dev.nvim remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0\nfatal: invalid reference: 6ff40c0"
    },
    msg = "Error getting updates for folke/lua-dev.nvim: remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0\nfatal: invalid reference: 6ff40c0"
  },
  msg = "Error checking updated commit for folke/lua-dev.nvim: 9da602d"
}[packer.nvim] [DEBUG 23:01:46] packer.lua:347: Processing plugin specs[packer.nvim] [INFO  23:01:46] packer.lua:783: Finished compiling lazy-loaders![packer.nvim] [DEBUG 23:01:46] packer.lua:367: packer.compile: CompletePacker setup complete
```

The fix in this pull request sets the `lua-dev.nvim` to a valid git commit reference.

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Deleted my local `~/.local/share/lunarvim` directory.
- Ran installer script on local repository with the change and the installation process concluded successfully. 

