### PR TITLE
fix: bash installer errors

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -457,7 +457,7 @@ function create_desktop_file() {
     cp "$LUNARVIM_BASE_DIR/utils/desktop/$size_folder/lvim.svg" "$XDG_DATA_HOME/icons/hicolor/$size_folder/apps"
   done
 
-  xdg-desktop-menu install --novendor "$LUNARVIM_BASE_DIR/utils/desktop/lvim.desktop"
+  xdg-desktop-menu install --novendor "$LUNARVIM_BASE_DIR/utils/desktop/lvim.desktop" || true
 }
 
 function print_logo() {

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -364,10 +364,10 @@ function __backup_dir() {
   else
     case "$OS" in
       Darwin)
-        cp -R "$src/"* "$src.old/."
+        cp -R "$src/." "$src.old/."
         ;;
       *)
-        cp -r "$src/"* "$src.old/."
+        cp -r "$src/." "$src.old/."
         ;;
     esac
   fi


### PR DESCRIPTION
ignores xdg desktop error `xdg-desktop-menu: No writable system menu directory found`
fixes `cp: cannot stat '/root/.config/lvim/*': No such file or directory`

fixes  #3684

