### PR TITLE
fix(plugin-loader): don't clean plugins on LvimUpdate

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -138,10 +138,7 @@ function plugin_loader.get_core_plugins()
   local get_name = require("lazy.core.plugin").Spec.get_name
   for _, spec in pairs(plugins) do
     if spec.enabled == true or spec.enabled == nil then
-      local name = get_name(spec[1])
-      if name ~= "lazy.nvim" then
-        table.insert(names, name)
-      end
+      table.insert(names, get_name(spec[1]))
     end
   end
   return names
@@ -150,8 +147,7 @@ end
 function plugin_loader.sync_core_plugins()
   local core_plugins = plugin_loader.get_core_plugins()
   Log:trace(string.format("Syncing core plugins: [%q]", table.concat(core_plugins, ", ")))
-  require("lazy").update { wait = true, plugins = { "lazy.nvim" } }
-  require("lazy").sync { wait = true, plugins = core_plugins }
+  require("lazy").update { wait = true, plugins = core_plugins }
 end
 
 function plugin_loader.ensure_plugins()


### PR DESCRIPTION
fixes #3744 
require("lazy").sync cleaned all plugins, instead of just updating which caused treesitter parsers to be deleted on update