### PR TITLE
docs: make it clearer that rolling is for nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you are running Neovim 0.8+
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
 ```
 
-If you are running Neovim 0.9+
+If you are running Neovim nightly 
 
 ```bash
 export LV_BRANCH="rolling"; bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/rolling/utils/installer/install.sh)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you are running Neovim 0.8+
 bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/install.sh)
 ```
 
-If you are running Neovim 0.8+
+If you are running Neovim 0.9+
 
 ```bash
 export LV_BRANCH="rolling"; bash <(curl -s https://raw.githubusercontent.com/lunarvim/lunarvim/rolling/utils/installer/install.sh)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The README is a bit confusing...

<img width="814" alt="image" src="https://user-images.githubusercontent.com/3210082/195784515-1e2b7a35-55eb-46c7-b29f-8f7329baa606.png">

This PR updates the README to match installation docs – https://www.lunarvim.org/docs/installation#nightly


