### PR TITLE
fix: Remove J and K key mappings for move

### DIFF
--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -83,10 +83,6 @@ local defaults = {
   },
 
   visual_block_mode = {
-    -- Move selected line / block of text in visual mode
-    ["K"] = ":move '<-2<CR>gv-gv",
-    ["J"] = ":move '>+1<CR>gv-gv",
-
     -- Move current line / block with Alt-j/k ala vscode.
     ["<A-j>"] = ":m '>+1<CR>gv-gv",
     ["<A-k>"] = ":m '<-2<CR>gv-gv",


### PR DESCRIPTION
# Description

Remove the _J_ and _K_ key mappings for moving lines of code since the _J_ mapping overrides the standard _J_ (join lines) action.
Not having the standard _J_ mapping is confusing for new users. _Alt-j_ and _Alt-k_ are still available for moving lines.

## How Has This Been Tested?

- Verified that _J_ (join lines) works in visual block mode.
- Verified that _Alt-j_ and _Alt-k_ can still be used to move lines.
