### PR TITLE
refactor(theme)!: decouple tokyonight options

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -10,7 +10,7 @@ end
 
 require("lvim.bootstrap"):init(base_dir)
 
-require("lvim.config"):load()
+require("lvim.config").load()
 
 local plugins = require "lvim.plugins"
 

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -25,6 +25,15 @@ function M.handle()
   }
 
   ---@deprecated
+  lvim.builtin.theme.options = {}
+  setmetatable(lvim.builtin.theme.options, {
+    __newindex = function(_, k, v)
+      deprecate("lvim.builtin.theme.options." .. k, "Use `lvim.builtin.theme.<theme>.options` instead")
+      lvim.builtin.theme.tokyonight.options[k] = v
+    end,
+  })
+
+  ---@deprecated
   lvim.builtin.notify = {}
   setmetatable(lvim.builtin.notify, {
     __newindex = function(_, k, _)

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -1,0 +1,75 @@
+---@diagnostic disable: deprecated
+local M = {}
+
+local function deprecate(name, alternative)
+  local in_headless = #vim.api.nvim_list_uis() == 0
+  if in_headless then
+    return
+  end
+
+  alternative = alternative or "See https://github.com/LunarVim/LunarVim#breaking-changes"
+
+  local trace = debug.getinfo(3, "Sl")
+  local shorter_src = trace.short_src
+  local t = shorter_src .. ":" .. (trace.currentline or trace.lastlinedefined)
+  vim.schedule(function()
+    vim.notify_once(string.format("%s: `%s` is deprecated.\n %s.", t, name, alternative), vim.log.levels.WARN)
+  end)
+end
+
+function M.handle()
+  local mt = {
+    __newindex = function(_, k, _)
+      deprecate(k)
+    end,
+  }
+
+  ---@deprecated
+  lvim.builtin.notify = {}
+  setmetatable(lvim.builtin.notify, {
+    __newindex = function(_, k, _)
+      deprecate("lvim.builtin.notify." .. k, "See LunarVim#3294")
+    end,
+  })
+
+  if lvim.lsp.override and not vim.tbl_isempty(lvim.lsp.override) then
+    deprecate("lvim.lsp.override", "Use `lvim.lsp.automatic_configuration.skipped_servers` instead")
+    vim.tbl_map(function(c)
+      if not vim.tbl_contains(lvim.lsp.automatic_configuration.skipped_servers, c) then
+        table.insert(lvim.lsp.automatic_configuration.skipped_servers, c)
+      end
+    end, lvim.lsp.override)
+  end
+
+  if lvim.autocommands.custom_groups then
+    deprecate(
+      "lvim.autocommands.custom_groups",
+      "Use vim.api.nvim_create_autocmd instead or check LunarVim#2592 to learn about the new syntax"
+    )
+  end
+
+  if lvim.lsp.automatic_servers_installation then
+    deprecate(
+      "lvim.lsp.automatic_servers_installation",
+      "Use `lvim.lsp.installer.setup.automatic_installation` instead"
+    )
+  end
+
+  ---@deprecated
+  lvim.builtin.dashboard = {}
+  setmetatable(lvim.builtin.dashboard, {
+    __newindex = function(_, k, _)
+      deprecate("lvim.builtin.dashboard." .. k, "Use `lvim.builtin.alpha` instead. See LunarVim#1906")
+    end,
+  })
+
+  ---@deprecated
+  lvim.lsp.popup_border = {}
+  setmetatable(lvim.lsp.popup_border, mt)
+
+  ---@deprecated
+  lvim.lang = {}
+  setmetatable(lvim.lang, mt)
+end
+
+return M

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -7,12 +7,12 @@ local user_config_file = utils.join_paths(user_config_dir, "config.lua")
 
 ---Get the full path to the user configuration file
 ---@return string
-function M:get_user_config_path()
+function M.get_user_config_path()
   return user_config_file
 end
 
 --- Initialize lvim default configuration and variables
-function M:init()
+function M.init()
   lvim = vim.deepcopy(require "lvim.config.defaults")
 
   require("lvim.keymappings").load_defaults()
@@ -29,100 +29,20 @@ function M:init()
   local lvim_lsp_config = require "lvim.lsp.config"
   lvim.lsp = vim.deepcopy(lvim_lsp_config)
 
-  ---@deprecated replaced with lvim.builtin.alpha
-  lvim.builtin.dashboard = {
-    active = false,
-    on_config_done = nil,
-    search_handler = "",
-    disable_at_vim_enter = 0,
-    session_directory = "",
-    custom_header = {},
-    custom_section = {},
-    footer = {},
-  }
-
   lvim.builtin.luasnip = {
     sources = {
       friendly_snippets = true,
     },
   }
 
-  ---@deprecated
-  lvim.builtin.notify = {
-    active = false,
-  }
-end
-
-local function handle_deprecated_settings()
-  local function deprecation_notice(setting, new_setting)
-    local in_headless = #vim.api.nvim_list_uis() == 0
-    if in_headless then
-      return
-    end
-
-    local msg = string.format(
-      "Deprecation notice: [%s] setting is no longer supported. %s",
-      setting,
-      new_setting or "See https://github.com/LunarVim/LunarVim#breaking-changes"
-    )
-    vim.schedule(function()
-      vim.notify_once(msg, vim.log.levels.WARN)
-    end)
-  end
-
-  ---lvim.lang.FOO.lsp
-  for lang, entry in pairs(lvim.lang) do
-    local deprecated_config = entry.formatters or entry.linters or {}
-    if not vim.tbl_isempty(deprecated_config) then
-      deprecation_notice(string.format("lvim.lang.%s", lang))
-    end
-  end
-
-  -- lvim.lsp.override
-  if lvim.lsp.override and not vim.tbl_isempty(lvim.lsp.override) then
-    deprecation_notice("lvim.lsp.override", "Use `lvim.lsp.automatic_configuration.skipped_servers` instead")
-    vim.tbl_map(function(c)
-      if not vim.tbl_contains(lvim.lsp.automatic_configuration.skipped_servers, c) then
-        table.insert(lvim.lsp.automatic_configuration.skipped_servers, c)
-      end
-    end, lvim.lsp.override)
-  end
-
-  -- lvim.lsp.popup_border
-  if vim.tbl_contains(vim.tbl_keys(lvim.lsp), "popup_border") then
-    deprecation_notice "lvim.lsp.popup_border"
-  end
-
-  -- dashboard.nvim
-  if lvim.builtin.dashboard.active then
-    deprecation_notice("lvim.builtin.dashboard", "Use `lvim.builtin.alpha` instead. See LunarVim#1906")
-  end
-
-  -- notify.nvim
-  if lvim.builtin.notify.active then
-    deprecation_notice("lvim.builtin.notify", "See LunarVim#3294")
-  end
-
-  if lvim.autocommands.custom_groups then
-    deprecation_notice(
-      "lvim.autocommands.custom_groups",
-      "Use vim.api.nvim_create_autocmd instead or check LunarVim#2592 to learn about the new syntax"
-    )
-  end
-
-  if lvim.lsp.automatic_servers_installation then
-    deprecation_notice(
-      "lvim.lsp.automatic_servers_installation",
-      "Use `lvim.lsp.installer.setup.automatic_installation` instead"
-    )
-  end
+  require("lvim.config._deprecated").handle()
 end
 
 --- Override the configuration with a user provided one
 -- @param config_path The path to the configuration overrides
-function M:load(config_path)
+function M.load(config_path)
   local autocmds = reload "lvim.core.autocmds"
-  config_path = config_path or self:get_user_config_path()
+  config_path = config_path or M.get_user_config_path()
   local ok, err = pcall(dofile, config_path)
   if not ok then
     if utils.is_file(user_config_file) then
@@ -137,8 +57,6 @@ function M:load(config_path)
   end
 
   Log:set_level(lvim.log.level)
-
-  handle_deprecated_settings()
 
   autocmds.define_autocmds(lvim.autocommands)
 
@@ -157,7 +75,7 @@ end
 
 --- Override the configuration with a user provided one
 -- @param config_path The path to the configuration overrides
-function M:reload()
+function M.reload()
   vim.schedule(function()
     reload("lvim.utils.hooks").run_pre_reload()
 

--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -5,83 +5,51 @@ local M = {}
 M.config = function()
   lvim.builtin.theme = {
     name = "tokyonight",
-    options = {
-      on_highlights = function(hl, c)
-        hl.IndentBlanklineContextChar = {
-          fg = c.dark5,
-        }
-        hl.TSConstructor = {
-          fg = c.blue1,
-        }
-        hl.TSTagDelimiter = {
-          fg = c.dark5,
-        }
-        -- local prompt = "#2d3149"
-        -- hl.TelescopeNormal = {
-        --   bg = c.bg_dark,
-        --   fg = c.fg_dark,
-        -- }
-        -- hl.TelescopeBorder = {
-        --   bg = c.bg_dark,
-        --   fg = c.bg_dark,
-        -- }
-        -- hl.TelescopePromptNormal = {
-        --   bg = prompt,
-        -- }
-        -- hl.TelescopePromptBorder = {
-        --   bg = prompt,
-        --   fg = prompt,
-        -- }
-        -- hl.TelescopePromptTitle = {
-        --   bg = prompt,
-        --   fg = prompt,
-        -- }
-        -- hl.TelescopePreviewTitle = {
-        --   bg = c.bg_dark,
-        --   fg = c.bg_dark,
-        -- }
-        -- hl.TelescopeResultsTitle = {
-        --   bg = c.bg_dark,
-        --   fg = c.bg_dark,
-        -- }
-      end,
-      style = "night", -- The theme comes in three styles, `storm`, a darker variant `night` and `day`
-      transparent = lvim.transparent_window, -- Enable this to disable setting the background color
-      terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
-      styles = {
-        -- Style to be applied to different syntax groups
-        -- Value is any valid attr-list value for `:help nvim_set_hl`
-        comments = { italic = true },
-        keywords = { italic = true },
-        functions = {},
-        variables = {},
-        -- Background styles. Can be "dark", "transparent" or "normal"
-        sidebars = "dark", -- style for sidebars, see below
-        floats = "dark", -- style for floating windows
+    tokyonight = {
+      options = {
+        on_highlights = function(hl, c)
+          hl.IndentBlanklineContextChar = {
+            fg = c.dark5,
+          }
+          hl.TSConstructor = {
+            fg = c.blue1,
+          }
+          hl.TSTagDelimiter = {
+            fg = c.dark5,
+          }
+        end,
+        style = "night", -- The theme comes in three styles, `storm`, a darker variant `night` and `day`
+        transparent = lvim.transparent_window, -- Enable this to disable setting the background color
+        terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
+        styles = {
+          -- Style to be applied to different syntax groups
+          -- Value is any valid attr-list value for `:help nvim_set_hl`
+          comments = { italic = true },
+          keywords = { italic = true },
+          functions = {},
+          variables = {},
+          -- Background styles. Can be "dark", "transparent" or "normal"
+          sidebars = "dark", -- style for sidebars, see below
+          floats = "dark", -- style for floating windows
+        },
+        -- Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`
+        sidebars = {
+          "qf",
+          "vista_kind",
+          "terminal",
+          "packer",
+          "spectre_panel",
+          "NeogitStatus",
+          "help",
+        },
+        day_brightness = 0.3, -- Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors
+        hide_inactive_statusline = false, -- Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**.
+        dim_inactive = false, -- dims inactive windows
+        lualine_bold = false, -- When `true`, section headers in the lualine theme will be bold
+        use_background = true, -- can be light/dark/auto. When auto, background will be set to vim.o.background
       },
-      -- Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`
-      sidebars = {
-        "qf",
-        "vista_kind",
-        "terminal",
-        "packer",
-        "spectre_panel",
-        "NeogitStatus",
-        "help",
-      },
-      day_brightness = 0.3, -- Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors
-      hide_inactive_statusline = false, -- Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**.
-      dim_inactive = false, -- dims inactive windows
-      lualine_bold = false, -- When `true`, section headers in the lualine theme will be bold
-      use_background = true, -- can be light/dark/auto. When auto, background will be set to vim.o.background
     },
   }
-  local status_ok, theme = pcall(require, "tokyonight")
-  if not status_ok then
-    return
-  end
-
-  theme.setup(lvim.builtin.theme.options)
 end
 
 M.setup = function()
@@ -91,10 +59,14 @@ M.setup = function()
     return
   end
 
-  local status_ok, theme = pcall(require, "tokyonight")
-  if status_ok and theme then
-    theme.setup(lvim.builtin.theme.options)
+  local selected_theme = lvim.builtin.theme.name
+  local status_ok, plugin = pcall(require, selected_theme)
+  if not status_ok then
+    return
   end
+  pcall(function()
+    plugin.setup(lvim.builtin.theme[selected_theme].options)
+  end)
 
   -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
   local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)

--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -109,21 +109,6 @@ end
 function M.clear(keymaps)
   local default = M.get_defaults()
   for mode, mappings in pairs(keymaps) do
-    local translated_mode = mode_adapters[mode] or mode
-    for key, _ in pairs(mappings) do
-      -- some plugins may override default bindings that the user hasn't manually overridden
-      if default[mode][key] ~= nil or (default[translated_mode] ~= nil and default[translated_mode][key] ~= nil) then
-        pcall(vim.keymap.del, translated_mode, key)
-      end
-    end
-  end
-end
-
--- Unsets all keybindings defined in keymaps
--- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
-function M.clear(keymaps)
-  local default = M.get_defaults()
-  for mode, mappings in pairs(keymaps) do
     local translated_mode = mode_adapters[mode] and mode_adapters[mode] or mode
     for key, _ in pairs(mappings) do
       -- some plugins may override default bindings that the user hasn't manually overriden

--- a/tests/specs/config_loader_spec.lua
+++ b/tests/specs/config_loader_spec.lua
@@ -28,14 +28,14 @@ a.describe("config-loader", function()
   end)
 
   a.it("should be able to load user-config without errors", function()
-    config:load(user_config_path)
+    config.load(user_config_path)
   end)
 
   a.it("should be able to reload user-config without errors", function()
-    config:load(user_config_path)
+    config.load(user_config_path)
     local test_path = "/tmp/lvim"
     os.execute(string.format([[echo "vim.opt.undodir = '%s'" >> %s]], test_path, user_config_path))
-    config:reload()
+    config.reload()
     vim.schedule(function()
       assert.equal(vim.opt.undodir:get()[1], test_path)
     end)
@@ -44,11 +44,11 @@ a.describe("config-loader", function()
   a.it("should not get interrupted by errors in user-config", function()
     local test_path = "/tmp/lunarvim"
     os.execute(string.format([[echo "vim.opt.undodir = '%s'" >> %s]], test_path, user_config_path))
-    config:load(user_config_path)
+    config.load(user_config_path)
     assert.equal(vim.opt.undodir:get()[1], test_path)
     require("lvim.core.log"):set_level "error"
     os.execute(string.format("echo 'invalid_function()' >> %s", user_config_path))
-    config:load(user_config_path)
+    config.load(user_config_path)
     require("lvim.core.log"):set_level "error"
     assert.equal(vim.opt.undodir:get()[1], test_path)
   end)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

#### (refactor!) decouple tokyonight options

moves `lvim.builtin.theme.options` into `lvim.builtin.theme.tokyonight.options` since they are
specific to how `tokyonight` is configured.

#### (refactor) better deprecation handling

- all the deprecated options are now in a single file
- use `__newindex` to handle new entries
- this gives us much better flexibility (e.g. this can handle `lvim.builtin.theme.options.dummy`)
- and it allows us to generate a trace where that action was last defined

#### misc

- chore: remove merge duplicate

<!--- Please list any dependencies that are required for this change. --->

related #3313, #3378

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->

```lua
-- add this somewhere in your config
lvim.builtin.theme.options.dim_inactive = true
```

