### PR TITLE
fix(installer): only install treesitter-cli if it's missing

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -39,8 +39,11 @@ declare -a __lvim_dirs=(
 
 declare -a __npm_deps=(
   "neovim"
-  "tree-sitter-cli"
 )
+# treesitter installed with brew causes conflicts #3738
+if ! command -v tree-sitter &>/dev/null; then
+	__npm_deps+=("tree-sitter-cli")
+fi
 
 declare -a __pip_deps=(
   "pynvim"

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -42,7 +42,7 @@ declare -a __npm_deps=(
 )
 # treesitter installed with brew causes conflicts #3738
 if ! command -v tree-sitter &>/dev/null; then
-	__npm_deps+=("tree-sitter-cli")
+  __npm_deps+=("tree-sitter-cli")
 fi
 
 declare -a __pip_deps=(


### PR DESCRIPTION
- fixes #3738
