### PR TITLE
fix(cmp): handle deprecated tree-sitter api

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -46,10 +46,6 @@ function M.config()
   }
 end
 
-local function on_confirm_done(...)
-  require("nvim-autopairs.completion.cmp").on_confirm_done()(...)
-end
-
 M.setup = function()
   local status_ok, autopairs = pcall(require, "nvim-autopairs")
   if not status_ok then
@@ -74,8 +70,11 @@ M.setup = function()
   if lvim.builtin.autopairs.on_config_done then
     lvim.builtin.autopairs.on_config_done(autopairs)
   end
+
   pcall(function()
-    require "nvim-autopairs.completion.cmp"
+    local function on_confirm_done(...)
+      require("nvim-autopairs.completion.cmp").on_confirm_done()(...)
+    end
     require("cmp").event:off("confirm_done", on_confirm_done)
     require("cmp").event:on("confirm_done", on_confirm_done)
   end)

--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -115,6 +115,11 @@ function M.setup()
   if lvim.builtin.treesitter.on_config_done then
     lvim.builtin.treesitter.on_config_done(treesitter_configs)
   end
+
+  -- handle deprecated API, https://github.com/windwp/nvim-autopairs/pull/324
+  local ts_utils = require "nvim-treesitter.ts_utils"
+  ts_utils.is_in_node_range = vim.treesitter.is_in_node_range
+  ts_utils.get_node_range = vim.treesitter.get_node_range
 end
 
 return M

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -117,6 +117,7 @@ local core_plugins = {
       require("lvim.core.autopairs").setup()
     end,
     enabled = lvim.builtin.autopairs.active,
+    dependencies = { "nvim-treesitter/nvim-treesitter", "hrsh7th/nvim-cmp" },
   },
 
   -- Treesitter


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Override deprecated API from `nvim-treesitter` as a workaround for https://github.com/LunarVim/LunarVim/pull/3836#issuecomment-1427613551


### How has this been tested?

not sure how to trigger the error in the first place..

