### PR TITLE
fix(breadcrumbs): use hlgroup from web devicons in breadcrumbs

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -49,7 +49,7 @@ function M:init()
 
   ---@deprecated
   lvim.builtin.notify = {
-    active = false
+    active = false,
   }
 end
 
@@ -98,12 +98,10 @@ local function handle_deprecated_settings()
     deprecation_notice("lvim.builtin.dashboard", "Use `lvim.builtin.alpha` instead. See LunarVim#1906")
   end
 
-
   -- notify.nvim
   if lvim.builtin.notify.active then
     deprecation_notice("lvim.builtin.notify", "See LunarVim#3294")
   end
-
 
   if lvim.autocommands.custom_groups then
     deprecation_notice(

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -99,12 +99,8 @@ M.get_filename = function()
   local f = require "lvim.utils.functions"
 
   if not f.isempty(filename) then
-    local file_icon, file_icon_color =
-      require("nvim-web-devicons").get_icon_color(filename, extension, { default = true })
+    local file_icon, hl_group = require("nvim-web-devicons").get_icon(filename, extension, { default = true })
 
-    local hl_group = "FileIconColor" .. extension
-
-    vim.api.nvim_set_hl(0, hl_group, { fg = file_icon_color })
     if f.isempty(file_icon) then
       file_icon = lvim.icons.kind.File
     end

--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -147,7 +147,6 @@ function M.setup()
     return
   end
 
-
   if lvim.builtin.nvimtree._setup_called then
     Log:debug "ignoring repeated setup call for nvim-tree, see kyazdani42/nvim-tree.lua#1308"
     return


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Use hlgroup from web devicons instead of creating our own, so the name doesn't contain illegal characters.

<!--- Please list any dependencies that are required for this change. --->

fixes #3330

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
lvim Dockerfile.ops-1
