### PR TITLE
feat(alpha): add quit button to dashboard

### DIFF
--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -15,6 +15,7 @@ function M.config()
       opts = { autostart = true },
     },
     active = true,
+    esc_to_quit = true,
     mode = "dashboard",
   }
 end

--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -15,7 +15,6 @@ function M.config()
       opts = { autostart = true },
     },
     active = true,
-    esc_to_quit = true,
     mode = "dashboard",
   }
 end

--- a/lua/lvim/core/alpha/dashboard.lua
+++ b/lua/lvim/core/alpha/dashboard.lua
@@ -135,6 +135,7 @@ function M.get_sections()
         lvim.icons.ui.Gear .. "  Configuration",
         "<CMD>edit " .. require("lvim.config"):get_user_config_path() .. " <CR>",
       },
+      { "q", lvim.icons.ui.Close .. "  Quit", "<CMD>quit<CR>" },
     },
   }
   return {

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -80,11 +80,12 @@ function M.load_defaults()
         group = "_filetype_settings",
         pattern = "alpha",
         callback = function()
-          vim.cmd [[
-            nnoremap <silent> <buffer> q :qa<CR>
+          vim.opt.buflisted = false
+          if lvim.builtin.alpha.esc_to_quit then
+            vim.cmd [[
             nnoremap <silent> <buffer> <esc> :qa<CR>
-            set nobuflisted
           ]]
+          end
         end,
       },
     },

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -82,7 +82,6 @@ function M.load_defaults()
         callback = function()
           vim.cmd [[
             set nobuflisted
-            nnoremap <silent> <buffer> <esc> :qa<CR>
           ]]
         end,
       },

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -82,10 +82,8 @@ function M.load_defaults()
         callback = function()
           vim.cmd [[
             set nobuflisted
-            nnoremap <silent> <buffer> q :qa<CR>
             nnoremap <silent> <buffer> <esc> :qa<CR>
           ]]
-          end
         end,
       },
     },

--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -80,9 +80,9 @@ function M.load_defaults()
         group = "_filetype_settings",
         pattern = "alpha",
         callback = function()
-          vim.opt.buflisted = false
-          if lvim.builtin.alpha.esc_to_quit then
-            vim.cmd [[
+          vim.cmd [[
+            set nobuflisted
+            nnoremap <silent> <buffer> q :qa<CR>
             nnoremap <silent> <buffer> <esc> :qa<CR>
           ]]
           end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Added option to modify the autocommand that declares \<ESC\> as :qa when in filetype=alpha 
Added default as true to alpha.lua's main config, to not have any change to the current settings. 
Added "q to exit" to the alpha (dashboard mode) prompt list to make the q to :qa\<CR\> remap apparent.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Tested with and without newly added setting `lvim.builtin.alpha.esc_to_quit = true/false` to only change the action if setting is added to personal config.



