### PR TITLE
feat(ts): enable indent for c and cpp

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -52,7 +52,7 @@ function M.config()
         json = "",
       },
     },
-    indent = { enable = true, disable = { "yaml", "python", "c", "cpp" } },
+    indent = { enable = true, disable = { "yaml", "python" } },
     autotag = { enable = false },
     textobjects = {
       swap = {


### PR DESCRIPTION
it's fixed now
Reverts LunarVim/LunarVim#3687