### PR TITLE
chore(breadcrumbs): remove `Markdown` from excluded file types

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -29,7 +29,6 @@ M.config = function()
       "dap-terminal",
       "dapui_console",
       "lab",
-      "Markdown",
       "notify",
       "noice",
       "",


### PR DESCRIPTION
# Description

The `Markdown` entry in the list of excluded file types for the **breadcrumbs** module did nothing, as the output of `vim.bo.filetype` for MD files yields the value of `markdown`.

## How Has This Been Tested?

No tests other than the simple smoke ones were necessary.

## Additional remarks

This PR addresses the discussion in #3189.

