### PR TITLE
feat: lock new installations to nvim 0.9+

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -34,10 +34,10 @@ body:
   - type: input
     id: nvim-version
     attributes:
-      label: Neovim version (>= 0.8.0)
+      label: Neovim version (>= 0.9.0)
       description: "Output of `nvim --version`"
       placeholder: |
-        NVIM v0.8.0-dev+199-g2875d45e7
+        NVIM v0.9.0-dev-983+g6dfabd014
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/lsp-issue-form.yaml
@@ -27,10 +27,10 @@ body:
   - type: input
     id: nvim-version
     attributes:
-      label: Neovim version (>= 0.8.0)
+      label: Neovim version (>= 0.9.0)
       description: "Output of `nvim --version`"
       placeholder: |
-        NVIM v0.8.0-dev+199-g2875d45e7
+        NVIM v0.9.0-dev-983+g6dfabd014
     validations:
       required: true
   - type: input

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -21,10 +21,10 @@ jobs:
         include:
           - runner: ubuntu-latest
             os: linux
-            neovim: v0.8.0
+            neovim: v0.9.0
           - runner: macos-latest
             os: osx
-            neovim: v0.8.0
+            neovim: v0.9.0
           - runner: ubuntu-22.04
             os: linux
             neovim: nightly
@@ -78,7 +78,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.8.0
+          version: v0.9.0
 
       - name: Install LunarVim
         timeout-minutes: 4

--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-if vim.fn.has "nvim-0.8" ~= 1 then
-  vim.notify("Please upgrade your Neovim base installation. Lunarvim requires v0.8+", vim.log.levels.WARN)
+if vim.fn.has "nvim-0.9" ~= 1 then
+  vim.notify("Please upgrade your Neovim base installation. Lunarvim requires v0.9+", vim.log.levels.WARN)
   vim.wait(5000, function()
     ---@diagnostic disable-next-line: redundant-return-value
     return false

--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -208,29 +208,27 @@ end
 
 M.create_winbar = function()
   vim.api.nvim_create_augroup("_winbar", {})
-  if vim.fn.has "nvim-0.8" == 1 then
-    vim.api.nvim_create_autocmd({
-      "CursorHoldI",
-      "CursorHold",
-      "BufWinEnter",
-      "BufFilePost",
-      "InsertEnter",
-      "BufWritePost",
-      "TabClosed",
-      "TabEnter",
-    }, {
-      group = "_winbar",
-      callback = function()
-        if lvim.builtin.breadcrumbs.active then
-          local status_ok, _ = pcall(vim.api.nvim_buf_get_var, 0, "lsp_floating_window")
-          if not status_ok then
-            -- TODO:
-            require("lvim.core.breadcrumbs").get_winbar()
-          end
+  vim.api.nvim_create_autocmd({
+    "CursorHoldI",
+    "CursorHold",
+    "BufWinEnter",
+    "BufFilePost",
+    "InsertEnter",
+    "BufWritePost",
+    "TabClosed",
+    "TabEnter",
+  }, {
+    group = "_winbar",
+    callback = function()
+      if lvim.builtin.breadcrumbs.active then
+        local status_ok, _ = pcall(vim.api.nvim_buf_get_var, 0, "lsp_floating_window")
+        if not status_ok then
+          -- TODO:
+          require("lvim.core.breadcrumbs").get_winbar()
         end
-      end,
-    })
-  end
+      end
+    end,
+  })
 end
 
 return M

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -43,7 +43,7 @@ function M.run_post_update()
   Log:debug "Starting post-update hook"
 
   if vim.fn.has "nvim-0.9" ~= 1 then
-    local compat_tag = "1.1.4"
+    local compat_tag = "1.2.0"
     vim.notify(
       "Please upgrade your Neovim base installation. Newer version of Lunarvim requires v0.9+",
       vim.log.levels.WARN

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -42,10 +42,10 @@ end
 function M.run_post_update()
   Log:debug "Starting post-update hook"
 
-  if vim.fn.has "nvim-0.8" ~= 1 then
+  if vim.fn.has "nvim-0.9" ~= 1 then
     local compat_tag = "1.1.4"
     vim.notify(
-      "Please upgrade your Neovim base installation. Newer version of Lunarvim requires v0.7+",
+      "Please upgrade your Neovim base installation. Newer version of Lunarvim requires v0.9+",
       vim.log.levels.WARN
     )
     vim.wait(1000)

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -213,11 +213,11 @@ function print_missing_dep_msg() {
 }
 
 function check_neovim_min_version() {
-  local verify_version_cmd='if !has("nvim-0.8") | cquit | else | quit | endif'
+  local verify_version_cmd='if !has("nvim-0.9") | cquit | else | quit | endif'
 
   # exit with an error if min_version not found
   if ! nvim --headless -u NONE -c "$verify_version_cmd"; then
-    echo "[ERROR]: LunarVim requires at least Neovim v0.8 or higher"
+    echo "[ERROR]: LunarVim requires at least Neovim v0.9 or higher"
     exit 1
   fi
 }


### PR DESCRIPTION
Using #3111 as reference for things to change
The stable checks won't pass until v0.9 is released