### PR TITLE
fix(dashboard): remove feedkeys

### DIFF
--- a/lua/lvim/core/alpha/dashboard.lua
+++ b/lua/lvim/core/alpha/dashboard.lua
@@ -87,7 +87,6 @@ function M.get_sections()
   local header = {
     type = "text",
     val = function()
-      vim.api.nvim_feedkeys("zb", "n", false)
       if vim.api.nvim_win_get_height(0) < 36 then
         return M.banner_small
       end


### PR DESCRIPTION
alpha is refreshing when opening the terminal and feedkeys put `zbzbzb` inside of it
I added `feedkeys` when making the dashboard responsive, bit it seems like a bad idea now 

after this fix the first lines of the logo will get sometimes cut off (the content is scrolled down for some reason) after resizing the application window