### PR TITLE
fix: call proper log function in notify override

### DIFF
--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -87,8 +87,8 @@ function Log:init()
         -- https://github.com/neovim/neovim/blob/685cf398130c61c158401b992a1893c2405cd7d2/runtime/lua/vim/lsp/log.lua#L5
         vim_log_level = vim_log_level + 1
       end
-
-      self:info(vim_log_level, msg)
+      
+      self:add_entry(vim_log_level, msg)
     end
   end
 


### PR DESCRIPTION
related to #3202

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

There is a wrong call when overriding vim.notify

<!--- Please list any dependencies that are required for this change. --->

There is no issue related, but there is a discussion #3202 

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Not tested

