### PR TITLE
fix(telescope): don't lazy load

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -49,8 +49,6 @@ local core_plugins = {
       require("lvim.core.telescope").setup()
     end,
     dependencies = { "telescope-fzf-native.nvim" },
-    lazy = true,
-    cmd = "Telescope",
     enabled = lvim.builtin.telescope.active,
   },
   { "nvim-telescope/telescope-fzf-native.nvim", build = "make", lazy = true, enabled = lvim.builtin.telescope.active },


### PR DESCRIPTION
solves this issue of the telescope config not loading on first use in alpha/new buffer:
![image](https://user-images.githubusercontent.com/65673442/221010006-0046f111-6bdd-4eb6-a6fd-52e3b673fe02.png)
Idk if other lazy loading logic would work, but this is broken since one of the recent plugin bumps