### PR TITLE
fix(installer): Use master in windows installer

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference = "Stop" # exit when command fails
 
 # set script variables
-$LV_BRANCH = $LV_BRANCH ?? "rolling"
+$LV_BRANCH = $LV_BRANCH ?? "master"
 $LV_REMOTE = $LV_REMOTE ??  "lunarvim/lunarvim.git"
 $INSTALL_PREFIX = $INSTALL_PREFIX ?? "$HOME\.local"
 

--- a/utils/installer/uninstall.ps1
+++ b/utils/installer/uninstall.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference = "Stop" # exit when command fails
 
 # set script variables
-$LV_BRANCH = $LV_BRANCH ?? "rolling"
+$LV_BRANCH = $LV_BRANCH ?? "master"
 $LV_REMOTE = $LV_REMOTE ??  "lunarvim/lunarvim.git"
 $INSTALL_PREFIX = $INSTALL_PREFIX ?? "$HOME\.local"
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

use the master branch instead of rolling in the windows installer

## How Has This Been Tested?

not tested
