### PR TITLE
refactor(hooks): use colorscheme event after reload

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -80,10 +80,17 @@ end
 
 function plugin_loader.recompile()
   plugin_loader.cache_clear()
+  vim.cmd [[LuaCacheClear]]
   pcall_packer_command "compile"
-  if utils.is_file(compile_path) then
-    Log:debug "generated packer_compiled.lua"
-  end
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "PackerCompileDone",
+    once = true,
+    callback = function()
+      if utils.is_file(compile_path) then
+        Log:debug "generated packer_compiled.lua"
+      end
+    end,
+  })
 end
 
 function plugin_loader.reload(configurations)
@@ -156,7 +163,6 @@ function plugin_loader.sync_core_plugins()
   })
 
   plugin_loader.cache_clear()
-  vim.cmd [[LuaCacheClear]]
   local core_plugins = plugin_loader.get_core_plugins()
   Log:trace(string.format("Syncing core plugins: [%q]", table.concat(core_plugins, ", ")))
   pcall_packer_command("sync", core_plugins)

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -70,6 +70,9 @@ local function pcall_packer_command(cmd, kwargs)
 end
 
 function plugin_loader.cache_clear()
+  if not utils.is_file(compile_path) then
+    return
+  end
   if vim.fn.delete(compile_path) == 0 then
     Log:debug "deleted packer_compiled.lua"
   end
@@ -151,7 +154,12 @@ function plugin_loader.sync_core_plugins()
       require("lvim.plugin-loader").load_snapshot(default_snapshot)
     end,
   })
-  pcall_packer_command "sync"
+
+  plugin_loader.cache_clear()
+  vim.cmd [[LuaCacheClear]]
+  local core_plugins = plugin_loader.get_core_plugins()
+  Log:trace(string.format("Syncing core plugins: [%q]", table.concat(core_plugins, ", ")))
+  pcall_packer_command("sync", core_plugins)
 end
 
 function plugin_loader.ensure_plugins()

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local Log = require "lvim.core.log"
 local in_headless = #vim.api.nvim_list_uis() == 0
+local plugin_loader = require "lvim.plugin-loader"
 
 function M.run_pre_update()
   Log:debug "Starting pre-update hook"
@@ -34,7 +35,7 @@ end
 ---It also forces regenerating any template ftplugin files
 ---Tip: Useful for clearing any outdated settings
 function M.reset_cache()
-  vim.cmd [[LuaCacheClear]]
+  plugin_loader.recompile()
   local lvim_modules = {}
   for module, _ in pairs(package.loaded) do
     if module:match "lvim.core" or module:match "lvim.lsp" then
@@ -68,7 +69,7 @@ function M.run_post_update()
   M.reset_cache()
 
   Log:debug "Syncing core plugins"
-  require("lvim.plugin-loader").sync_core_plugins()
+  plugin_loader.sync_core_plugins()
 
   if not in_headless then
     vim.schedule(function()

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -16,10 +16,12 @@ function M.run_on_packer_complete()
   Log:debug "Packer operation complete"
   vim.api.nvim_exec_autocmds("User", { pattern = "PackerComplete" })
 
-  vim.g.colors_name = lvim.colorscheme
-  pcall(vim.cmd, "colorscheme " .. lvim.colorscheme)
-
   if M._reload_triggered then
+    if not in_headless then
+      vim.schedule(function()
+        pcall(vim.api.nvim_exec_autocmds, "ColorScheme", { pattern = "*" })
+      end)
+    end
     Log:debug "Reloaded configuration"
     M._reload_triggered = nil
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- fix(hooks): use ColorScheme event in the reload-hook
- fix(packer): run packer recompile on cache_reset
- fix(packer): actually restrict sync core plugins

<!--- Please list any dependencies that are required for this change. --->

fixes #3257

## How Has This Been Tested?

tested with @ChristianChiarulli 's config files

```bash
#!/usr/bin/env bash

export INSTALL_PREFIX="/tmp/lvim/v2"
export LV_BRANCH="fix-reload-hooks"
export LV_REMOTE="kylo252/lunarvim.git"
export LUNARVIM_BASE_DIR="/tmp/lvim/v2/base"
export LUNARVIM_RUNTIME_DIR="/tmp/lvim/v2/data"
export LUNARVIM_CONFIG_DIR="/tmp/lvim/v2/conf"
export LUNARVIM_CACHE_DIR="/tmp/lvim/v2/cache"

installer_url="https://raw.githubusercontent.com/kylo252/LunarVim/6fc2e4fc3545228b4ded9fa3d08feda6bc1978da/utils/installer/install.sh"

installer="$(mktemp)"

curl -LSs "$installer_url" -o "$installer" && bash "$installer" --no-install-dependencies
```

