### PR TITLE
feat: portal integration to jumping between  buffers history

### DIFF
--- a/lua/lvim/keymappings.lua
+++ b/lua/lvim/keymappings.lua
@@ -59,6 +59,10 @@ local defaults = {
     ["<A-j>"] = ":m .+1<CR>==",
     ["<A-k>"] = ":m .-2<CR>==",
 
+    -- portal to jump between buffers history
+    ["<A-i>"] = require("portal").jump_forward, {},
+    ["<A-o>"] = require("portal").jump_backward, {},
+
     -- QuickFix
     ["]q"] = ":cnext<CR>",
     ["[q"] = ":cprev<CR>",

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -1,6 +1,16 @@
 -- local require = require("lvim.utils.require").require
 local core_plugins = {
   -- Packer can manage itself as an optional plugin
+  {
+    "cbochs/portal.nvim",
+    config = function()
+        require("portal").setup()
+    end,
+    requires = {
+        "cbochs/grapple.nvim",  -- Optional: provides the "grapple" query item
+        "ThePrimeagen/harpoon", -- Optional: provides the "harpoon" query item
+    },
+  },
   { "wbthomason/packer.nvim" },
   { "neovim/nvim-lspconfig" },
   { "tamago324/nlsp-settings.nvim" },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

portal plugin added to go to back or forward in buffers history with alt + i and alt + o  beeing like easy-motion of buffers history:
https://github.com/cbochs/portal.nvim

## How Has This Been Tested?
i just added portal plugin and i set the keymaps (alt + i , alt + o) to jumping between buffers history

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:lua require("portal").jump_backward()`
- Run command `:lua require("portal").jump_forward()`
- I just assigned that both functions in keymapps alt + i  and alt + o

