### PR TITLE
feat(alpha): allow configuring highlight groups

### DIFF
--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -4,8 +4,8 @@ function M.config()
   local lvim_dashboard = require "lvim.core.alpha.dashboard"
   local lvim_startify = require "lvim.core.alpha.startify"
   lvim.builtin.alpha = {
-    dashboard = { config = {}, section = lvim_dashboard.get_sections() },
-    startify = { config = {}, section = lvim_startify.get_sections() },
+    dashboard = { config = {}, section = lvim_dashboard.get_sections(), opts = {} },
+    startify = { config = {}, section = lvim_startify.get_sections(), opts = {} },
     active = true,
     mode = "dashboard",
   }
@@ -45,6 +45,9 @@ local function resolve_config(theme_name)
       end
     end
   end
+
+  local opts = lvim.builtin.alpha[theme_name].opts or {}
+  selected_theme.config.opts = vim.tbl_extend("force", selected_theme.config.opts, opts)
 
   return selected_theme.config
 end

--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -7,13 +7,11 @@ function M.config()
     dashboard = {
       config = {},
       section = lvim_dashboard.get_sections(),
-      default_button_opts = { hl_shortcut = "Include" },
       opts = { autostart = true },
     },
     startify = {
       config = {},
       section = lvim_startify.get_sections(),
-      default_button_opts = {},
       opts = { autostart = true },
     },
     active = true,
@@ -35,7 +33,7 @@ local function resolve_buttons(theme_name, entries)
     button_element.on_press = on_press
 
     button_element.opts =
-      vim.tbl_extend("force", button_element.opts, entry[4] or lvim.builtin.alpha[theme_name].default_button_opts)
+      vim.tbl_extend("force", button_element.opts, entry[4] or lvim.builtin.alpha[theme_name].section.buttons.opts)
 
     table.insert(val, button_element)
   end

--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -4,8 +4,8 @@ function M.config()
   local lvim_dashboard = require "lvim.core.alpha.dashboard"
   local lvim_startify = require "lvim.core.alpha.startify"
   lvim.builtin.alpha = {
-    dashboard = { config = {}, section = lvim_dashboard.get_sections(), opts = {} },
-    startify = { config = {}, section = lvim_startify.get_sections(), opts = {} },
+    dashboard = { config = {}, section = lvim_dashboard.get_sections(), opts = { autostart = true } },
+    startify = { config = {}, section = lvim_startify.get_sections(), opts = { autostart = true } },
     active = true,
     mode = "dashboard",
   }

--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -11,7 +11,7 @@ function M.config()
   }
 end
 
-local function resolve_buttons(theme_name, entries)
+local function resolve_buttons(theme_name, entries, opts)
   local selected_theme = require("alpha.themes." .. theme_name)
   local val = {}
   for _, entry in pairs(entries) do
@@ -23,6 +23,9 @@ local function resolve_buttons(theme_name, entries)
     local button_element = selected_theme.button(entry[1], entry[2], entry[3])
     -- this became necessary after recent changes in alpha.nvim (06ade3a20ca9e79a7038b98d05a23d7b6c016174)
     button_element.on_press = on_press
+    if opts then
+      button_element.opts = vim.tbl_extend("force", button_element.opts, opts)
+    end
     table.insert(val, button_element)
   end
   return val
@@ -36,7 +39,7 @@ local function resolve_config(theme_name)
   for name, el in pairs(section) do
     for k, v in pairs(el) do
       if name:match "buttons" and k == "entries" then
-        resolved_section[name].val = resolve_buttons(theme_name, v)
+        resolved_section[name].val = resolve_buttons(theme_name, v, el.opts)
       elseif v then
         resolved_section[name][k] = v
       end

--- a/lua/lvim/core/alpha/dashboard.lua
+++ b/lua/lvim/core/alpha/dashboard.lua
@@ -102,31 +102,25 @@ function M.get_sections()
       hl = "Number",
     },
   }
-  local buttons = {}
 
-  local status_ok, dashboard = pcall(require, "alpha.themes.dashboard")
-  if status_ok then
-    local function button(sc, txt, keybind, keybind_opts)
-      local b = dashboard.button(sc, txt, keybind, keybind_opts)
-      b.opts.hl_shortcut = "Include"
-      return b
-    end
-    buttons = {
-      val = {
-        button("f", lvim.icons.ui.FindFile .. "  Find File", "<CMD>Telescope find_files<CR>"),
-        button("n", lvim.icons.ui.NewFile .. "  New File", "<CMD>ene!<CR>"),
-        button("p", lvim.icons.ui.Project .. "  Projects ", "<CMD>Telescope projects<CR>"),
-        button("r", lvim.icons.ui.History .. "  Recent files", ":Telescope oldfiles <CR>"),
-        button("t", lvim.icons.ui.FindText .. "  Find Text", "<CMD>Telescope live_grep<CR>"),
-        button(
-          "c",
-          lvim.icons.ui.Gear .. "  Configuration",
-          "<CMD>edit " .. require("lvim.config"):get_user_config_path() .. " <CR>"
-        ),
+  local buttons = {
+    opts = {
+      hl_shortcut = "Include",
+      spacing = 1,
+    },
+    entries = {
+      { "f", lvim.icons.ui.FindFile .. "  Find File", "<CMD>Telescope find_files<CR>" },
+      { "n", lvim.icons.ui.NewFile .. "  New File", "<CMD>ene!<CR>" },
+      { "p", lvim.icons.ui.Project .. "  Projects ", "<CMD>Telescope projects<CR>" },
+      { "r", lvim.icons.ui.History .. "  Recent files", ":Telescope oldfiles <CR>" },
+      { "t", lvim.icons.ui.FindText .. "  Find Text", "<CMD>Telescope live_grep<CR>" },
+      {
+        "c",
+        lvim.icons.ui.Gear .. "  Configuration",
+        "<CMD>edit " .. require("lvim.config"):get_user_config_path() .. " <CR>",
       },
-    }
-  end
-
+    },
+  }
   return {
     header = header,
     buttons = buttons,


### PR DESCRIPTION


<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- makes the hl groups overridable
- makes opts overridable

- fixes #3400 

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
empty config:
![image](https://user-images.githubusercontent.com/110467150/204092465-e354fc61-09fe-4e97-9d44-d557d639f36e.png)

```lua
lvim.builtin.alpha.dashboard.section.buttons.opts.hl = "Error"
lvim.builtin.alpha.dashboard.section.buttons.opts.hl_shortcut = "Error"
lvim.builtin.alpha.dashboard.section.footer.opts.hl = "Error"
lvim.builtin.alpha.dashboard.section.header.opts.hl = "Error"
```
![image](https://user-images.githubusercontent.com/110467150/204092441-3dcb8ca0-cfd1-4093-a908-757e12fdc4c0.png)

setting `lvim.builtin.alpha.dashboard.opts = {autostart = false}` also works