### PR TITLE
chore(dap-ui): move dap-ui config to lvim.builtin.dap

### DIFF
--- a/lua/lvim/core/dap.lua
+++ b/lua/lvim/core/dap.lua
@@ -24,6 +24,47 @@ M.config = function()
     },
     ui = {
       auto_open = true,
+      config = {
+        expand_lines = true,
+        icons = { expanded = "", collapsed = "", circular = "" },
+        mappings = {
+          -- Use a table to apply multiple mappings
+          expand = { "<CR>", "<2-LeftMouse>" },
+          open = "o",
+          remove = "d",
+          edit = "e",
+          repl = "r",
+          toggle = "t",
+        },
+        layouts = {
+          {
+            elements = {
+              { id = "scopes", size = 0.33 },
+              { id = "breakpoints", size = 0.17 },
+              { id = "stacks", size = 0.25 },
+              { id = "watches", size = 0.25 },
+            },
+            size = 0.33,
+            position = "right",
+          },
+          {
+            elements = {
+              { id = "repl", size = 0.45 },
+              { id = "console", size = 0.55 },
+            },
+            size = 0.27,
+            position = "bottom",
+          },
+        },
+        floating = {
+          max_height = 0.9,
+          max_width = 0.5, -- Floats will be treated as percentage of your screen.
+          border = vim.g.border_chars, -- Border style. Can be 'single', 'double' or 'rounded'
+          mappings = {
+            close = { "q", "<Esc>" },
+          },
+        },
+      },
     },
   }
 end
@@ -69,47 +110,7 @@ M.setup_ui = function()
     return
   end
   local dapui = require "dapui"
-  dapui.setup {
-    expand_lines = true,
-    icons = { expanded = "", collapsed = "", circular = "" },
-    mappings = {
-      -- Use a table to apply multiple mappings
-      expand = { "<CR>", "<2-LeftMouse>" },
-      open = "o",
-      remove = "d",
-      edit = "e",
-      repl = "r",
-      toggle = "t",
-    },
-    layouts = {
-      {
-        elements = {
-          { id = "scopes", size = 0.33 },
-          { id = "breakpoints", size = 0.17 },
-          { id = "stacks", size = 0.25 },
-          { id = "watches", size = 0.25 },
-        },
-        size = 0.33,
-        position = "right",
-      },
-      {
-        elements = {
-          { id = "repl", size = 0.45 },
-          { id = "console", size = 0.55 },
-        },
-        size = 0.27,
-        position = "bottom",
-      },
-    },
-    floating = {
-      max_height = 0.9,
-      max_width = 0.5, -- Floats will be treated as percentage of your screen.
-      border = vim.g.border_chars, -- Border style. Can be 'single', 'double' or 'rounded'
-      mappings = {
-        close = { "q", "<Esc>" },
-      },
-    },
-  }
+  dapui.setup(lvim.builtin.dap.ui.config)
 
   if lvim.builtin.dap.ui.auto_open then
     dap.listeners.after.event_initialized["dapui_config"] = function()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Move `dap-ui` config to `lvim.builtin.dap` to make it configurable for user.