### PR TITLE
chore: bump nvim web devicons

### DIFF
--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -93,7 +93,7 @@
     "commit": "a0f8956"
   },
   "nvim-web-devicons": {
-    "commit": "2b96193"
+    "commit": "ade34ca"
   },
   "onedarker.nvim": {
     "commit": "b00dd21"


### PR DESCRIPTION
fix vue icon, https://github.com/nvim-tree/nvim-web-devicons/commit/ade34ca7d19543904b28b903e606be8930fb9ee3
