### PR TITLE
feat(cmp): add configs for cmp.setup.cmdline

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -334,6 +334,23 @@ M.config = function()
         fallback() -- if not exited early, always fallback
       end),
     },
+    cmdline = {
+      enable = true,
+      options = {
+        {
+          type = ":",
+          sources = {
+            { name = "path" },
+          },
+        },
+        {
+          type = { "/", "?" },
+          sources = {
+            { name = "buffer" },
+          },
+        },
+      },
+    },
   }
 end
 
@@ -341,18 +358,14 @@ function M.setup()
   local cmp = require "cmp"
   cmp.setup(lvim.builtin.cmp)
 
-  cmp.setup.cmdline(":", {
-    mapping = cmp.mapping.preset.cmdline(),
-    sources = {
-      { name = "path" },
-    },
-  })
-  cmp.setup.cmdline({ "/", "?" }, {
-    mapping = cmp.mapping.preset.cmdline(),
-    sources = {
-      { name = "buffer" },
-    },
-  })
+  if lvim.builtin.cmp.cmdline.enable then
+    for _, option in ipairs(lvim.builtin.cmp.cmdline.options) do
+      cmp.setup.cmdline(option.type, {
+        mapping = cmp.mapping.preset.cmdline(),
+        sources = option.sources,
+      })
+    end
+  end
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
I'm using https://github.com/gelguy/wilder.nvim for cmdline suggestions and the recent change to cmp.cmdline is conflicting with my configs, so I added an extra property in the cmp config object to control cmp.cmdline

summary of the change

added `lvim.builtin.cmp.cmdline` config to control cmp from the config.lua file

## How Has This Been Tested?
```lua
-- in config.lua
lvim.builtin.cmp.cmdline.enable = false
```