### PR TITLE
fix(terminal): don't set  the shell by default

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -78,13 +78,11 @@ local function get_dynamic_terminal_size(direction, size)
 end
 
 M.init = function()
-  lvim.builtin.terminal.shell = lvim.builtin.terminal.shell or vim.o.shell
-
   for i, exec in pairs(lvim.builtin.terminal.execs) do
     local direction = exec[4] or lvim.builtin.terminal.direction
 
     local opts = {
-      cmd = exec[1] or lvim.builtin.terminal.shell,
+      cmd = exec[1] or lvim.builtin.terminal.shell or vim.o.shell,
       keymap = exec[2],
       label = exec[3],
       -- NOTE: unable to consistently bind id/count <= 9, see #2146

--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -18,7 +18,7 @@ M.config = function()
     -- direction = 'vertical' | 'horizontal' | 'window' | 'float',
     direction = "float",
     close_on_exit = true, -- close the terminal window when the process exits
-    shell = vim.o.shell, -- change the default shell
+    shell = nil, -- change the default shell
     -- This field is only relevant if direction is set to 'float'
     float_opts = {
       -- The border key is *almost* the same as 'nvim_win_open'
@@ -78,6 +78,8 @@ local function get_dynamic_terminal_size(direction, size)
 end
 
 M.init = function()
+  lvim.builtin.terminal.shell = lvim.builtin.terminal.shell or vim.o.shell
+
   for i, exec in pairs(lvim.builtin.terminal.execs) do
     local direction = exec[4] or lvim.builtin.terminal.direction
 


### PR DESCRIPTION
# Description

I have an issue on Windows when my shell settings like `vim.opt.shell` or `lvim.builtin.terminal.shell` has no effect with `open_mapping` key.

Tested on other OSes as well.

## How Has This Been Tested?

- Setting `vim.opt.shell = "pwsh"` or `lvim.builtin.terminal.shell = "pwsh"`
- See that the shell change when pressing with `open_mapping` key like `<C-\>`