### PR TITLE
feat(breadcrumbs): add exclude check for file path (buf name)

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -67,14 +67,6 @@ function M.load_defaults()
       },
     },
     {
-      { "BufWinEnter", "BufRead", "BufNewFile" },
-      {
-        group = "_format_options",
-        pattern = "*",
-        command = "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-      },
-    },
-    {
       "VimResized",
       {
         group = "_auto_resize",

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -8,6 +8,7 @@ M.config = function()
   lvim.builtin.breadcrumbs = {
     active = true,
     on_config_done = nil,
+    winbar_path_contains_exclude = { "noice://" },
     winbar_filetype_exclude = {
       "help",
       "startify",
@@ -162,7 +163,18 @@ local get_gps = function()
 end
 
 local excludes = function()
-  return vim.tbl_contains(lvim.builtin.breadcrumbs.winbar_filetype_exclude or {}, vim.bo.filetype)
+  if vim.tbl_contains(lvim.builtin.breadcrumbs.winbar_filetype_exclude or {}, vim.bo.filetype) then
+    return true
+  end
+
+  local bufname = vim.api.nvim_buf_get_name(0)
+  for _, value in ipairs(lvim.builtin.breadcrumbs.winbar_path_contains_exclude or {}) do
+    if bufname:find(value) then
+      return true
+    end
+  end
+
+  return false
 end
 
 M.get_winbar = function()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

[Noice](https://github.com/folke/noice.nvim) is setting some of popup window with filetype `lua`, `vim`, `regex`, and `sh`. If I don't exclude that filetype, breadcrumbs and noice are error. But, I don't want to exclude that filetype. That's why I check with the buffer name instead.

So, this PR is dirty check from me (lack of experience with lua and neovim api) to also exclude breadcrumbs from certain file path or buffer name.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- check this in my local environment. `lua` file has working breadcrumbs and no error when I open noice cmdline_popup.

