### PR TITLE
fix(terminal): use user's shell in execs

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -36,14 +36,14 @@ M.config = function()
       },
     },
     -- Add executables on the config.lua
-    -- { exec, keymap, name}
-    -- lvim.builtin.terminal.execs = {{}} to overwrite
+    -- { cmd, keymap, description, direction, size(fraction/integer)}
+    -- lvim.builtin.terminal.execs = {...} to overwrite
     -- lvim.builtin.terminal.execs[#lvim.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
     -- TODO: pls add mappings in which key and refactor this
     execs = {
-      { vim.o.shell, "<M-1>", "Horizontal Terminal", "horizontal", 0.3 },
-      { vim.o.shell, "<M-2>", "Vertical Terminal", "vertical", 0.4 },
-      { vim.o.shell, "<M-3>", "Float Terminal", "float", nil },
+      { nil, "<M-1>", "Horizontal Terminal", "horizontal", 0.3 },
+      { nil, "<M-2>", "Vertical Terminal", "vertical", 0.4 },
+      { nil, "<M-3>", "Float Terminal", "float", nil },
     },
   }
 end
@@ -63,7 +63,7 @@ end
 
 --- Get the dynamic terminal size in cells
 ---@param direction number
----@param size integer
+---@param size number
 ---@return integer
 local function get_dynamic_terminal_size(direction, size)
   size = size or lvim.builtin.terminal.size
@@ -85,7 +85,7 @@ M.setup = function()
     local direction = exec[4] or lvim.builtin.terminal.direction
 
     local opts = {
-      cmd = exec[1],
+      cmd = exec[1] or lvim.builtin.terminal.shell,
       keymap = exec[2],
       label = exec[3],
       -- NOTE: unable to consistently bind id/count <= 9, see #2146

--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -36,7 +36,7 @@ M.config = function()
       },
     },
     -- Add executables on the config.lua
-    -- { cmd, keymap, description, direction, size(fraction/integer)}
+    -- { cmd, keymap, description, direction, size }
     -- lvim.builtin.terminal.execs = {...} to overwrite
     -- lvim.builtin.terminal.execs[#lvim.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
     -- TODO: pls add mappings in which key and refactor this


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

user's config is sourced after terminal's config, which caused setting vim.opt.shell to not have any effect in the execs

<!--- Please list any dependencies that are required for this change. --->

fixes #3526 

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
1. changed lvim.builtin.terminal.shell
2. `<M-1>`
