### PR TITLE
fix: always use border for lsp hover

### DIFF
--- a/lua/lvim/lsp/handlers.lua
+++ b/lua/lvim/lsp/handlers.lua
@@ -12,9 +12,7 @@ function M.setup()
     float = lvim.lsp.diagnostics.float,
   }
   vim.diagnostic.config(config)
-  if not lvim.builtin.illuminate.active then
-    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, lvim.lsp.float)
-  end
+  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, lvim.lsp.float)
   vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, lvim.lsp.float)
 end
 


### PR DESCRIPTION
Right now, if illuminate is active lsp hover border will not be used. I don't see why those two should be related. I removed the condition to always have it on.