### PR TITLE
ci: better issue templates description

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -1,5 +1,5 @@
 name: General Issue
-description: File a bug report not related to LSP (intellisense, comletion, diagnostics, etc)
+description: File a bug report not related to LSP (intellisense, completion, diagnostics, etc)
 labels: [bug]
 
 body:

--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -1,5 +1,5 @@
 name: General Issue
-description: File a bug report not related to LSP (language support, diagnostics)
+description: File a bug report not related to LSP (intellisense, comletion, diagnostics, etc)
 labels: [bug]
 
 body:

--- a/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
@@ -1,5 +1,5 @@
 name: LSP Issue
-description: File a LSP (language support, diagnostics) related bug report
+description: File a bug report related to LSP (intellisense, comletion, diagnostics, etc) 
 labels: [bug, LSP]
 
 body:

--- a/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
@@ -1,5 +1,5 @@
 name: LSP Issue
-description: File a bug report related to LSP (intellisense, comletion, diagnostics, etc) 
+description: File a bug report related to LSP (intellisense, completion, diagnostics, etc) 
 labels: [bug, LSP]
 
 body:


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Better examples of what LSP means 

from https://github.com/LunarVim/LunarVim/issues/3570#issuecomment-1336842777 (LSP issue created using the general template)

> About the issue template, I don't think it could be any clearer, it just that for a person who is not too familiar with the business like me, Tailwindcss intellisense didn't seem to have anything to do with LSP, because Tailwindcss itself is not a language, so yeah, everyday you learn a new thing, thanks in advanced for the quick support. Besides, adding a few examples to the issue template's description may help if the misunderstanding happens too often
