### PR TITLE
fix: Remove notify which key mapping

### DIFF
--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -229,7 +229,6 @@ M.config = function()
           },
           P = { "<cmd>edit $LUNARVIM_CACHE_DIR/packer.nvim.log<cr>", "Open the Packer logfile" },
         },
-        n = { "<cmd>Telescope notify<cr>", "View Notifications" },
         r = { "<cmd>LvimReload<cr>", "Reload LunarVim's configuration" },
         u = { "<cmd>LvimUpdate<cr>", "Update LunarVim" },
       },


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Removes keymapping left behind when nvim-notify was removed

<!--- Please list any dependencies that are required for this change. --->

fixes #3329 

## How Has This Been Tested?

Tested locally. 

Key map is removed from the menu

<img width="831" alt="image" src="https://user-images.githubusercontent.com/1205776/197675547-cb77a566-c0de-449d-b373-697030d8a49f.png">

- ...

