### PR TITLE
fix(breadcrumbs): correctly ignore markdown files

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -88,7 +88,7 @@ M.winbar_filetype_exclude = {
   "dap-terminal",
   "dapui_console",
   "lab",
-  "Markdown",
+  "markdown",
   "",
 }
 


### PR DESCRIPTION
# Description

The Markdown file type was incorrectly specified in the breadcrumbs ignore list as `Markdown` with the first letter capitalized. This resulted in creating a winbar for Markdown files.

## How Has This Been Tested?

By simply using LunarVim in a Markdown file.

