### PR TITLE
fix(lsp): template generation for filetypes with dots

### DIFF
--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -44,6 +44,7 @@ function M.generate_ftplugin(server_name, dir)
   end
 
   for _, filetype in ipairs(filetypes) do
+    filetype = filetype:match "%.([^.]*)$" or filetype
     local filename = join_paths(dir, filetype .. ".lua")
     local setup_cmd = string.format([[require("lvim.lsp.manager").setup(%q)]], server_name)
     -- print("using setup_cmd: " .. setup_cmd)


### PR DESCRIPTION
for filetypes like yaml.ansible [nvim will load yaml.lua and ansible.lua](https://github.com/neovim/neovim/blob/e5d8220179f932ab9c9ef59996cab357a25eaaf8/runtime/ftplugin.vim#L28-L34) form ftplugin, not yaml.ansible.lua

