### PR TITLE
refactor(logger): adapt to new changes upstream

### DIFF
--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -10,6 +10,7 @@ Log.levels = {
 vim.tbl_add_reverse_lookup(Log.levels)
 
 local notify_opts = {}
+local log_notify_as_notification = false
 
 function Log:set_level(level)
   local logger_ok, logger = pcall(function()
@@ -17,8 +18,8 @@ function Log:set_level(level)
   end)
   local log_level = Log.levels[level:upper()]
   if logger_ok and logger and log_level then
-    for _, s in ipairs(logger.sinks) do
-      s.level = log_level
+    for _, pipeline in ipairs(logger.pipelines) do
+      pipeline.level = log_level
     end
   end
 
@@ -37,13 +38,12 @@ function Log:init()
   end
 
   local log_level = Log.levels[(lvim.log.level):upper() or "WARN"]
-  local lvim_log = {
+  structlog.configure {
     lvim = {
-      sinks = {
-        structlog.sinks.Console(log_level, {
-          async = false,
+      pipelines = {
+        {
+          level = log_level,
           processors = {
-            structlog.processors.Namer(),
             structlog.processors.StackWriter({ "line", "file" }, { max_parents = 0, stack_level = 2 }),
             structlog.processors.Timestamper "%H:%M:%S",
           },
@@ -52,10 +52,11 @@ function Log:init()
             { "timestamp", "level", "logger_name", "msg" },
             { level = structlog.formatters.FormatColorizer.color_level() }
           ),
-        }),
-        structlog.sinks.File(log_level, self:get_path(), {
+          sink = structlog.sinks.Console(false), -- async=false
+        },
+        {
+          level = log_level,
           processors = {
-            structlog.processors.Namer(),
             structlog.processors.StackWriter({ "line", "file" }, { max_parents = 3, stack_level = 2 }),
             structlog.processors.Timestamper "%F %H:%M:%S",
           },
@@ -63,13 +64,12 @@ function Log:init()
             "%s [%-5s] %s: %-30s",
             { "timestamp", "level", "logger_name", "msg" }
           ),
-        }),
+          sink = structlog.sinks.File(self:get_path()),
+        },
       },
     },
   }
 
-  lvim_log.lvim.sinks[1].async = false -- HACK: Bug in structlog prevents setting async to false
-  structlog.configure(lvim_log)
   local logger = structlog.get_logger "lvim"
 
   -- Overwrite `vim.notify` to use the logger
@@ -95,49 +95,34 @@ function Log:init()
 end
 
 --- Configure the sink in charge of logging notifications
----@param notif_handle table The implementation used by the sink for displaying the notifications
-function Log:configure_notifications(notif_handle)
+---@param nvim_notify table The nvim-notify instance
+function Log:configure_notifications(nvim_notify)
   local status_ok, structlog = pcall(require, "structlog")
   if not status_ok then
     return
   end
 
-  local default_namer = function(logger, entry)
-    entry["title"] = logger.name
-    return entry
-  end
-
-  local notify_opts_injecter = function(_, entry)
-    for key, value in pairs(notify_opts) do
-      entry[key] = value
-    end
+  local function log_writer(log)
+    local opts = { title = log.logger_name }
+    opts = vim.tbl_deep_extend("force", opts, notify_opts)
     notify_opts = {}
-    return entry
+
+    if log_notify_as_notification then
+      nvim_notify(log.msg, log.level, opts)
+    end
   end
 
-  local sink = structlog.sinks.NvimNotify(Log.levels.INFO, {
-    processors = {
-      default_namer,
-      notify_opts_injecter,
-    },
-    formatter = structlog.formatters.Format( --
+  local notif_pipeline = structlog.Pipeline(
+    structlog.level.INFO,
+    {},
+    structlog.formatters.Format( --
       "%s",
       { "msg" },
       { blacklist_all = true }
     ),
-    -- This should probably not be hard-coded
-    params_map = {
-      icon = "icon",
-      keep = "keep",
-      on_open = "on_open",
-      on_close = "on_close",
-      timeout = "timeout",
-      title = "title",
-    },
-    impl = notif_handle,
-  })
-
-  table.insert(self.__handle.sinks, sink)
+    structlog.sinks.Adapter(log_writer)
+  )
+  self.__handle:add_pipeline(notif_pipeline)
 end
 
 --- Adds a log entry using Plenary.log

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -108,7 +108,7 @@
     "commit": "eee175f"
   },
   "structlog.nvim": {
-    "commit": "232a8e2"
+    "commit": "45b26a2"
   },
   "telescope-fzf-native.nvim": {
     "commit": "fab3e22"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Refactor structlog usage for future 0.2 release

- Add a flag for disabling vim.notify logging as notification (to discuss)

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

- Run lvim
- Log something
- Check that it is logged into all sinks

## Related work

https://github.com/Tastyep/structlog.nvim/pull/6