### PR TITLE
fix(autocmds): add separate autoreload config group 

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -186,8 +186,9 @@ function M.enable_reload_config_on_save()
     -- autocmds require forward slashes even on windows
     user_config_file = user_config_file:gsub("\\", "/")
   end
+  vim.api.nvim_create_augroup("lvim_reload_config_on_save", {})
   vim.api.nvim_create_autocmd("BufWritePost", {
-    group = "_general_settings",
+    group = "lvim_reload_config_on_save",
     pattern = user_config_file,
     desc = "Trigger LvimReload on saving config.lua",
     callback = function()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The autoreload config cmd was created on every save which incremented the number of autorelaod functions

<!--- Please list any dependencies that are required for this change. --->

fixes #3392
fixes #3391

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Reload config a couple times
- Run command `:lua vim.pretty_print(vim.api.nvim_get_autocmds {group="lvim_reload_config_on_save"})`
- See one config reload autocmd
- Nothing brakes even with quite a lot of swift saves


