### PR TITLE
feat(null-ls): warn if the formatter fails

### DIFF
--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -93,8 +93,11 @@ function M.register_sources(configs, method)
           local success = code <= 1
 
           if not success then
-            Log:warn "Formatting failed!"
-            Log:debug(stderr)
+            vim.defer_fn(function()
+              vim.api.nvim_out_write(stderr)
+              vim.cmd "redraw"
+              Log:warn "Formatting failed!"
+            end, 100)
           end
 
           return success

--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -90,7 +90,7 @@ function M.register_sources(configs, method)
       local check_exit_code
       if method == null_ls.methods.FORMATTING then
         check_exit_code = function(code, stderr)
-          local success = code <= 1
+          local success = code == 0
 
           if not success then
             Log:warn "Formatting failed!"

--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -90,7 +90,7 @@ function M.register_sources(configs, method)
       local check_exit_code
       if method == null_ls.methods.FORMATTING then
         check_exit_code = function(code, stderr)
-          local success = code == 0
+          local success = code <= 1
 
           if not success then
             Log:warn "Formatting failed!"

--- a/lua/lvim/lsp/null-ls/services.lua
+++ b/lua/lvim/lsp/null-ls/services.lua
@@ -87,7 +87,21 @@ function M.register_sources(configs, method)
         compat_opts.args = nil
       end
 
-      local opts = vim.tbl_deep_extend("keep", { command = command }, compat_opts)
+      local check_exit_code
+      if method == null_ls.methods.FORMATTING then
+        check_exit_code = function(code, stderr)
+          local success = code <= 1
+
+          if not success then
+            Log:warn "Formatting failed!"
+            Log:debug(stderr)
+          end
+
+          return success
+        end
+      end
+
+      local opts = vim.tbl_deep_extend("keep", { command = command, check_exit_code = check_exit_code }, compat_opts)
       Log:debug("Registering source " .. name)
       Log:trace(vim.inspect(opts))
       table.insert(sources, source.with(opts))


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

prints a warning when a formatter fails

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
run a formatter on a file with a syntax error (e.g. prettier on a html with a tag that is not closed)
