### PR TITLE
fix(bufkill): wrap around correctly

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -220,7 +220,7 @@ function M.buf_kill(kill_command, bufnr, force)
   if #buffers > 1 and #windows > 0 then
     for i, v in ipairs(buffers) do
       if v == bufnr then
-        local prev_buf_idx = i == 1 and (#buffers - 1) or (i - 1)
+        local prev_buf_idx = i == 1 and #buffers or (i - 1)
         local prev_buffer = buffers[prev_buf_idx]
         for _, win in ipairs(windows) do
           api.nvim_win_set_buf(win, prev_buffer)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fixes a bug in buf_kill where wrapping around doesn't work. Lua indexes start at 1 and not 0, so the last element is `#buffers` and not `#buffers - 1` :)

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
opened 2 buffers, closed the first one