### PR TITLE
fix(bufferline): fallback to empty table if `buf_nums` is nil

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -26,7 +26,7 @@ end
 local function custom_filter(buf, buf_nums)
   local logs = vim.tbl_filter(function(b)
     return is_ft(b, "log")
-  end, buf_nums)
+  end, buf_nums or {})
   if vim.tbl_isempty(logs) then
     return true
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`buf_nums` can be nil if `lvim.builtin.bufferline.options.mode == "tabs"`

<!--- Please list any dependencies that are required for this change. --->

fixes #3367 

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
opened a buffer with `mode="tabs"` in bufferline