### PR TITLE
fix: telescope delete_buffer binds correct scope (and small refactor)

### DIFF
--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -1,65 +1,62 @@
 local M = {}
 
-local ok, actions = pcall(require, "telescope.actions")
-if not ok then
-  return
-end
-
-local pickers = {
-  find_files = {
-    theme = "dropdown",
-    hidden = true,
-    previewer = false,
-  },
-  live_grep = {
-    --@usage don't include the filename in the search results
-    only_sort_text = true,
-    theme = "dropdown",
-  },
-  grep_string = {
-    only_sort_text = true,
-    theme = "dropdown",
-  },
-  buffers = {
-    theme = "dropdown",
-    previewer = false,
-    initial_mode = "normal",
-    mappings = {
-      i = {
-        ["<C-d>"] = actions.delete_buffer,
-      },
-      n = {
-        ["dd"] = actions.delete_buffer,
+local function get_pickers(actions)
+  return {
+    find_files = {
+      theme = "dropdown",
+      hidden = true,
+      previewer = false,
+    },
+    live_grep = {
+      --@usage don't include the filename in the search results
+      only_sort_text = true,
+      theme = "dropdown",
+    },
+    grep_string = {
+      only_sort_text = true,
+      theme = "dropdown",
+    },
+    buffers = {
+      theme = "dropdown",
+      previewer = false,
+      initial_mode = "normal",
+      mappings = {
+        i = {
+          ["<C-d>"] = actions.delete_buffer,
+        },
+        n = {
+          ["dd"] = actions.delete_buffer,
+        },
       },
     },
-  },
-  planets = {
-    show_pluto = true,
-    show_moon = true,
-  },
-  git_files = {
-    theme = "dropdown",
-    hidden = true,
-    previewer = false,
-    show_untracked = true,
-  },
-  lsp_references = {
-    theme = "dropdown",
-    initial_mode = "normal",
-  },
-  lsp_definitions = {
-    theme = "dropdown",
-    initial_mode = "normal",
-  },
-  lsp_declarations = {
-    theme = "dropdown",
-    initial_mode = "normal",
-  },
-  lsp_implementations = {
-    theme = "dropdown",
-    initial_mode = "normal",
-  },
-}
+    planets = {
+      show_pluto = true,
+      show_moon = true,
+    },
+    git_files = {
+      theme = "dropdown",
+      hidden = true,
+      previewer = false,
+      show_untracked = true,
+    },
+    lsp_references = {
+      theme = "dropdown",
+      initial_mode = "normal",
+    },
+    lsp_definitions = {
+      theme = "dropdown",
+      initial_mode = "normal",
+    },
+    lsp_declarations = {
+      theme = "dropdown",
+      initial_mode = "normal",
+    },
+    lsp_implementations = {
+      theme = "dropdown",
+      initial_mode = "normal",
+    },
+  }
+end
 
 function M.config()
   -- Define this minimal config so that it's available if telescope is not yet available.
@@ -70,6 +67,10 @@ function M.config()
     on_config_done = nil,
   }
 
+  local ok, actions = pcall(require, "telescope.actions")
+  if not ok then
+    return
+  end
   lvim.builtin.telescope = vim.tbl_extend("force", lvim.builtin.telescope, {
     defaults = {
       prompt_prefix = lvim.icons.ui.Telescope .. " ",
@@ -121,7 +122,7 @@ function M.config()
           ["<C-q>"] = actions.smart_send_to_qflist + actions.open_qflist,
         },
       },
-      pickers = pickers,
+      pickers = get_pickers(actions),
       file_ignore_patterns = {},
       path_display = { "smart" },
       winblend = 0,
@@ -130,7 +131,7 @@ function M.config()
       color_devicons = true,
       set_env = { ["COLORTERM"] = "truecolor" }, -- default = nil,
     },
-    pickers = pickers,
+    pickers = get_pickers(actions),
     extensions = {
       fzf = {
         fuzzy = true, -- false will only do exact matching

--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -1,5 +1,10 @@
 local M = {}
 
+local ok, actions = pcall(require, "telescope.actions")
+if not ok then
+  return
+end
+
 local pickers = {
   find_files = {
     theme = "dropdown",
@@ -21,10 +26,10 @@ local pickers = {
     initial_mode = "normal",
     mappings = {
       i = {
-        ["<C-d>"] = require("telescope.actions").delete_buffer,
+        ["<C-d>"] = actions.delete_buffer,
       },
       n = {
-        ["dd"] = require("telescope.actions").delete_buffer,
+        ["dd"] = actions.delete_buffer,
       },
     },
   },
@@ -65,10 +70,6 @@ function M.config()
     on_config_done = nil,
   }
 
-  local ok, actions = pcall(require, "telescope.actions")
-  if not ok then
-    return
-  end
   lvim.builtin.telescope = vim.tbl_extend("force", lvim.builtin.telescope, {
     defaults = {
       prompt_prefix = lvim.icons.ui.Telescope .. " ",

--- a/lua/lvim/core/telescope.lua
+++ b/lua/lvim/core/telescope.lua
@@ -19,6 +19,14 @@ local pickers = {
     theme = "dropdown",
     previewer = false,
     initial_mode = "normal",
+    mappings = {
+      i = {
+        ["<C-d>"] = require("telescope.actions").delete_buffer,
+      },
+      n = {
+        ["dd"] = require("telescope.actions").delete_buffer,
+      },
+    },
   },
   planets = {
     show_pluto = true,
@@ -95,6 +103,7 @@ function M.config()
         "--hidden",
         "--glob=!.git/",
       },
+      ---@usage Mappings are fully customizable. Many familiar mapping patterns are setup as defaults.
       mappings = {
         i = {
           ["<C-n>"] = actions.move_selection_next,
@@ -104,13 +113,11 @@ function M.config()
           ["<C-k>"] = actions.cycle_history_prev,
           ["<C-q>"] = actions.smart_send_to_qflist + actions.open_qflist,
           ["<CR>"] = actions.select_default,
-          ["<C-d>"] = require("telescope.actions").delete_buffer,
         },
         n = {
           ["<C-n>"] = actions.move_selection_next,
           ["<C-p>"] = actions.move_selection_previous,
           ["<C-q>"] = actions.smart_send_to_qflist + actions.open_qflist,
-          ["dd"] = require("telescope.actions").delete_buffer,
         },
       },
       pickers = pickers,
@@ -137,7 +144,6 @@ end
 function M.setup()
   local previewers = require "telescope.previewers"
   local sorters = require "telescope.sorters"
-  local actions = require "telescope.actions"
 
   lvim.builtin.telescope = vim.tbl_extend("keep", {
     file_previewer = previewers.vim_buffer_cat.new,
@@ -145,24 +151,6 @@ function M.setup()
     qflist_previewer = previewers.vim_buffer_qflist.new,
     file_sorter = sorters.get_fuzzy_file,
     generic_sorter = sorters.get_generic_fuzzy_sorter,
-    ---@usage Mappings are fully customizable. Many familiar mapping patterns are setup as defaults.
-    mappings = {
-      i = {
-        ["<C-n>"] = actions.move_selection_next,
-        ["<C-p>"] = actions.move_selection_previous,
-        ["<C-c>"] = actions.close,
-        ["<C-j>"] = actions.cycle_history_next,
-        ["<C-k>"] = actions.cycle_history_prev,
-        ["<C-q>"] = actions.smart_send_to_qflist + actions.open_qflist,
-        ["<CR>"] = actions.select_default + actions.center,
-      },
-      n = {
-        ["<C-n>"] = actions.move_selection_next,
-        ["<C-p>"] = actions.move_selection_previous,
-        ["<C-q>"] = actions.smart_send_to_qflist + actions.open_qflist,
-        ["dd"] = require("telescope.actions").delete_buffer,
-      },
-    },
   }, lvim.builtin.telescope)
 
   local telescope = require "telescope"


### PR DESCRIPTION
1. Fixes #3064 by defining the delete_buffer bindings only for the buffers telescope. This lets you use the default C-d/C-u in insert mode and dd in normal mode for other telescopes, and prevent an error from showing, while retaining functionality in the buffers telescope.
2. Also removed duplication of defining the default binds