### PR TITLE
fix(icons): make devicons optional

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -99,33 +99,40 @@ M.get_filename = function()
   local f = require "lvim.utils.functions"
 
   if not f.isempty(filename) then
-    local file_icon, hl_group = require("nvim-web-devicons").get_icon(filename, extension, { default = true })
+    local file_icon, hl_group
+    local devicons_ok, devicons = pcall(require, "nvim-web-devicons")
+    if lvim.use_icons and devicons_ok then
+      file_icon, hl_group = devicons.get_icon(filename, extension, { default = true })
 
-    if f.isempty(file_icon) then
-      file_icon = lvim.icons.kind.File
+      if f.isempty(file_icon) then
+        file_icon = lvim.icons.kind.File
+      end
+
+      local buf_ft = vim.bo.filetype
+
+      if buf_ft == "dapui_breakpoints" then
+        file_icon = lvim.icons.ui.Bug
+      end
+
+      if buf_ft == "dapui_stacks" then
+        file_icon = lvim.icons.ui.Stacks
+      end
+
+      if buf_ft == "dapui_scopes" then
+        file_icon = lvim.icons.ui.Scopes
+      end
+
+      if buf_ft == "dapui_watches" then
+        file_icon = lvim.icons.ui.Watches
+      end
+
+      -- if buf_ft == "dapui_console" then
+      --   file_icon = lvim.icons.ui.DebugConsole
+      -- end
+    else
+      file_icon = ""
+      hl_group = "Normal"
     end
-
-    local buf_ft = vim.bo.filetype
-
-    if buf_ft == "dapui_breakpoints" then
-      file_icon = lvim.icons.ui.Bug
-    end
-
-    if buf_ft == "dapui_stacks" then
-      file_icon = lvim.icons.ui.Stacks
-    end
-
-    if buf_ft == "dapui_scopes" then
-      file_icon = lvim.icons.ui.Scopes
-    end
-
-    if buf_ft == "dapui_watches" then
-      file_icon = lvim.icons.ui.Watches
-    end
-
-    -- if buf_ft == "dapui_console" then
-    --   file_icon = lvim.icons.ui.DebugConsole
-    -- end
 
     local navic_text = vim.api.nvim_get_hl_by_name("Normal", true)
     vim.api.nvim_set_hl(0, "Winbar", { fg = navic_text.foreground })

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -107,32 +107,32 @@ M.get_filename = function()
       if f.isempty(file_icon) then
         file_icon = lvim.icons.kind.File
       end
-
-      local buf_ft = vim.bo.filetype
-
-      if buf_ft == "dapui_breakpoints" then
-        file_icon = lvim.icons.ui.Bug
-      end
-
-      if buf_ft == "dapui_stacks" then
-        file_icon = lvim.icons.ui.Stacks
-      end
-
-      if buf_ft == "dapui_scopes" then
-        file_icon = lvim.icons.ui.Scopes
-      end
-
-      if buf_ft == "dapui_watches" then
-        file_icon = lvim.icons.ui.Watches
-      end
-
-      -- if buf_ft == "dapui_console" then
-      --   file_icon = lvim.icons.ui.DebugConsole
-      -- end
     else
       file_icon = ""
       hl_group = "Normal"
     end
+
+    local buf_ft = vim.bo.filetype
+
+    if buf_ft == "dapui_breakpoints" then
+      file_icon = lvim.icons.ui.Bug
+    end
+
+    if buf_ft == "dapui_stacks" then
+      file_icon = lvim.icons.ui.Stacks
+    end
+
+    if buf_ft == "dapui_scopes" then
+      file_icon = lvim.icons.ui.Scopes
+    end
+
+    if buf_ft == "dapui_watches" then
+      file_icon = lvim.icons.ui.Watches
+    end
+
+    -- if buf_ft == "dapui_console" then
+    --   file_icon = lvim.icons.ui.DebugConsole
+    -- end
 
     local navic_text = vim.api.nvim_get_hl_by_name("Normal", true)
     vim.api.nvim_set_hl(0, "Winbar", { fg = navic_text.foreground })

--- a/lua/lvim/core/lir.lua
+++ b/lua/lvim/core/lir.lua
@@ -83,6 +83,10 @@ M.config = function()
 end
 
 function M.icon_setup()
+  if not lvim.builtin.lir.devicons_enable then
+    return
+  end
+
   local function get_hl_by_name(name)
     local ret = vim.api.nvim_get_hl_by_name(name.group, true)
     return string.format("#%06x", ret[name.property])
@@ -93,13 +97,16 @@ function M.icon_setup()
     icon_hl = "#42A5F5"
   end
 
-  require("nvim-web-devicons").set_icon {
-    lir_folder_icon = {
-      icon = lvim.builtin.lir.icon,
-      color = icon_hl,
-      name = "LirFolderNode",
-    },
-  }
+  local devicons_ok, devicons = pcall(require, "nvim-web-devicons")
+  if devicons_ok then
+    devicons.set_icon {
+      lir_folder_icon = {
+        icon = lvim.builtin.lir.icon,
+        color = icon_hl,
+        name = "LirFolderNode",
+      },
+    }
+  end
 end
 
 function M.setup()
@@ -107,6 +114,11 @@ function M.setup()
   if not status_ok then
     return
   end
+
+  if not lvim.use_icons then
+    lvim.builtin.lir.devicons_enable = false
+  end
+
   lir.setup(lvim.builtin.lir)
 
   if lvim.builtin.lir.on_config_done then

--- a/lua/lvim/core/lir.lua
+++ b/lua/lvim/core/lir.lua
@@ -83,7 +83,7 @@ M.config = function()
 end
 
 function M.icon_setup()
-  if not lvim.builtin.lir.devicons_enable then
+  if not lvim.builtin.lir.devicons.enable then
     return
   end
 
@@ -116,7 +116,7 @@ function M.setup()
   end
 
   if not lvim.use_icons then
-    lvim.builtin.lir.devicons_enable = false
+    lvim.builtin.lir.devicons.enable = false
   end
 
   lir.setup(lvim.builtin.lir)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

we were requiring `nvim-web-devicons` in a couple places without checking if it's available or if icons are enabled

Fixes #3640

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
1. `lvim.use_icons = false`
2. `:PackerSync`
3. no more errors in lir and breadcrumbs
