### PR TITLE
doc(readme): deprecation warning on `rolling` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# :warning: This branch is no longer maintained :warning:
+
+This `rolling` branch has been deprecated.
+Rolling/nightly releases are now based on the `master` branch.
+All new work should forked from the latest changes on `master`, and PRs should be targeted at `master`.
+
 ![lunarvim_logo_dark](https://user-images.githubusercontent.com/59826753/159940098-54284f26-f1da-4481-8b03-1deb34c57533.png)
 
 <div align="center"><p>


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adds a warning to the README on the `rolling` branch that that branch is deprecated.

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

It's just a quick change to the markdown.
