### PR TITLE
fix(autocmds): create reload config autocmd only once

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -181,11 +181,20 @@ end
 
 function M.enable_reload_config_on_save()
   local user_config_file = require("lvim.config"):get_user_config_path()
-
   if vim.loop.os_uname().version:match "Windows" then
     -- autocmds require forward slashes even on windows
     user_config_file = user_config_file:gsub("\\", "/")
   end
+
+  local exists, autocmds = pcall(vim.api.nvim_get_autocmds, {
+    group = "_general_settings",
+    event = "BufWritePost",
+    pattern = user_config_file,
+  })
+  if exists and #autocmds > 0 then
+    return
+  end
+
   vim.api.nvim_create_autocmd("BufWritePost", {
     group = "_general_settings",
     pattern = user_config_file,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The autocommand to reload config is being created on every reload, this pr checks if it has already been created and aborts creating a new one if that's the case

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Reload config
- Run command `:lua vim.pretty_print(vim.api.nvim_get_autocmds {group="_general_settings"})`
- See one config reload autocmd
