### PR TITLE
fix(installer): use quotes in set-alias

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -271,7 +271,7 @@ function create_alias {
         New-Item -Path $PROFILE -ItemType "file" -Force
     }
 
-    Add-Content -Path $PROFILE -Value $("`r`nSet-Alias lvim $lvim_bin")
+    Add-Content -Path $PROFILE -Value $("`r`nSet-Alias lvim '$lvim_bin'")
 
     Write-Host 'To use the new alias in this window reload your profile with: `. $PROFILE`' -ForegroundColor Green
 }


### PR DESCRIPTION
This can prevent spacing in the path causeing the Set-Alias error.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

summary of the change
Simply add a '' to prevent the error/bug.
<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)
Fix error when the path to the lvim.ps1 have spacing.(e.g. the username has spaces)
## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run the setup script, then run the```. $profile```, see if there is any error message.

