### PR TITLE
chore(plugins): remove deprecated FixCursorHold.nvim

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -6,7 +6,6 @@ local core_plugins = {
   {
     "jose-elias-alvarez/null-ls.nvim",
   },
-  { "antoinemadec/FixCursorHold.nvim" }, -- Needed while issue https://github.com/neovim/neovim/issues/12587 is still open
   { "williamboman/mason-lspconfig.nvim" },
   {
     "williamboman/mason.nvim",

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -2,9 +2,6 @@
   "Comment.nvim": {
     "commit": "0860b5f"
   },
-  "FixCursorHold.nvim": {
-    "commit": "70a9516"
-  },
   "LuaSnip": {
     "commit": "d36c063"
   },


### PR DESCRIPTION
https://github.com/neovim/neovim/issues/12587 is now fixed.