### PR TITLE
fix(defaults): don't use smartindent

### DIFF
--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -28,7 +28,6 @@ M.load_default_options = function()
     showmode = false, -- we don't need to see things like -- INSERT -- anymore
     showtabline = 2, -- always show tabs
     smartcase = true, -- smart case
-    smartindent = true, -- make indenting smarter again
     splitbelow = true, -- force all horizontal splits to go below current window
     splitright = true, -- force all vertical splits to go to the right of current window
     swapfile = false, -- creates a swapfile


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
disables smartindent

<!--- Please list any dependencies that are required for this change. --->

fixes #3219

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->

1. Open any file with lines like `# this is a title`
2. Use >> on that line
3. The line is indented
