### PR TITLE
fix(autocmds): remove _format_options group

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -67,14 +67,6 @@ function M.load_defaults()
       },
     },
     {
-      { "BufWinEnter", "BufRead", "BufNewFile" },
-      {
-        group = "_format_options",
-        pattern = "*",
-        command = "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-      },
-    },
-    {
       "VimResized",
       {
         group = "_auto_resize",


### PR DESCRIPTION
# Description
Removes `_format_options` autocmd group which was causing issues for some users.

fixes #3237

