### PR TITLE
feat(dap): update dap ui to resize when toggled

### DIFF
--- a/lua/lvim/core/which-key.lua
+++ b/lua/lvim/core/which-key.lua
@@ -133,7 +133,7 @@ M.config = function()
         r = { "<cmd>lua require'dap'.repl.toggle()<cr>", "Toggle Repl" },
         s = { "<cmd>lua require'dap'.continue()<cr>", "Start" },
         q = { "<cmd>lua require'dap'.close()<cr>", "Quit" },
-        U = { "<cmd>lua require'dapui'.toggle()<cr>", "Toggle UI" },
+        U = { "<cmd>lua require'dapui'.toggle({reset = true})<cr>", "Toggle UI" },
       },
       p = {
         name = "Packer",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When toggling the dap UI via `<leader>dU` the dap UI never re-adjusts based on window size.  I tend to resize my window, especially when doing things like debugging.  

I've [seen in other dotfile examples](https://github.com/rcarriga/dotfiles/blob/master/.config/nvim/lua/config/dap.lua#L38), people pass in `{reset = true}` to the dap toggle.  I want to propose it as a reasonable default behavior.  

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->

Re-opened the dapui after resizing the window several times to ensure it was picking up the new behavior. 
