### PR TITLE
fix: typo in git.lua

### DIFF
--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -40,7 +40,7 @@ local function safe_deep_fetch()
     Log:error(vim.inspect(error))
     return
   end
-  -- git fetch --unshallow will cause an error on a a complete clone
+  -- git fetch --unshallow will cause an error on a complete clone
   local fetch_mode = result[1] == "true" and "--unshallow" or "--all"
   ret = git_cmd { args = { "fetch", fetch_mode } }
   if ret ~= 0 then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

summary of the change

Removed an extra `a` in https://github.com/lunarvim/lunarvim/blob/rolling/lua/lvim/utils/git.lua#L43 
