### PR TITLE
feat(reload): add all conf files to aupat

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -182,12 +182,6 @@ end
 function M.enable_reload_config_on_save()
   local pattern = get_config_dir() .. "/*.lua"
 
-  -- add symlinked path to the pattern
-  local linked_config_lua = vim.fn.resolve(join_paths(get_config_dir(), "config.lua"))
-  if linked_config_lua ~= join_paths(get_config_dir(), "config.lua") then
-    local linked_config_dir = linked_config_lua:sub(1, #linked_config_lua - #"config.lua")
-    pattern = pattern .. "," .. linked_config_dir .. "*.lua"
-  end
 
   if vim.loop.os_uname().version:match "Windows" then
     -- autocmds require forward slashes even on windows

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -184,11 +184,6 @@ function M.enable_reload_config_on_save()
   -- autocmds require forward slashes (even on windows)
   local pattern = user_config_file:gsub("\\", "/") .. "/*.lua"
 
-
-  if vim.loop.os_uname().version:match "Windows" then
-    -- autocmds require forward slashes even on windows
-    pattern = pattern:gsub("\\", "/")
-  end
   vim.api.nvim_create_augroup("lvim_reload_config_on_save", {})
   vim.api.nvim_create_autocmd("BufWritePost", {
     group = "lvim_reload_config_on_save",

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -180,7 +180,9 @@ function M.toggle_format_on_save()
 end
 
 function M.enable_reload_config_on_save()
-  local pattern = get_config_dir() .. "/*.lua"
+  local user_config_file = require("lvim.config"):get_user_config_path()
+  -- autocmds require forward slashes (even on windows)
+  local pattern = user_config_file:gsub("\\", "/") .. "/*.lua"
 
 
   if vim.loop.os_uname().version:match "Windows" then

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -180,9 +180,8 @@ function M.toggle_format_on_save()
 end
 
 function M.enable_reload_config_on_save()
-  local user_config_file = require("lvim.config"):get_user_config_path()
   -- autocmds require forward slashes (even on windows)
-  local pattern = user_config_file:gsub("\\", "/") .. "/*.lua"
+  local pattern = get_config_dir():gsub("\\", "/") .. "/*.lua"
 
   vim.api.nvim_create_augroup("lvim_reload_config_on_save", {})
   vim.api.nvim_create_autocmd("BufWritePost", {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

adds all lua files in the config dir to the reload on save autocmd pattern
adds symlinked directories to the pattern (for things like stow)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
save a lua file in the config

