### PR TITLE
fix(theme): do not fallback to tokyonight if no user's theme found

### DIFF
--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -99,7 +99,7 @@ M.setup = function()
   -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
   local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)
   if #colors == 0 then
-    Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
+    Log:debug(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
     return
   end
 

--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -100,7 +100,7 @@ M.setup = function()
   local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)
   if #colors == 0 then
     Log:warn(string.format("Could not find '%s' colorscheme", lvim.colorscheme))
-    lvim.colorscheme = "tokyonight"
+    return
   end
 
   vim.g.colors_name = lvim.colorscheme


### PR DESCRIPTION
# Description
This fixes the problem that `tokyonight` colorscheme cannot be found.

Related #3311
