### PR TITLE
fix(lsp): add neocmake to skipped_servers

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -15,6 +15,7 @@ local skipped_servers = {
   "graphql",
   "jedi_language_server",
   "ltex",
+  "neocmake",
   "ocamlls",
   "phpactor",
   "psalm",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
[neocmake was recently added to mason](https://github.com/williamboman/mason-lspconfig.nvim/commit/e8bd50153b94cc5bbfe3f59fc10ec7c4902dd526) and now we have two servers in cmake.lua template and ci tests are failing on all new PRs