### PR TITLE
Add group_empty nvimtree setting

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -92,6 +92,7 @@ function M.config()
           },
         },
         highlight_git = true,
+        group_empty = false,
         root_folder_modifier = ":t",
       },
       filters = {


### PR DESCRIPTION
This setting is a hidden gem for JVM devs that have deeply nested directory structures. 

This PR doesn't change the default value, it just adds the setting to the `lvim.builtin.nvimtree` object so that it is discoverable via LSP autocompletion