### PR TITLE
fix(config-loader): defer invalid configuration warning

### DIFF
--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -51,7 +51,9 @@ function M:load(config_path)
   local ok, err = pcall(dofile, config_path)
   if not ok then
     if utils.is_file(user_config_file) then
-      Log:warn("Invalid configuration: " .. err)
+      vim.schedule(function()
+        Log:warn("Invalid configuration: " .. err)
+      end)
     else
       vim.notify_once(
         string.format("User-configuration not found. Creating an example configuration in %s", config_path)

--- a/lua/lvim/config/init.lua
+++ b/lua/lvim/config/init.lua
@@ -55,9 +55,11 @@ function M:load(config_path)
         Log:warn("Invalid configuration: " .. err)
       end)
     else
-      vim.notify_once(
-        string.format("User-configuration not found. Creating an example configuration in %s", config_path)
-      )
+      vim.schedule(function()
+        vim.notify_once(
+          string.format("User-configuration not found. Creating an example configuration in %s", config_path)
+        )
+      end)
       local config_name = vim.loop.os_uname().version:match "Windows" and "config_win" or "config"
       local example_config = join_paths(get_lvim_base_dir(), "utils", "installer", config_name .. ".example.lua")
       vim.fn.mkdir(user_config_dir, "p")


### PR DESCRIPTION
before this pr the error message after loading invalid config disappeared after loading the theme and it was easily missed