### PR TITLE
refactor(bootstrap)!: improve stdpath override

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -64,11 +64,14 @@ function M:init(base_dir)
   self.lazy_install_dir = join_paths(self.pack_dir, "lazy", "opt", "lazy.nvim")
 
   ---@meta overridden to use LUNARVIM_CACHE_DIR instead, since a lot of plugins call this function internally
-  ---NOTE: changes to "data" are currently unstable, see #2507
   ---@diagnostic disable-next-line: duplicate-set-field
   vim.fn.stdpath = function(what)
     if what == "cache" then
       return _G.get_cache_dir()
+    elseif what == "config" then
+      return _G.get_config_dir()
+    elseif what == "data" then
+      return _G.get_runtime_dir()
     end
     return vim.call("stdpath", what)
   end

--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -73,6 +73,13 @@ function M:init(base_dir)
     return vim.call("stdpath", what)
   end
 
+  vim.api.nvim_call_function = function(fn, args)
+    if fn == "stdpath" then
+      return vim.fn.stdpath(args[1])
+    end
+    return vim.call(fn, unpack(args))
+  end
+
   ---Get the full path to LunarVim's base directory
   ---@return string
   function _G.get_lvim_base_dir()


### PR DESCRIPTION
Fixes #3541 #3840 
Now overriding `stdpath` when called through `nvim_call_function` too, used to only apply to `vim.fn.stdpath`
It used to only have `config`, I've added `config` and `data` overrides too.
As per #2507, there was originally an issue with lsp-installer which is not used anymore. And after a bit of testing, nothing else seems broken.

Down side is, everything stored in `nvim` path would be lost. E.g. Mason binaries.
Thinking about making the move as smooth as possible, maybe it makes sense to copy the old data folder to the new location as part of the update process