### PR TITLE
fix(alpha): make startify sections always appear

### DIFF
--- a/lua/lvim/core/alpha/startify.lua
+++ b/lua/lvim/core/alpha/startify.lua
@@ -21,19 +21,16 @@ function M.get_sections()
     entries = {
       { "e", lvim.icons.ui.NewFile .. " New File", "<CMD>ene!<CR>" },
     },
-    val = {},
   }
 
   local bottom_buttons = {
     entries = {
       { "q", "Quit", "<CMD>quit<CR>" },
     },
-    val = {},
   }
 
   local footer = {
     type = "group",
-    val = {},
   }
 
   return {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
depending on the random iteration order `resolve_config` in alpha.lua would sometimes overwrite val with {} after `resolve_buttons`

<!--- Please list any dependencies that are required for this change. --->

fixes #3027

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
Opened lvim 20 times and checked if all sections were present