### PR TITLE
fix: lualine custom theme

### DIFF
--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -89,7 +89,6 @@ M.setup = function()
   end
 
   theme.setup(lvim.builtin.theme.options)
-  lvim.builtin.lualine.options.theme = "tokyonight"
 end
 
 return M


### PR DESCRIPTION
A few issues opened about this, #3106 #3066 and (maybe) #3137
LuaLine was forced to use TokyoNight with no option to change in config. Instead it will now use "auto" which will work for custom themes as well as TokyoNight.