### PR TITLE
ci: restrict scheduled workflows to lunarvim

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   plugins-version-bump:
+    if: github.repository_owner == 'LunarVim'
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Currently, the `plugins version bump` github workflow is running and failing on forks and sending emails to the fork owner every 15 mins.
Added a check to only run the CI for the repo owned by lunarvim

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?
Ran the workflow on my fork and it was skipped.

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:mycommand`
- Check logs
- ...

