### PR TITLE
fix(autopairs): attach confirm_done only once

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -46,6 +46,10 @@ function M.config()
   }
 end
 
+local function on_confirm_done(...)
+  require("nvim-autopairs.completion.cmp").on_confirm_done()(...)
+end
+
 M.setup = function()
   local status_ok, autopairs = pcall(require, "nvim-autopairs")
   if not status_ok then
@@ -83,8 +87,9 @@ M.setup = function()
     lvim.builtin.autopairs.on_config_done(autopairs)
   end
   pcall(function()
-    local cmp_autopairs = require "nvim-autopairs.completion.cmp"
-    require("cmp").event:on("confirm_done", cmp_autopairs.on_confirm_done())
+    require "nvim-autopairs.completion.cmp"
+    require("cmp").event:off("confirm_done", on_confirm_done)
+    require("cmp").event:on("confirm_done", on_confirm_done)
   end)
 end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
After running :LvimReload, with each run autopairs' `on_confirm_done` was added to cmp's events, and that caused additional `()` to be added to function completion (only noticed this in lua though). This PR makes sure the event listener is added only once

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:LvimReload` a couple times
- See that one pair of parenthesis is added with completion
