### PR TITLE
fix: only call theme's setup if it's selected

### DIFF
--- a/lua/lvim/core/theme.lua
+++ b/lua/lvim/core/theme.lua
@@ -64,13 +64,16 @@ M.setup = function()
   end
 
   local selected_theme = lvim.builtin.theme.name
-  local status_ok, plugin = pcall(require, selected_theme)
-  if not status_ok then
-    return
+
+  if vim.startswith(lvim.colorscheme, selected_theme) then
+    local status_ok, plugin = pcall(require, selected_theme)
+    if not status_ok then
+      return
+    end
+    pcall(function()
+      plugin.setup(lvim.builtin.theme[selected_theme].options)
+    end)
   end
-  pcall(function()
-    plugin.setup(lvim.builtin.theme[selected_theme].options)
-  end)
 
   -- ref: https://github.com/neovim/neovim/issues/18201#issuecomment-1104754564
   local colors = vim.api.nvim_get_runtime_file(("colors/%s.*"):format(lvim.colorscheme), false)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

only call theme.setup if the theme is selected, fixes issues with vimscript colorschemes