### PR TITLE
chore: bump nvim-tree.lua version to `b01e7be`

### DIFF
--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -75,7 +75,7 @@
     "commit": "4144654"
   },
   "nvim-tree.lua": {
-    "commit": "7282f7d"
+    "commit": "b01e7be"
   },
   "nvim-treesitter": {
     "commit": "8e76333"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I can't wait for the bot to it

summary of the change

Bump nvim-tree.lua to version [b01e7be](https://github.com/nvim-tree/nvim-tree.lua/commit/b01e7beaa6f0dbbf5df775cf4ecc829a23f0be54), it has changes from this PR https://github.com/nvim-tree/nvim-tree.lua/pull/1637

<!--- Please list any dependencies that are required for this change. --->
