### PR TITLE
fix(uninstaller): add separate flag to remove user config

### DIFF
--- a/utils/installer/uninstall.sh
+++ b/utils/installer/uninstall.sh
@@ -2,6 +2,7 @@
 set -eo pipefail
 
 ARGS_REMOVE_BACKUPS=0
+ARGS_REMOVE_CONFIG=0
 
 declare -r XDG_DATA_HOME="${XDG_DATA_HOME:-"$HOME/.local/share"}"
 declare -r XDG_CACHE_HOME="${XDG_CACHE_HOME:-"$HOME/.cache"}"
@@ -12,16 +13,18 @@ declare -r LUNARVIM_CONFIG_DIR="${LUNARVIM_CONFIG_DIR:-"$XDG_CONFIG_HOME/lvim"}"
 declare -r LUNARVIM_CACHE_DIR="${LUNARVIM_CACHE_DIR:-"$XDG_CACHE_HOME/lvim"}"
 
 declare -a __lvim_dirs=(
-  "$LUNARVIM_CONFIG_DIR"
   "$LUNARVIM_RUNTIME_DIR"
   "$LUNARVIM_CACHE_DIR"
 )
+
+__lvim_config_dir="$LUNARVIM_CONFIG_DIR"
 
 function usage() {
   echo "Usage: uninstall.sh [<options>]"
   echo ""
   echo "Options:"
   echo "    -h, --help                       Print this help message"
+  echo "    --remove-config                  Remove old backup folders as well"
   echo "    --remove-backups                 Remove old backup folders as well"
 }
 
@@ -30,6 +33,9 @@ function parse_arguments() {
     case "$1" in
       --remove-backups)
         ARGS_REMOVE_BACKUPS=1
+        ;;
+      --remove-config)
+        ARGS_REMOVE_CONFIG=1
         ;;
       -h | --help)
         usage
@@ -41,6 +47,9 @@ function parse_arguments() {
 }
 
 function remove_lvim_dirs() {
+  if [ "$ARGS_REMOVE_CONFIG" -eq 1 ]; then
+    __lvim_dirs+=($__lvim_config_dir)
+  fi
   for dir in "${__lvim_dirs[@]}"; do
     rm -rf "$dir"
     if [ "$ARGS_REMOVE_BACKUPS" -eq 1 ]; then


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feature: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - doc: on documentation updates

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

By default when we uninstall lunarvim, the uninstaller script removes user configuration,which normally located in .config/lvim/  and unlike installer script, it will not make a *.old file

This is means those configuration made by the user is completely gone, and is not reversible, if  anytime user wants to install lvim back. ( :*(  just now i lost it, glad i had a backup of system, but it was old).

This is unexpected because most package managers don't remove user configurations

So i made default behaviour to not to remove user config files, and  but added it as a  additional option for those who wanted it. @Lost Neophyte from discord proposed this idea to make it additional flag rather than (y/n) question


<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `bash uninstall.sh` for not removing .config/lvim directory
- Run command `bash uninstall.sh --remove-config` to remove .config/lvim directory

