### PR TITLE
fix(icons): do not reload `nvim-web-devicons` module

### DIFF
--- a/lua/lvim/core/lir.lua
+++ b/lua/lvim/core/lir.lua
@@ -94,7 +94,7 @@ function M.icon_setup()
     icon_hl = "#42A5F5"
   end
 
-  reload("nvim-web-devicons").set_icon {
+  require("nvim-web-devicons").set_icon {
     lir_folder_icon = {
       icon = lvim.builtin.lir.icon,
       color = icon_hl,


### PR DESCRIPTION
# Description

`nvim-web-devicons` is reloaded causing issue that user cannot have their own custom icon change.

## How Has This Been Tested?
- Before: 
<img width="125" alt="Screenshot 2022-10-26 at 03 35 53" src="https://user-images.githubusercontent.com/42694704/197876698-cfaa7db4-f2ab-45ed-9eb9-91986b3fef42.png">

- Set custom icon in `config.lua`

```lua
require("nvim-web-devicons").set_icon {
    ["docker-compose.yml"] = {
        icon = "",
        color = "#00a4ff",
        name = "Dockerfile",
    },
}
```

- See that the icon now change (which cannot be achieved before)

<img width="136" alt="Screenshot 2022-10-26 at 03 36 40" src="https://user-images.githubusercontent.com/42694704/197876828-41028648-29bc-494e-af6a-156a17071ad7.png">
