### PR TITLE
fix(lsp): check if config is returned

### DIFF
--- a/lua/lvim/lsp/utils.lua
+++ b/lua/lvim/lsp/utils.lua
@@ -44,7 +44,7 @@ end
 ---@return string[] supported filestypes as a list of strings
 function M.get_supported_filetypes(server_name)
   local status_ok, config = pcall(require, ("lspconfig.server_configurations.%s"):format(server_name))
-  if not status_ok then
+  if not status_ok or not config then
     return {}
   end
 


### PR DESCRIPTION
macos ci on #3836 sometimes fails because `config` is somehow a boolean 