### PR TITLE
fix(indentlines): set indent_char to LineLeft

### DIFF
--- a/lua/lvim/core/indentlines.lua
+++ b/lua/lvim/core/indentlines.lua
@@ -18,6 +18,7 @@ M.config = function()
         "text",
       },
       char = lvim.icons.ui.LineLeft,
+      indent_char = lvim.icons.ui.LineLeft,
       show_trailing_blankline_indent = false,
       show_first_indent_level = true,
       use_treesitter = true,


### PR DESCRIPTION
the current context is using the default middle line, and other lines use our left aligned one, which should not be the case
![image](https://user-images.githubusercontent.com/110467150/212736296-5b7f1f22-3f52-43f7-a8bf-d9efa8fce7a3.png)
