### PR TITLE
feat: display changelog on :LvimUpdate

### DIFF
--- a/lua/lvim/core/info.lua
+++ b/lua/lvim/core/info.lua
@@ -7,6 +7,7 @@ local M = {
     [[ / /___/ /_/ / / / / /_/ / /   | |/ / / / / / / /]],
     [[/_____/\__,_/_/ /_/\__,_/_/    |___/_/_/ /_/ /_/ ]],
   },
+  changelog = "",
 }
 
 local fmt = string.format
@@ -218,5 +219,40 @@ function M.toggle_popup(ft)
   set_syntax_hl()
 
   return Popup
+end
+
+M.make_changelog = function()
+  local content_provider = function(popup)
+    local content = {}
+
+    for _, section in ipairs {
+      M.banner,
+      { "" },
+      { "" },
+      { "changelog: " },
+      { "" },
+      M.changelog,
+      { "" },
+    } do
+      vim.list_extend(content, section)
+    end
+
+    return text.align_left(popup, content, 0.1)
+  end
+
+  local function set_syntax_hl()
+    vim.cmd [[highlight LvimInfoIdentifier gui=bold]]
+    vim.cmd [[highlight link LvimInfoHeader Type]]
+    vim.fn.matchadd("LvimInfoHeader", "changelog:")
+    vim.fn.matchadd("LvimInfoHeader", "[0-9a-f]\\{7,8}")
+  end
+
+  local Popup = require("lvim.interface.popup"):new {
+    win_opts = { number = false },
+    buf_opts = { modifiable = false, filetype = "lspinfo" },
+  }
+
+  Popup:display(content_provider)
+  set_syntax_hl()
 end
 return M

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -140,7 +140,7 @@ function plugin_loader.load_snapshot(snapshot_file)
   require("packer").rollback(snapshot_file, unpack(core_plugins))
 end
 
-function plugin_loader.sync_core_plugins()
+function plugin_loader.sync_core_plugins(callback)
   -- problem: rollback() will get stuck if a plugin directory doesn't exist
   -- solution: call sync() beforehand
   -- see https://github.com/wbthomason/packer.nvim/issues/862
@@ -149,6 +149,9 @@ function plugin_loader.sync_core_plugins()
     once = true,
     callback = function()
       require("lvim.plugin-loader").load_snapshot(default_snapshot)
+      if callback then
+        callback()
+      end
     end,
   })
   pcall_packer_command "sync"

--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -3,6 +3,7 @@ local M = {}
 local Log = require "lvim.core.log"
 local fmt = string.format
 local if_nil = vim.F.if_nil
+local Info = require "lvim.core.info"
 
 local function git_cmd(opts)
   local plenary_loaded, Job = pcall(require, "plenary.job")
@@ -77,6 +78,11 @@ function M.update_base_lvim()
     Log:info "LunarVim is already up-to-date"
     return
   end
+
+  -- Get the messages before merging
+  local _, stdout =
+    git_cmd { args = { "--no-pager", "log", "--pretty=format:* %h -%d %s (%cr) <%an>", "HEAD..@{upstream}" } }
+  Info.changelog = stdout
 
   ret = git_cmd { args = { "merge", "--ff-only", "--progress" } }
   if ret ~= 0 then

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local Log = require "lvim.core.log"
+local Info = require "lvim.core.info"
 local in_headless = #vim.api.nvim_list_uis() == 0
 
 function M.run_pre_update()
@@ -68,14 +69,15 @@ function M.run_post_update()
   M.reset_cache()
 
   Log:debug "Syncing core plugins"
-  require("lvim.plugin-loader").sync_core_plugins()
+  require("lvim.plugin-loader").sync_core_plugins(function()
+    Info.make_changelog()
+  end)
 
   if not in_headless then
     vim.schedule(function()
       if package.loaded["nvim-treesitter"] then
         vim.cmd [[ TSUpdateSync ]]
       end
-      -- TODO: add a changelog
       vim.notify("Update complete", vim.log.levels.INFO)
     end)
   end


### PR DESCRIPTION
instead of https://github.com/LunarVim/LunarVim/pull/3218
Everytime I run `:LvimUpdate` I have to go to github and check the commits log on LunarVim repo, so I thought it would be nice if lvim displays them after running `:LvimUpdate`, the PR still WIP, waiting for your thoughts on this

![image](https://user-images.githubusercontent.com/17254073/195493454-e9403295-6e97-47d9-92ee-cef72519b577.png)
