### PR TITLE
fix(lsp): sumneko-lua library scanning

### DIFF
--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -3,6 +3,8 @@ local default_workspace = {
     vim.fn.expand "$VIMRUNTIME",
     get_lvim_base_dir(),
     require("neodev.config").types(),
+    "${3rd}/busted/library",
+    "${3rd}/luassert/library",
   },
   checkThirdParty = false,
 

--- a/lua/lvim/lsp/providers/sumneko_lua.lua
+++ b/lua/lvim/lsp/providers/sumneko_lua.lua
@@ -6,7 +6,6 @@ local default_workspace = {
     "${3rd}/busted/library",
     "${3rd}/luassert/library",
   },
-  checkThirdParty = false,
 
   maxPreload = 5000,
   preloadFileSize = 10000,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Enables `busted` and `luassert` libraries by default to prevent popup every time
- Enables [`checkThirdParty`](https://github.com/sumneko/lua-language-server/wiki/Settings#workspacecheckthirdparty)

<!--- Please list any dependencies that are required for this change. --->

fixes #3439

## How Has This Been Tested?

- Tested in VS Code, confirmed no issues and very minimal startup time increase (`~22ms`)

Currently unable to test in LunarVim, but it would be my first time using it anyway, so bad behaviour would be hard to catch.

