### PR TITLE
fix(lsp): disable annoying sumneko popup on Release branch

### DIFF
--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -4,6 +4,7 @@ local default_workspace = {
     get_lvim_base_dir(),
     require("neodev.config").types(),
   },
+  checkThirdParty = false,
 
   maxPreload = 5000,
   preloadFileSize = 10000,


### PR DESCRIPTION
this is mirroring fix #3445 made on master for this release v1.2.9. Fixes this popup (error/check):
```
Do you need to configure your work environment as `luassert`?                                                                                                                                
                                                                                                                                                                                             
Request Actions:                                                                                                                                                                             
1. Apply and modify settings                                                                                                                                                                 
2. Apply but do not modify settings                                                                                                                                                          
3. Don't show again                                                                                                                                                                          
Type number and <Enter> or click with the mouse (q or empty cancels): 
```