### PR TITLE
fix(breadcrumbs): refresh on TabEnter

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -210,7 +210,8 @@ M.create_winbar = function()
   vim.api.nvim_create_augroup("_winbar", {})
   if vim.fn.has "nvim-0.8" == 1 then
     vim.api.nvim_create_autocmd(
-      { "CursorHoldI", "CursorHold", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost", "TabClosed" },
+      { "CursorHoldI", "CursorHold", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost", "TabClosed", "TabEnter" }
+      ,
       {
         group = "_winbar",
         callback = function()

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -217,20 +217,19 @@ M.create_winbar = function()
       "InsertEnter",
       "BufWritePost",
       "TabClosed",
-      "TabEnter"
-    },
-      {
-        group = "_winbar",
-        callback = function()
-          if lvim.builtin.breadcrumbs.active then
-            local status_ok, _ = pcall(vim.api.nvim_buf_get_var, 0, "lsp_floating_window")
-            if not status_ok then
-              -- TODO:
-              require("lvim.core.breadcrumbs").get_winbar()
-            end
+      "TabEnter",
+    }, {
+      group = "_winbar",
+      callback = function()
+        if lvim.builtin.breadcrumbs.active then
+          local status_ok, _ = pcall(vim.api.nvim_buf_get_var, 0, "lsp_floating_window")
+          if not status_ok then
+            -- TODO:
+            require("lvim.core.breadcrumbs").get_winbar()
           end
-        end,
-      })
+        end
+      end,
+    })
   end
 end
 

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -210,8 +210,16 @@ M.create_winbar = function()
   vim.api.nvim_create_augroup("_winbar", {})
   if vim.fn.has "nvim-0.8" == 1 then
     vim.api.nvim_create_autocmd(
-      { "CursorHoldI", "CursorHold", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost", "TabClosed", "TabEnter" }
-      ,
+      {
+        "CursorHoldI",
+        "CursorHold",
+        "BufWinEnter",
+        "BufFilePost",
+        "InsertEnter",
+        "BufWritePost",
+        "TabClosed",
+        "TabEnter"
+      },
       {
         group = "_winbar",
         callback = function()

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -209,17 +209,16 @@ end
 M.create_winbar = function()
   vim.api.nvim_create_augroup("_winbar", {})
   if vim.fn.has "nvim-0.8" == 1 then
-    vim.api.nvim_create_autocmd(
-      {
-        "CursorHoldI",
-        "CursorHold",
-        "BufWinEnter",
-        "BufFilePost",
-        "InsertEnter",
-        "BufWritePost",
-        "TabClosed",
-        "TabEnter"
-      },
+    vim.api.nvim_create_autocmd({
+      "CursorHoldI",
+      "CursorHold",
+      "BufWinEnter",
+      "BufFilePost",
+      "InsertEnter",
+      "BufWritePost",
+      "TabClosed",
+      "TabEnter"
+    },
       {
         group = "_winbar",
         callback = function()
@@ -231,8 +230,7 @@ M.create_winbar = function()
             end
           end
         end,
-      }
-    )
+      })
   end
 end
 


### PR DESCRIPTION
To reproduce the issue:
1. Open a new tab
2. Switch back to an existing tab
3. Tab count (right side of the breadcrumbs) will show the old tab count for a brief moment.
As a fix, add TabEnter as an additional event for refresh autocmd.