### PR TITLE
docs(contributing): make it clear how to title PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ shfmt -i 2 -ci -bn -l -d .
 - Your PR must pass all the [automated-ci-tests](https://github.com/neovim/neovim/actions).
 - Use a [git-feature-branch](https://www.atlassian.com/git/tutorials/comparing-workflows) instead of the master/rolling branch.
 - Use a [rebase-workflow](http://git-scm.com/book/en/v2/Git-Branching-Rebasing).
+- Title the PR the same way as commit headers
 
 ### Commit Messages
 * Commit header is limited to 72 characters.


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

CI tests check the PR title, but there's no information in the guidelines how to do it
