### PR TITLE
feat: cmdline config option enables cmp-cmdline plugin

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -62,7 +62,7 @@ local core_plugins = {
   {
     "hrsh7th/cmp-cmdline",
     lazy = true,
-    enabled = lvim.builtin.cmp.cmdline.enable,
+    enabled = lvim.builtin.cmp and lvim.builtin.cmp.cmdline.enable or false,
   },
   {
     "L3MON4D3/LuaSnip",

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -52,12 +52,18 @@ local core_plugins = {
       "cmp_luasnip",
       "cmp-buffer",
       "cmp-path",
+      "cmp-cmdline"
     },
   },
   { "hrsh7th/cmp-nvim-lsp", lazy = true },
   { "saadparwaiz1/cmp_luasnip", lazy = true },
   { "hrsh7th/cmp-buffer", lazy = true },
   { "hrsh7th/cmp-path", lazy = true },
+  {
+    "hrsh7th/cmp-cmdline",
+    lazy = true,
+    enabled = lvim.builtin.cmp.cmdline.enable
+  },
   {
     "L3MON4D3/LuaSnip",
     config = function()

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -52,7 +52,7 @@ local core_plugins = {
       "cmp_luasnip",
       "cmp-buffer",
       "cmp-path",
-      "cmp-cmdline"
+      "cmp-cmdline",
     },
   },
   { "hrsh7th/cmp-nvim-lsp", lazy = true },
@@ -62,7 +62,7 @@ local core_plugins = {
   {
     "hrsh7th/cmp-cmdline",
     lazy = true,
-    enabled = lvim.builtin.cmp.cmdline.enable
+    enabled = lvim.builtin.cmp.cmdline.enable,
   },
   {
     "L3MON4D3/LuaSnip",


### PR DESCRIPTION
We already have the configuration for cmdline completions (disabled by default). But the plugin has to be installed as a user plugin after enabling it.
With this commit setting `lvim.builtin.cmp.cmdline.enable = true` will also enable the `cmp-cmdline` plugin.