### PR TITLE
feature: Add chevron to breadcrumbs (with matching highlight group)

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -3,6 +3,7 @@ local M = {}
 -- local Log = require "lvim.core.log"
 
 local icons = lvim.icons.kind
+local icons_ui = lvim.icons.ui
 
 M.config = function()
   lvim.builtin.breadcrumbs = {
@@ -72,7 +73,7 @@ M.config = function()
         Variable = icons.Variable .. " ",
       },
       highlight = true,
-      separator = " " .. ">" .. " ",
+      separator = " " .. icons_ui.ChevronShortRight .. " ",
       depth_limit = 0,
       depth_limit_indicator = "..",
     },
@@ -154,8 +155,7 @@ local get_gps = function()
   end
 
   if not require("lvim.utils.functions").isempty(gps_location) then
-    -- TODO: replace with chevron
-    return ">" .. " " .. gps_location
+    return "%#NavicSeparator#".. icons_ui.ChevronShortRight .. "%* " .. gps_location
   else
     return ""
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This PR:

- resolves the [todo comment](https://github.com/LunarVim/LunarVim/blob/master/lua/lvim/core/breadcrumbs.lua#L157) about adding a chevron to the navic plugin
- adds a chevron to the spot near the comment
- adds a chevron to the 'separator' config option so the chevrons match
- adds the `NavicSeparator` highlight group to the new chevron so that it matches the rest of the separators in the breadcrumb trail

Please note that I chose the icon that looked most like what was already in place, but just let me know if it should be a different icon.


## How Has This Been Tested?

I ran this locally to verify. I also changed the highlight group styling to verify that the chevron was consistent throughout the breadcrumb trial.