### PR TITLE
fix(breadcrumbs): updating extension to empty string if it contains c…

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -95,12 +95,12 @@ end
 
 M.get_filename = function()
   local filename = vim.fn.expand "%:t"
-    
+
   local extension = vim.fn.expand "%:e"
   if string.find(extension, ":") then
-    extension = ""    
+    extension = ""
   end
-    
+
   local f = require "lvim.utils.functions"
 
   if not f.isempty(filename) then

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -95,7 +95,12 @@ end
 
 M.get_filename = function()
   local filename = vim.fn.expand "%:t"
+    
   local extension = vim.fn.expand "%:e"
+  if string.find(extension, ":") then
+    extension = ""    
+  end
+    
   local f = require "lvim.utils.functions"
 
   if not f.isempty(filename) then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Extension contains special character (colon) which is causing errors on nvim function `nvim_set_hl`. 

<!--- Please list any dependencies that are required for this change. --->

fixes #3713

## How Has This Been Tested?

Setup Octo and its dependencies.
Start a PR review and place cursor on hunk. 
Run `:Octo comment add` and the file should open where a comment can be added.
