### PR TITLE
fix: nil table in breadcrumbs in autocommand

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -162,10 +162,7 @@ local get_gps = function()
 end
 
 local excludes = function()
-  if vim.tbl_contains(lvim.builtin.breadcrumbs.winbar_filetype_exclude, vim.bo.filetype) then
-    return true
-  end
-  return false
+  return vim.tbl_contains(lvim.builtin.breadcrumbs.winbar_filetype_exclude or {}, vim.bo.filetype)
 end
 
 M.get_winbar = function()


### PR DESCRIPTION
Got an "Error detected while processing CursorMoved Autocommands for '*'", originating from when winbar_filetype_exclude is not populated/set to nil.
