### PR TITLE
fix: revert ColorScheme autocmd execution

### DIFF
--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -19,7 +19,9 @@ function M.run_on_packer_complete()
   if M._reload_triggered then
     if not in_headless then
       vim.schedule(function()
-        pcall(vim.api.nvim_exec_autocmds, "ColorScheme", { pattern = "*" })
+        -- FIXME(kylo252): nvim-tree.lua/lua/nvim-tree/view.lua:442: Invalid window id
+        -- pcall(vim.api.nvim_exec_autocmds, "ColorScheme", { pattern = "*" })
+        pcall(vim.cmd.colorscheme, lvim.colorscheme)
       end)
     end
     Log:debug "Reloaded configuration"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
 bug in nvim-tree is breaking things on reload

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:PackerSync`

