### PR TITLE
fix(typo): fix language server name typo in config example #3176

### DIFF
--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -107,7 +107,7 @@ lvim.builtin.treesitter.highlight.enable = true
 
 -- -- make sure server will always be installed even if the server is in skipped_servers list
 -- lvim.lsp.installer.setup.ensure_installed = {
---     "sumeko_lua",
+--     "sumneko_lua",
 --     "jsonls",
 -- }
 -- -- change UI setting of `LspInstallInfo`


### PR DESCRIPTION
Sorry for missing the second config example.
This is an follow-up for #3176.