### PR TITLE
fix(ts): disable indent for c and cpp

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -52,7 +52,7 @@ function M.config()
         json = "",
       },
     },
-    indent = { enable = true, disable = { "yaml", "python" } },
+    indent = { enable = true, disable = { "yaml", "python", "c", "cpp" } },
     autotag = { enable = false },
     textobjects = {
       swap = {


### PR DESCRIPTION
treesitter indentation for cpp is broken. to reproduce:
 
1.  ```cpp
      while()<CR>{
      ```
2.  ```cpp
      while()
          { // the brace isn't moved back as it should be (that's what happens with `:TSBufDisable indent`)
      ```

fixes #3685 