### PR TITLE
fix(packer): increase clone timeout in headless

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -39,7 +39,7 @@ function plugin_loader.init(opts)
 
   if in_headless then
     init_opts.display = nil
-    init_opts.git.clone_timeout = 240
+    init_opts.git.clone_timeout = 300
   end
 
   if not utils.is_directory(install_path) then

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -39,6 +39,7 @@ function plugin_loader.init(opts)
 
   if in_headless then
     init_opts.display = nil
+    init_opts.git.clone_timeout = 240
   end
 
   if not utils.is_directory(install_path) then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Increases git clone timeout in packer when in headless so that the installer is less likely to fail

fixes #3464 

## How Has This Been Tested?
not tested, but I did test that changing it to 0 makes the install fail so this should work as well
