### PR TITLE
fix(lsp): do a nil check before string matching autocmd desc

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -62,7 +62,7 @@ local function client_is_configured(server_name, ft)
   ft = ft or vim.bo.filetype
   local active_autocmds = vim.api.nvim_get_autocmds { event = "FileType", pattern = ft }
   for _, result in ipairs(active_autocmds) do
-    if result.desc:match("server " .. server_name .. " ") then
+    if result.desc ~= nil and result.desc:match("server " .. server_name .. " ") then
       Log:debug(string.format("[%q] is already configured", server_name))
       return true
     end


### PR DESCRIPTION
Apparently in the latest neovim build, filetype.lua or packer.nvim is working a bit different, 
for example when I want to load a plugin only in certain filetypes, this happens:
<img width="1679" alt="Screenshot 2022-10-27 at 12 49 21 PM" src="https://user-images.githubusercontent.com/10992695/198245595-9600ff24-7c77-412d-b643-b8ca06e9102a.png">

because some autocmds don't have a description:
<img width="840" alt="Screenshot 2022-10-27 at 12 49 29 PM" src="https://user-images.githubusercontent.com/10992695/198246047-a1af8ce4-3dd2-46c0-b736-078c2c892edf.png">


