### PR TITLE
feat(installer): describe language installation dependencies

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -46,6 +46,11 @@ declare -a __pip_deps=(
   "pynvim"
 )
 
+declare -a __rust_deps=(
+	"fd::fd-find"
+	"rg::ripgrep"
+)
+
 function usage() {
   echo "Usage: install.sh [<options>]"
   echo ""
@@ -110,6 +115,10 @@ function confirm() {
   done
 }
 
+function stringify_array() {
+  echo -n "${@}" | sed 's/ /, /'
+}
+
 function main() {
   parse_arguments "$@"
 
@@ -122,14 +131,14 @@ function main() {
 
   if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
     if [ "$INTERACTIVE_MODE" -eq 1 ]; then
-      if confirm "Would you like to install LunarVim's NodeJS dependencies?"; then
-        install_nodejs_deps
+			if confirm "Would you like to install LunarVim's NodeJS dependencies: $(stringify_array ${__npm_deps[@]})?"; then
+				install_nodejs_deps
       fi
-      if confirm "Would you like to install LunarVim's Python dependencies?"; then
-        install_python_deps
+      if confirm "Would you like to install LunarVim's Python dependencies: $(stringify_array ${__pip_deps[@]})?"; then
+				install_python_deps
       fi
-      if confirm "Would you like to install LunarVim's Rust dependencies?"; then
-        install_rust_deps
+      if confirm "Would you like to install LunarVim's Rust dependencies: $(stringify_array ${__rust_deps[@]})?"; then
+				install_rust_deps
       fi
     else
       install_nodejs_deps

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -47,8 +47,8 @@ declare -a __pip_deps=(
 )
 
 declare -a __rust_deps=(
-	"fd::fd-find"
-	"rg::ripgrep"
+  "fd::fd-find"
+  "rg::ripgrep"
 )
 
 function usage() {
@@ -131,7 +131,7 @@ function main() {
 
   if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
     if [ "$INTERACTIVE_MODE" -eq 1 ]; then
-			if confirm "Would you like to install LunarVim's NodeJS dependencies: $(stringify_array ${__npm_deps[@]})?"; then
+      if confirm "Would you like to install LunarVim's NodeJS dependencies: $(stringify_array ${__npm_deps[@]})?"; then
 				install_nodejs_deps
       fi
       if confirm "Would you like to install LunarVim's Python dependencies: $(stringify_array ${__pip_deps[@]})?"; then

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -132,13 +132,13 @@ function main() {
   if [ "$ARGS_INSTALL_DEPENDENCIES" -eq 1 ]; then
     if [ "$INTERACTIVE_MODE" -eq 1 ]; then
       if confirm "Would you like to install LunarVim's NodeJS dependencies: $(stringify_array ${__npm_deps[@]})?"; then
-				install_nodejs_deps
+        install_nodejs_deps
       fi
       if confirm "Would you like to install LunarVim's Python dependencies: $(stringify_array ${__pip_deps[@]})?"; then
-				install_python_deps
+        install_python_deps
       fi
       if confirm "Would you like to install LunarVim's Rust dependencies: $(stringify_array ${__rust_deps[@]})?"; then
-				install_rust_deps
+        install_rust_deps
       fi
     else
       install_nodejs_deps

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -344,8 +344,7 @@ function __attempt_to_install_with_cargo() {
 
 # we try to install the missing one with cargo even though it's unlikely to be found
 function install_rust_deps() {
-  local -a deps=("fd::fd-find" "rg::ripgrep")
-  for dep in "${deps[@]}"; do
+  for dep in "${__rust_deps[@]}"; do
     if ! command -v "${dep%%::*}" &>/dev/null; then
       __attempt_to_install_with_cargo "${dep##*::}"
     fi


### PR DESCRIPTION
# Description

During install it's unclear what the installer is asking to install - this change outputs the dependencies as part of the questions to aid the user in decision making.

```
Detecting platform for managing any additional neovim dependencies
--------------------------------------------------------------------------------
Would you like to install LunarVim's NodeJS dependencies: neovim, tree-sitter-cli?
[y]es or [n]o (default: no) : no
--------------------------------------------------------------------------------
Would you like to install LunarVim's Python dependencies: pynvim?
[y]es or [n]o (default: no) : no
--------------------------------------------------------------------------------
Would you like to install LunarVim's Rust dependencies: fd::fd-find, rg::ripgrep?
[y]es or [n]o (default: no) : no
```

# Testing

Tested by running the install script `bash -x install.sh` and inputting yes/no.

