### PR TITLE
fix(breadcrumbs): add CursorMoved makes winbar seems 10 times faster

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -207,7 +207,7 @@ M.create_winbar = function()
   vim.api.nvim_create_augroup("_winbar", {})
   if vim.fn.has "nvim-0.8" == 1 then
     vim.api.nvim_create_autocmd(
-      { "CursorHoldI", "CursorHold", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost", "TabClosed" },
+      { "CursorHoldI", "CursorHold", "CursorMoved", "CursorMovedI", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost", "TabClosed", },
       {
         group = "_winbar",
         callback = function()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Related: https://github.com/glepnir/lspsaga.nvim/issues/334

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
Enabled `lvim.builtin.breadcrumbs.active = true` in `config.lua`

