### PR TITLE
chore: replace deprecated MDI Orbit icon

### DIFF
--- a/lua/lvim/icons.lua
+++ b/lua/lvim/icons.lua
@@ -118,7 +118,7 @@ return {
     SignOut = "",
     Tab = "",
     Table = "",
-    Target = "",
+    Target = "󰀘",
     Telescope = "",
     Text = "",
     Tree = "",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
### Description

Replaces the old Material Design `nf-mdi-orbit` icon with the new one `nf-md-orbit`.

The old one is deprecated since [Nerd Fonts](https://www.nerdfonts.com/cheat-sheet) v2.3, and will be removed in v3.

### How Has This Been Tested?

1. Edit `lua/lvim/core/lualine/components.lua`
2. Check the statusline:
    <img width="1069" alt="Screenshot 2023-02-21 at 10 58 42" src="https://user-images.githubusercontent.com/3299086/220312772-2782d566-e756-47a6-add3-9d2ffccbf38e.png">

### Additional context

- https://github.com/ryanoasis/nerd-fonts/releases/tag/v2.3.3 (see _Material Design Icons_)
- ryanoasis/nerd-fonts#1097
- ryanoasis/nerd-fonts#773