### PR TITLE
fix(snapshots): correct tokyonight commit sha

### DIFF
--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -120,7 +120,7 @@
     "commit": "b02a167"
   },
   "tokyonight.nvim": {
-    "commit": "0f7b6a5"
+    "commit": "ecae454"
   },
   "vim-illuminate": {
     "commit": "a6d0b28"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

current commit sha of tokyonight is invalid, it causes ci to fail (also packer on first installs) 

https://github.com/folke/tokyonight.nvim/commit/0f7b6a5 says `This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository`
