### PR TITLE
feat: lock new installations to nvim 0.8+

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -33,7 +33,7 @@ body:
   - type: input
     id: nvim-version
     attributes:
-      label: Neovim version (>= 0.7.2)
+      label: Neovim version (>= 0.8.0)
       description: "Output of `nvim --version`"
       placeholder: |
         NVIM v0.8.0-dev+199-g2875d45e7

--- a/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
@@ -27,7 +27,7 @@ body:
   - type: input
     id: nvim-version
     attributes:
-      label: Neovim version (>= 0.7)
+      label: Neovim version (>= 0.8.0)
       description: "Output of `nvim --version`"
       placeholder: |
         NVIM v0.8.0-dev+199-g2875d45e7

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -21,10 +21,10 @@ jobs:
         include:
           - runner: ubuntu-latest
             os: linux
-            neovim: v0.7.0
+            neovim: v0.8.0
           - runner: macos-latest
             os: osx
-            neovim: v0.7.0
+            neovim: v0.8.0
           - runner: ubuntu-22.04
             os: linux
             neovim: nightly
@@ -78,7 +78,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.7.0
+          version: v0.8.0
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -33,7 +33,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.7.0
+          version: v0.8.0
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@
 
 ## Install In One Command!
 
-Make sure you have the release version of Neovim (0.7+).
+Make sure you have the release version of Neovim (0.8+).
 
 ### Linux/MacOS:
 
-If you are running Neovim 0.7+
+If you are running Neovim 0.8+
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)

--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-if vim.fn.has "nvim-0.7" ~= 1 then
-  vim.notify("Please upgrade your Neovim base installation. Lunarvim requires v0.7+", vim.log.levels.WARN)
+if vim.fn.has "nvim-0.8" ~= 1 then
+  vim.notify("Please upgrade your Neovim base installation. Lunarvim requires v0.8+", vim.log.levels.WARN)
   vim.wait(5000, function()
     return false
   end)

--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -23,25 +23,14 @@ function M.get_active_clients_by_ft(filetype)
 end
 
 function M.get_client_capabilities(client_id)
-  local client
-  if not client_id then
-    local buf_clients = vim.lsp.buf_get_clients()
-    for _, buf_client in pairs(buf_clients) do
-      if buf_client.name ~= "null-ls" then
-        client = buf_client
-        break
-      end
-    end
-  else
-    client = vim.lsp.get_client_by_id(tonumber(client_id))
-  end
+  local client = vim.lsp.get_client_by_id(tonumber(client_id))
   if not client then
-    error "Unable to determine client_id"
+    Log:warn("Unable to determine client from client_id: " .. client_id)
     return
   end
 
   local enabled_caps = {}
-  for capability, status in pairs(client.server_capabilities or client.resolved_capabilities) do
+  for capability, status in pairs(client.server_capabilities) do
     if status == true then
       table.insert(enabled_caps, capability)
     end

--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -178,47 +178,13 @@ function M.format_filter(client)
   end
 end
 
----Provide vim.lsp.buf.format for nvim <0.8
----@param opts table
+---Simple wrapper for vim.lsp.buf.format() to provide defaults
+---@param opts table|nil
 function M.format(opts)
   opts = opts or {}
   opts.filter = opts.filter or M.format_filter
 
-  if vim.lsp.buf.format then
-    return vim.lsp.buf.format(opts)
-  end
-
-  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
-
-  ---@type table|nil
-  local clients = vim.lsp.get_active_clients {
-    id = opts.id,
-    bufnr = bufnr,
-    name = opts.name,
-  }
-
-  if opts.filter then
-    clients = vim.tbl_filter(opts.filter, clients)
-  end
-
-  clients = vim.tbl_filter(function(client)
-    return client.supports_method "textDocument/formatting"
-  end, clients)
-
-  if #clients == 0 then
-    vim.notify_once "[LSP] Format request failed, no matching language servers."
-  end
-
-  local timeout_ms = opts.timeout_ms or 1000
-  for _, client in pairs(clients) do
-    local params = vim.lsp.util.make_formatting_params(opts.formatting_options)
-    local result, err = client.request_sync("textDocument/formatting", params, timeout_ms, bufnr)
-    if result and result.result then
-      vim.lsp.util.apply_text_edits(result.result, bufnr, client.offset_encoding)
-    elseif err then
-      vim.notify(string.format("[LSP][%s] %s", client.name, err), vim.log.levels.WARN)
-    end
-  end
+  return vim.lsp.buf.format(opts)
 end
 
 return M

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -52,8 +52,8 @@ end
 function M.run_post_update()
   Log:debug "Starting post-update hook"
 
-  if vim.fn.has "nvim-0.7" ~= 1 then
-    local compat_tag = "1.1.3"
+  if vim.fn.has "nvim-0.8" ~= 1 then
+    local compat_tag = "1.1.4"
     vim.notify(
       "Please upgrade your Neovim base installation. Newer version of Lunarvim requires v0.7+",
       vim.log.levels.WARN

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -201,11 +201,11 @@ function print_missing_dep_msg() {
 }
 
 function check_neovim_min_version() {
-  local verify_version_cmd='if !has("nvim-0.7") | cquit | else | quit | endif'
+  local verify_version_cmd='if !has("nvim-0.8") | cquit | else | quit | endif'
 
   # exit with an error if min_version not found
   if ! nvim --headless -u NONE -c "$verify_version_cmd"; then
-    echo "[ERROR]: LunarVim requires at least Neovim v0.7 or higher"
+    echo "[ERROR]: LunarVim requires at least Neovim v0.8 or higher"
     exit 1
   fi
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

<!--- Please list any dependencies that are required for this change. --->

- require v0.8+ for starting lunarvim (prevent issues with manual update)
- running :LvimUpdate when using a neovim <0.8 should switch to the tag 1.1.4 automatically and print a warning message

see #2491 for more info on the implementation

closes #3019

## How Has This Been Tested?

should pass the CI?
