### PR TITLE
feat: add command & keybind to view docs

### DIFF
--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -32,7 +32,7 @@ M.defaults = {
   {
     name = "LvimDocs",
     fn = function()
-      local documentation_url = "https://www.lunarvim.org/docs/installation"
+      local documentation_url = "https://www.lunarvim.org/docs/quick-start"
       if vim.fn.has "mac" == 1 or vim.fn.has "macunix" == 1 then
         vim.fn.execute("!open " .. documentation_url)
       elseif vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
@@ -41,7 +41,6 @@ M.defaults = {
         vim.fn.execute("!xdg-open " .. documentation_url)
       else
         vim.notify "Opening docs in a browser is not supported on your OS"
-
       end
     end,
   },

--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -37,8 +37,11 @@ M.defaults = {
         vim.fn.execute("!open " .. documentation_url)
       elseif vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
         vim.fn.execute("!start " .. documentation_url)
-      else
+      elseif vim.fn.has "unix" == 1 then
         vim.fn.execute("!xdg-open " .. documentation_url)
+      else
+        vim.notify "Opening docs in a browser is not supported on your OS"
+
       end
     end,
   },

--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -10,8 +10,6 @@ vim.cmd [[
   endfunction
 ]]
 
-vim.cmd [[command! LvimDocs execute 'silent !open "https://www.lunarvim.org/docs/installation"']]
-
 M.defaults = {
   {
     name = "BufferKill",
@@ -29,6 +27,19 @@ M.defaults = {
     name = "LvimInfo",
     fn = function()
       require("lvim.core.info").toggle_popup(vim.bo.filetype)
+    end,
+  },
+  {
+    name = "LvimDocs",
+    fn = function()
+      local documentation_url = "https://www.lunarvim.org/docs/installation"
+      if vim.fn.has "mac" == 1 or vim.fn.has "macunix" == 1 then
+        vim.fn.execute("!open " .. documentation_url)
+      elseif vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
+        vim.fn.execute("!start " .. documentation_url)
+      else
+        vim.fn.execute("!xdg-open " .. documentation_url)
+      end
     end,
   },
   {

--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -10,6 +10,8 @@ vim.cmd [[
   endfunction
 ]]
 
+vim.cmd [[command! LvimDocs execute 'silent !open "https://www.lunarvim.org/docs/installation"']]
+
 M.defaults = {
   {
     name = "BufferKill",

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -186,6 +186,7 @@ M.config = function()
           "<cmd>edit " .. get_config_dir() .. "/config.lua<cr>",
           "Edit config.lua",
         },
+        d = { "<cmd>LvimDocs<cr>", "View LunarVim's docs" },
         f = {
           "<cmd>lua require('lvim.core.telescope.custom-finders').find_lunarvim_files()<cr>",
           "Find LunarVim files",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Added command `:LvimDocs` and keybind `<leader> L d` to open LunarVim's documentation (https://www.lunarvim.org/docs/installation) as requested in #3312.

> This ticket is assigned to another user, please favour their PR over this one. I thought I would submit a PR as there has been no activity for a while & no draft PR open. I'm very new to LunarVim (and NeoVim) and saw this ticket as a great opportunity to get involved and start learning more. 😄 

<!--- Please list any dependencies that are required for this change. --->

fixes #3312

## How Has This Been Tested?
### Operating Systems Tested
- macOS (Ventura 13.0)
- Windows 11
- Linux - Tested by @LostNeophyte 

### Tests
* Ran command `:LvimDocs` and verified the link opened in my default browser.
* Ran the keybind `<leader> L d` and verified the link opened in my default browser.


