### PR TITLE
fix: discard invalid choice when closing buffers

### DIFF
--- a/lua/lvim/core/bufferline.lua
+++ b/lua/lvim/core/bufferline.lua
@@ -194,7 +194,7 @@ function M.buf_kill(kill_command, bufnr, force)
       vim.ui.input({
         prompt = string.format([[%s. Close it anyway? [y]es or [n]o (default: no): ]], warning),
       }, function(choice)
-        if choice:match "ye?s?" then force = true end
+        if choice ~= nil and choice:match "ye?s?" then force = true end
       end)
       if not force then return end
     end


### PR DESCRIPTION
# Description

Fixed spitting strack trace when unsaved buffers are attempted to close. 
<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command:  Try closing buffers to the left with unsaved changed and press Escape. It spits the following traceback
- Error executing Lua callback: .../.local/share/lunarvim/lvim/lua/lvim/core/bufferline.lua:197: attempt to index local 'choice' (a nil value)
stack traceback:
        .../.local/share/lunarvim/lvim/lua/lvim/core/bufferline.lua:197: in function 'on_confirm'
        ...al/Cellar/neovim/0.8.0/share/nvim/runtime/lua/vim/ui.lua:95: in function 'input'
        .../.local/share/lunarvim/lvim/lua/lvim/core/bufferline.lua:194: in function 'buf_kill'
        .../.local/share/lunarvim/lvim/lua/lvim/core/bufferline.lua:62: in function 'command'
        ...k/packer/opt/bufferline.nvim/lua/bufferline/commands.lua:61: in function 'handle_user_command'
        ...k/packer/opt/bufferline.nvim/lua/bufferline/commands.lua:81: in function 'handle_close'
        ...k/packer/opt/bufferline.nvim/lua/bufferline/commands.lua:89: in function 'delete_element'
        ...k/packer/opt/bufferline.nvim/lua/bufferline/commands.lua:215: in function 'close_in_direction'
        .../site/pack/packer/opt/bufferline.nvim/lua/bufferline.lua:232: in function <.../site/pack/packer/opt/bufferline.nvim/lua/bufferline.lua:232>


