### PR TITLE
fix: lazy cache

### DIFF
--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -47,9 +47,11 @@ function plugin_loader.init(opts)
   vim.opt.runtimepath:append(lazy_install_dir)
   vim.opt.runtimepath:append(join_paths(plugins_dir, "*"))
 
-  -- set a custom path for lazy's cache
-  local lazy_cache = require "lazy.core.cache"
-  lazy_cache.path = join_paths(get_cache_dir(), "lazy", "luac")
+  pcall(function()
+    -- set a custom path for lazy's cache
+    local lazy_cache = require "lazy.core.cache"
+    lazy_cache.path = join_paths(get_cache_dir(), "lazy", "luac")
+  end)
 end
 
 function plugin_loader.reload(spec)

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -47,22 +47,9 @@ function plugin_loader.init(opts)
   vim.opt.runtimepath:append(lazy_install_dir)
   vim.opt.runtimepath:append(join_paths(plugins_dir, "*"))
 
-  pcall(function()
-    -- set a custom path for lazy's cache and enable it
-    local lazy_cache = require "lazy.core.cache"
-    lazy_cache.path = join_paths(get_cache_dir(), "lazy", "luac")
-    lazy_cache.enable()
-  end)
-end
-
-function plugin_loader.reset_cache()
-  -- TODO(kylo252): is this really necessary anymore?
+  -- set a custom path for lazy's cache
   local lazy_cache = require "lazy.core.cache"
-  local cache_path = lazy_cache.path
-  if utils.is_directory(cache_path) then
-    vim.fn.delete(cache_path, "rf")
-    vim.fn.mkdir(cache_path, "p")
-  end
+  lazy_cache.path = join_paths(get_cache_dir(), "lazy", "luac")
 end
 
 function plugin_loader.reload(spec)

--- a/lua/lvim/utils/hooks.lua
+++ b/lua/lvim/utils/hooks.lua
@@ -27,7 +27,6 @@ end
 ---It also forces regenerating any template ftplugin files
 ---Tip: Useful for clearing any outdated settings
 function M.reset_cache()
-  plugin_loader.reset_cache()
   local lvim_modules = {}
   for module, _ in pairs(package.loaded) do
     if module:match "lvim.core" or module:match "lvim.lsp" then


### PR DESCRIPTION
Calling `lazy.cache.enable()` in `plugin_loader.init()` doesn't work properly, it is before calling lazy setup and then the lazy setup calls `cache.enable` again on it's own.
Instead only override the path and let lazy do the rest. (already enabled in default lazy config)
Also remove the `pcall`, this is an internal variable and we would wanna know if it breaks in the future.
`reset_cache` is also removed as looks like that's not necessary.