### PR TITLE
fix(nvimtree): avoid hard-coded mapping

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -152,7 +152,6 @@ function M.setup()
     return
   end
 
-  lvim.builtin.which_key.mappings["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" }
   lvim.builtin.nvimtree._setup_called = true
 
   -- Implicitly update nvim-tree when project module is active

--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -86,6 +86,7 @@ M.config = function()
       ["c"] = { "<cmd>BufferKill<CR>", "Close Buffer" },
       ["f"] = { require("lvim.core.telescope.custom-finders").find_project_files, "Find File" },
       ["h"] = { "<cmd>nohlsearch<CR>", "No Highlight" },
+      ["e"] = { "<cmd>NvimTreeToggle<CR>", "Explorer" },
       b = {
         name = "Buffers",
         j = { "<cmd>BufferLinePick<cr>", "Jump" },


### PR DESCRIPTION
Remove hardcode mapping on `lua/lvim/core/nvimtree.lua`. It allows uses to define there bind their bind in their own config file without being overwritten by nvimtree setup file.

PR closes #3491
