### PR TITLE
fix: add cmdline source

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -341,6 +341,7 @@ M.config = function()
           type = ":",
           sources = {
             { name = "path" },
+            { name = "cmdline" }
           },
         },
         {


### PR DESCRIPTION


<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The `cmdline` table does not include the `cmdline` source for auto-completed suggestions when in command line mode. With this change, the `cmdline` source is included.

## How Has This Been Tested?

1. Add  `lvim.builtin.cmp.cmdline.enable = true` to config
2. Observe auto completions *NOT* working
3. Add `{ name = "cmdline" }` to config within `lua/lvim/core/cmp.lua`
4. Exit and enter lvim
5. Observe auto completions now working.

