### PR TITLE
refactor(config): better deprecation handling

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -29,93 +29,13 @@ function M:init()
   local lvim_lsp_config = require "lvim.lsp.config"
   lvim.lsp = vim.deepcopy(lvim_lsp_config)
 
-  ---@deprecated replaced with lvim.builtin.alpha
-  lvim.builtin.dashboard = {
-    active = false,
-    on_config_done = nil,
-    search_handler = "",
-    disable_at_vim_enter = 0,
-    session_directory = "",
-    custom_header = {},
-    custom_section = {},
-    footer = {},
-  }
-
   lvim.builtin.luasnip = {
     sources = {
       friendly_snippets = true,
     },
   }
 
-  ---@deprecated
-  lvim.builtin.notify = {
-    active = false,
-  }
-end
-
-local function handle_deprecated_settings()
-  local function deprecation_notice(setting, new_setting)
-    local in_headless = #vim.api.nvim_list_uis() == 0
-    if in_headless then
-      return
-    end
-
-    local msg = string.format(
-      "Deprecation notice: [%s] setting is no longer supported. %s",
-      setting,
-      new_setting or "See https://github.com/LunarVim/LunarVim#breaking-changes"
-    )
-    vim.schedule(function()
-      vim.notify_once(msg, vim.log.levels.WARN)
-    end)
-  end
-
-  ---lvim.lang.FOO.lsp
-  for lang, entry in pairs(lvim.lang) do
-    local deprecated_config = entry.formatters or entry.linters or {}
-    if not vim.tbl_isempty(deprecated_config) then
-      deprecation_notice(string.format("lvim.lang.%s", lang))
-    end
-  end
-
-  -- lvim.lsp.override
-  if lvim.lsp.override and not vim.tbl_isempty(lvim.lsp.override) then
-    deprecation_notice("lvim.lsp.override", "Use `lvim.lsp.automatic_configuration.skipped_servers` instead")
-    vim.tbl_map(function(c)
-      if not vim.tbl_contains(lvim.lsp.automatic_configuration.skipped_servers, c) then
-        table.insert(lvim.lsp.automatic_configuration.skipped_servers, c)
-      end
-    end, lvim.lsp.override)
-  end
-
-  -- lvim.lsp.popup_border
-  if vim.tbl_contains(vim.tbl_keys(lvim.lsp), "popup_border") then
-    deprecation_notice "lvim.lsp.popup_border"
-  end
-
-  -- dashboard.nvim
-  if lvim.builtin.dashboard.active then
-    deprecation_notice("lvim.builtin.dashboard", "Use `lvim.builtin.alpha` instead. See LunarVim#1906")
-  end
-
-  -- notify.nvim
-  if lvim.builtin.notify.active then
-    deprecation_notice("lvim.builtin.notify", "See LunarVim#3294")
-  end
-
-  if lvim.autocommands.custom_groups then
-    deprecation_notice(
-      "lvim.autocommands.custom_groups",
-      "Use vim.api.nvim_create_autocmd instead or check LunarVim#2592 to learn about the new syntax"
-    )
-  end
-
-  if lvim.lsp.automatic_servers_installation then
-    deprecation_notice(
-      "lvim.lsp.automatic_servers_installation",
-      "Use `lvim.lsp.installer.setup.automatic_installation` instead"
-    )
-  end
+  require("lvim.config._deprecated").handle()
 end
 
 --- Override the configuration with a user provided one
@@ -137,8 +57,6 @@ function M:load(config_path)
   end
 
   Log:set_level(lvim.log.level)
-
-  handle_deprecated_settings()
 
   autocmds.define_autocmds(lvim.autocommands)
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

### (refactor) better deprecation handling

- all the deprecated options are now in a single file
- use `__newindex` to handle new entries
- this gives us much better flexibility (e.g. this can handle `lvim.builtin.theme.options.dummy`)
- and it allows us to generate a trace where that action was last defined

originally added in #3384

### How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->

```lua
-- add this somewhere in your config
lvim.builtin.theme.options.dim_inactive = true
```
