### PR TITLE
fix(finders): use lunarvim basedir

### DIFF
--- a/lua/lvim/core/telescope/custom-finders.lua
+++ b/lua/lvim/core/telescope/custom-finders.lua
@@ -9,8 +9,6 @@ local _, actions = pcall(require, "telescope.actions")
 local _, previewers = pcall(require, "telescope.previewers")
 local _, make_entry = pcall(require, "telescope.make_entry")
 
-local utils = require "lvim.utils"
-
 function M.find_lunarvim_files(opts)
   opts = opts or {}
   local theme_opts = themes.get_ivy {
@@ -19,7 +17,7 @@ function M.find_lunarvim_files(opts)
     prompt_prefix = ">> ",
     prompt_title = "~ LunarVim files ~",
     cwd = get_runtime_dir(),
-    search_dirs = { utils.join_paths(get_runtime_dir(), "lvim"), lvim.lsp.templates_dir },
+    search_dirs = { get_lvim_base_dir(), lvim.lsp.templates_dir },
   }
   opts = vim.tbl_deep_extend("force", theme_opts, opts)
   builtin.find_files(opts)
@@ -33,7 +31,7 @@ function M.grep_lunarvim_files(opts)
     prompt_prefix = ">> ",
     prompt_title = "~ search LunarVim ~",
     cwd = get_runtime_dir(),
-    search_dirs = { utils.join_paths(get_runtime_dir(), "lvim"), lvim.lsp.templates_dir },
+    search_dirs = { get_lvim_base_dir(), lvim.lsp.templates_dir },
   }
   opts = vim.tbl_deep_extend("force", theme_opts, opts)
   builtin.live_grep(opts)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When LunarVim is cloned in ~/.config/nvim (to make it play with Neovide), the LunarVim which-key shortcuts `Lf` and `Lg` did not work, because a wrong base-directory was used.

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

I tested the shortcuts in both settings - when LunarVim is cloned to ~/.config/nvim and when installed the usual way.

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:mycommand`
- Check logs
- ...

