### PR TITLE
fix(tree-sitter): force update bundled parsers

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -4,8 +4,24 @@ local Log = require "lvim.core.log"
 function M.config()
   lvim.builtin.treesitter = {
     on_config_done = nil,
-    ensure_installed = {}, -- one of "all", "maintained" (parsers with maintainers), or a list of languages
+
+    -- A list of parser names, or "all"
+    ensure_installed = {},
+
+    -- List of parsers to ignore installing (for "all")
     ignore_install = {},
+
+    -- A directory to install the parsers into.
+    -- By default parsers are installed to either the package dir, or the "site" dir.
+    -- If a custom path is used (not nil) it must be added to the runtimepath.
+    parser_install_dir = nil,
+
+    -- Install parsers synchronously (only applied to `ensure_installed`)
+    sync_install = false,
+
+    -- Automatically install missing parsers when entering buffer
+    auto_install = false,
+
     matchup = {
       enable = false, -- mandatory, false will disable the whole extension
       -- disable = { "c", "ruby" },  -- optional, list of language that will be disabled


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

### Problem

The `ensure_installed` option is misbehaving due to `is_installed()` picking up parsers shipped by
neovim v0.8 with unknown version and compatability.

### Solution

Forcefully update all bundled parsers that aren't already installed by nvim-treesitter.

fixes #3460, #3464, #3465, #3466


## How Has This Been Tested?

- should update bundled parsers automatically on a fresh install
