### PR TITLE
fix(bufferline): use buf kill on close

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -58,9 +58,9 @@ M.config = function()
     options = {
       mode = "buffers", -- set to "tabs" to only show tabpages instead
       numbers = "none", -- can be "none" | "ordinal" | "buffer_id" | "both" | function
-      close_command = function(bufnr)
-        M.buf_kill("bd", bufnr, true)
-      end, -- can be a string | function, see "Mouse actions"
+      close_command = function(bufnr) -- can be a string | function, see "Mouse actions"
+        M.buf_kill("bd", bufnr, false)
+      end,
       right_mouse_command = "vert sbuffer %d", -- can be a string | function, see "Mouse actions"
       left_mouse_command = "buffer %d", -- can be a string | function, see "Mouse actions"
       middle_mouse_command = nil, -- can be a string | function, see "Mouse actions"
@@ -217,7 +217,7 @@ function M.buf_kill(kill_command, bufnr, force)
   -- If there is only one buffer (which has to be the current one), vim will
   -- create a new buffer on :bd.
   -- For more than one buffer, pick the previous buffer (wrapping around if necessary)
-  if #buffers > 1 and #windows ~= 0 then
+  if #buffers > 1 and #windows > 0 then
     for i, v in ipairs(buffers) do
       if v == bufnr then
         local prev_buf_idx = i == 1 and (#buffers - 1) or (i - 1)

--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -58,7 +58,9 @@ M.config = function()
     options = {
       mode = "buffers", -- set to "tabs" to only show tabpages instead
       numbers = "none", -- can be "none" | "ordinal" | "buffer_id" | "both" | function
-      close_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
+      close_command = function(bufnr)
+        M.buf_kill("bd", bufnr, true)
+      end, -- can be a string | function, see "Mouse actions"
       right_mouse_command = "vert sbuffer %d", -- can be a string | function, see "Mouse actions"
       left_mouse_command = "buffer %d", -- can be a string | function, see "Mouse actions"
       middle_mouse_command = nil, -- can be a string | function, see "Mouse actions"
@@ -203,8 +205,6 @@ function M.buf_kill(kill_command, bufnr, force)
     return api.nvim_win_get_buf(win) == bufnr
   end, api.nvim_list_wins())
 
-  if #windows == 0 then return end
-
   if force then
     kill_command = kill_command .. "!"
   end
@@ -217,7 +217,7 @@ function M.buf_kill(kill_command, bufnr, force)
   -- If there is only one buffer (which has to be the current one), vim will
   -- create a new buffer on :bd.
   -- For more than one buffer, pick the previous buffer (wrapping around if necessary)
-  if #buffers > 1 then
+  if #buffers > 1 and #windows ~= 0 then
     for i, v in ipairs(buffers) do
       if v == bufnr then
         local prev_buf_idx = i == 1 and (#buffers - 1) or (i - 1)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

closing active buffer with bufferline caused nvimtree to go "fullscreen"

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
close active buffer with bufferline
