### PR TITLE
fix(lsp): don't start servers multiple times

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -62,7 +62,7 @@ local function client_is_configured(server_name, ft)
   ft = ft or vim.bo.filetype
   local active_autocmds = vim.api.nvim_get_autocmds { event = "FileType", pattern = ft }
   for _, result in ipairs(active_autocmds) do
-    if result.command:match(server_name) then
+    if result.desc:match("server " .. server_name .. " ") then
       Log:debug(string.format("[%q] is already configured", server_name))
       return true
     end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

[This fix](https://github.com/LunarVim/LunarVim/commit/b8f681374b25740e0aea1c859bf313197ed63dd5) doesn't work anymore since [this commit](https://github.com/neovim/nvim-lspconfig/commit/fe7a6f41e59654db6bbc9eb2d084decc54b295e4#diff-0e1bd346624fa540fa153e867fbc2036ced5c83d5cd7d79d9308df1328b7c879R69-R79) in lspconfig because the commit removed `command` from the autocommand. This PR changes the lua match from the now nonexistent `command` to `desc` which does contain the name of the server

<!--- Please list any dependencies that are required for this change. --->

fixes #3144

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
Opened a cpp file in lvim (cpp because then both c and cpp ftplugins will run, so require("lvim.lsp.manager").setup("clangd") will be called twice)
Before this change a warning appeared: `Client 1 quit with exit code 1 and signal 0`

