### PR TITLE
feat: don't prompt smart quit when buffer open in another window

### DIFF
--- a/lua/lvim/utils/functions.lua
+++ b/lua/lvim/utils/functions.lua
@@ -2,8 +2,9 @@ local M = {}
 
 function M.smart_quit()
   local bufnr = vim.api.nvim_get_current_buf()
+  local buf_windows = vim.call("win_findbuf", bufnr)
   local modified = vim.api.nvim_buf_get_option(bufnr, "modified")
-  if modified then
+  if modified and #buf_windows == 1 then
     vim.ui.input({
       prompt = "You have unsaved changes. Quit anyway? (y/n) ",
     }, function(input)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

summary of the change

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:mycommand`
- Check logs
- ...

