### PR TITLE
fix: disable unsupported asian characters spellchecking

### DIFF
--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -57,6 +57,7 @@ M.load_default_options = function()
   }
 
   ---  SETTINGS  ---
+  vim.opt.spelllang:append "cjk" -- disable spellchecking for asian characters (VIM algorithm does not support it)
   vim.opt.shortmess:append "c" -- don't show redundant messages from ins-completion-menu
   vim.opt.shortmess:append "I" -- don't show the default intro message
   vim.opt.whichwrap:append "<,>,[,],h,l"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

[VIM algorithm does not support spellchecking for Asian characters](https://vim-jp.org/vimdoc-en/spell.html#spell-cjk), but they are spellchecked by default anyway, which results in every sentence highlighted as wrong when you use multiple languages in your file.

Before the change:
all Asian characters are spellchecked and, as a result, underlined
![image](https://user-images.githubusercontent.com/25802053/196023375-376812d9-a681-490b-9ad6-3a7f50c46e16.png)

After the change:
they are omitted from spellchecking
![image](https://user-images.githubusercontent.com/25802053/196023429-b807ce15-c52e-49c8-b269-83d5434fe5aa.png)

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Open an empty buffer
-  Paste a few Japanese/Chinese sentences
```md
こんにちは、LunarVimは素晴らしいです
お疲れ様でした

This is a correct English sentence.

VIMの日本語のスペルチェックは不可能です
```
- set the language spelling `:set spelllang=en`
- all Asian characters are highlighted as errors
- append the `cjk` to disable Asian characters spell checking `set spelllang+=cjk`
- now everything is correct