### PR TITLE
chore(devicons): rename devicons owner & update

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -177,7 +177,7 @@ local core_plugins = {
 
   -- Icons
   {
-    "kyazdani42/nvim-web-devicons",
+    "nvim-tree/nvim-web-devicons",
     enabled = lvim.use_icons,
   },
 

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -90,7 +90,7 @@
     "commit": "4a42b30"
   },
   "nvim-web-devicons": {
-    "commit": "05e1072"
+    "commit": "6c38926"
   },
   "onedarker.nvim": {
     "commit": "b00dd21"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`kyazdani42/nvim-web-devicons` is renamed to its org: https://github.com/nvim-tree/nvim-web-devicons. Also, update the plugin to its latest commit.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Updated the plugin myself
- Check with additional new feature to set default icons:
  ```lua
  local ok, devicons = pcall(require, "nvim-web-devicons")
  if ok then devicons.set_default_icon("", "#6d8086") end -- this func is not available in the previous commit, only the latest
  ```
- Works!

