### PR TITLE
fix(luadev): this plugin has been renamed

### DIFF
--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -2,7 +2,7 @@ local default_workspace = {
   library = {
     vim.fn.expand "$VIMRUNTIME",
     get_lvim_base_dir(),
-    require("lua-dev.config").types(),
+    require("neodev.config").types(),
   },
 
   maxPreload = 5000,

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -92,8 +92,8 @@ local core_plugins = {
     "hrsh7th/cmp-path",
   },
   {
-    "folke/lua-dev.nvim",
-    module = "lua-dev",
+    "folke/neodev.nvim",
+    module = "neodev",
   },
 
   -- Autopairs

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -35,8 +35,8 @@
   "lir.nvim": {
     "commit": "7d8c6c4"
   },
-  "lua-dev.nvim": {
-    "commit": "2410be2"
+  "neodev.nvim": {
+    "commit": "b2fd8b7"
   },
   "lualine.nvim": {
     "commit": "a52f078"
@@ -72,7 +72,7 @@
     "commit": "132b273"
   },
   "nvim-notify": {
-    "commit": "4144654"
+    "commit": "af935fd"
   },
   "nvim-tree.lua": {
     "commit": "b01e7be"


### PR DESCRIPTION
[lua-dev.nvim](https://github.com/folke/lua-dev.nvim) is now [neodev.nvim](https://github.com/folke/neodev.nvim)