### PR TITLE
fix: Limit max_jobs to avoid freezes in macOS

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -20,7 +20,7 @@ function plugin_loader.init(opts)
     package_root = opts.package_root or join_paths(vim.fn.stdpath "data", "site", "pack"),
     compile_path = compile_path,
     snapshot_path = snapshot_path,
-    max_jobs = 100,
+    max_jobs = 50,
     log = { level = "warn" },
     git = {
       clone_timeout = 120,


### PR DESCRIPTION
Limit the number of max_jobs to 50, to avoid freezes in macOS.
Basically re-implements https://github.com/LunarVim/LunarVim/pull/2781, but with 50(seems to work locally for me)

This should be temporary, until we find a better fix

- Run command `:PackerSync` before and after, and observe that the update process does not hangup.

