### PR TITLE
fix: don't overwrite previous config

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -439,7 +439,8 @@ function setup_lvim() {
 
   setup_shim
 
-  cp "$LUNARVIM_BASE_DIR/utils/installer/config.example.lua" "$LUNARVIM_CONFIG_DIR/config.lua"
+  [ ! -f "$LUNARVIM_CONFIG_DIR/config.lua" ] \
+    && cp "$LUNARVIM_BASE_DIR/utils/installer/config.example.lua" "$LUNARVIM_CONFIG_DIR/config.lua"
 
   echo "Preparing Packer setup"
 


### PR DESCRIPTION
# Description

The installer now checks if the user has a config at `.config/lvim/config.lua` and won't overwrite it if that's the case.

<!--- Please list any dependencies that are required for this change. --->

fixes #3146

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
### Reproduce the issue
- Install luavim using the utils script
- Edit the default config file at `.config/lvim/config.lua`
- Uninstall luavim using the utils script
- ReInstall luavim using the utils script

The config file has been overwritten

### Test my changed
- Edit the default config file at `.config/lvim/config.lua`
- Modifie the install script and check it using shfmt (`shfmt -i 2 -ci -bn -l -d utils/installer/install.sh`
- Uninstall it and Reinstall it with the modified script

The config file has not been overwritten