### PR TITLE
feat(cmp): add on_config_done callback

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -129,6 +129,7 @@ M.config = function()
 
   lvim.builtin.cmp = {
     active = true,
+    on_config_done = nil,
     enabled = function()
       local buftype = vim.api.nvim_buf_get_option(0, "buftype")
       if buftype == "prompt" then
@@ -366,6 +367,9 @@ function M.setup()
         sources = option.sources,
       })
     end
+  end
+  if lvim.builtin.cmp.on_config_done then
+    lvim.builtin.cmp.on_config_done(cmp)
   end
 end
 

--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -368,6 +368,7 @@ function M.setup()
       })
     end
   end
+  
   if lvim.builtin.cmp.on_config_done then
     lvim.builtin.cmp.on_config_done(cmp)
   end


### PR DESCRIPTION
# Description

User can use a `on_config_done` property in nvim-cmp config. It allow user to hook on the plugin and make additionnal configuration after the plugin is setup.

## How has this been tested

1. See that completion shows up when writing a commit for exemple
2. Add 
```lua
lvim.builtin.cmp.on_config_done = function(cmp)
  cmp.setup.filetype("gitcommit", {
    enabled = false,
  })
end
```
In the nvim config file
4. Reload LunarVim
5. Commit something in a repo and see that completion doesn't open

Signed-off-by: Mathieu Cartaud <dev@mcartaud.com>