### PR TITLE
fix: name treesitter source in cmp

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -155,6 +155,7 @@ M.config = function()
         buffer = "(Buffer)",
         tmux = "(TMUX)",
         copilot = "(Copilot)",
+        treesitter = "(TreeSitter)",
       },
       duplicates = {
         buffer = 1,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Just added a name for treesitter to cmp to make sure al built-in sources are named

<!--- Please list any dependencies that are required for this change. --->


## How Has This Been Tested?

Just use it

