### PR TITLE
fix(alpha): rollback to older commit

### DIFF
--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -6,7 +6,7 @@
     "commit": "d404ec3"
   },
   "alpha-nvim": {
-    "commit": "d5fdeb2"
+    "commit": "21a0f25"
   },
   "bigfile.nvim": {
     "commit": "c1bad34"


### PR DESCRIPTION
latest version of alpha breaks if you open a file first and then open the dashboard 
https://github.com/goolord/alpha-nvim/issues/178