### PR TITLE
feat: configure dap logging

### DIFF
--- a/lua/lvim/core/dap.lua
+++ b/lua/lvim/core/dap.lua
@@ -140,8 +140,13 @@ M.setup_ui = function()
       return vim.notify(msg, level, opts)
     end
 
-    opts = opts or {}
-    opts.title = opts.title or "dapui"
+    opts = vim.tbl_extend("keep", opts or {}, {
+      title = "dap-ui",
+      icon = "",
+      on_open = function(win)
+        vim.api.nvim_buf_set_option(vim.api.nvim_win_get_buf(win), "filetype", "markdown")
+      end,
+    })
 
     -- vim_log_level can be omitted
     if level == nil then

--- a/lua/lvim/core/dap.lua
+++ b/lua/lvim/core/dap.lua
@@ -22,8 +22,14 @@ M.config = function()
       linehl = "Visual",
       numhl = "DiagnosticSignWarn",
     },
+    log = {
+      level = "info",
+    },
     ui = {
       auto_open = true,
+      notify = {
+        threshold = vim.log.levels.INFO,
+      },
       config = {
         expand_lines = true,
         icons = { expanded = "", collapsed = "", circular = "" },
@@ -99,6 +105,8 @@ M.setup = function()
     U = { "<cmd>lua require'dapui'.toggle()<cr>", "Toggle UI" },
   }
 
+  dap.set_log_level(lvim.builtin.dap.log.level)
+
   if lvim.builtin.dap.on_config_done then
     lvim.builtin.dap.on_config_done(dap)
   end
@@ -122,6 +130,38 @@ M.setup_ui = function()
     -- dap.listeners.before.event_exited["dapui_config"] = function()
     --   dapui.close()
     -- end
+  end
+
+  local Log = require "lvim.core.log"
+
+  -- until rcarriga/nvim-dap-ui#164 is fixed
+  local function notify_handler(msg, level, opts)
+    if level >= lvim.builtin.dap.ui.notify.threshold then
+      return vim.notify(msg, level, opts)
+    end
+
+    opts = opts or {}
+    opts.title = opts.title or "dapui"
+
+    -- vim_log_level can be omitted
+    if level == nil then
+      level = Log.levels["INFO"]
+    elseif type(level) == "string" then
+      level = Log.levels[(level):upper()] or Log.levels["INFO"]
+    else
+      -- https://github.com/neovim/neovim/blob/685cf398130c61c158401b992a1893c2405cd7d2/runtime/lua/vim/lsp/log.lua#L5
+      level = level + 1
+    end
+
+    msg = string.format("%s: %s", opts.title, msg)
+    Log:add_entry(level, msg)
+  end
+
+  local dapui_ok, _ = xpcall(function()
+    require("dapui.util").notify = notify_handler
+  end, debug.traceback)
+  if not dapui_ok then
+    Log:debug "Unable to override dap-ui logging level"
   end
 end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

configurable logging level for dap/dap-ui


## How Has This Been Tested?


#### dap

```lua
-- config.lua
lvim.builtin.dap.log.level = "debug"
```

start a debug session and check `$LUNARVIM_CACHE_DIR/dap.log`


#### dap-ui

```lua
-- config.lua
lvim.builtin.dap.ui.notify.threshold = vim.log.levels.INFO
```

run `:PackerCompile` and check that "setup called twice" has disppeared

