### PR TITLE
fix(lsp): launch setup only on installed server

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -119,10 +119,10 @@ function M.setup(server_name, user_config)
           end)
         end
       end)
-      return
     else
       Log:debug(server_name .. " is not managed by the automatic installer")
     end
+    return
   end
 
   local config = resolve_config(server_name, resolve_mason_config(server_name), user_config)


### PR DESCRIPTION
# Description

Do not run `lsp` setup on server that is not installed as describe in the error below.

<img width="1167" alt="Screenshot 2022-10-30 at 06 27 31" src="https://user-images.githubusercontent.com/42694704/198856241-b6bd8c1d-8a1d-4447-b275-fabb68672d68.png">
