### PR TITLE
chore(custom-finders): solve deprecation warning

### DIFF
--- a/lua/lvim/core/telescope/custom-finders.lua
+++ b/lua/lvim/core/telescope/custom-finders.lua
@@ -74,9 +74,9 @@ function M.view_lunarvim_changelog()
       attach_mappings = function(_, map)
         map("i", "<enter>", copy_to_clipboard_action)
         map("n", "<enter>", copy_to_clipboard_action)
-        map("i", "<esc>", actions._close)
-        map("n", "<esc>", actions._close)
-        map("n", "q", actions._close)
+        map("i", "<esc>", actions.close)
+        map("n", "<esc>", actions.close)
+        map("n", "q", actions.close)
         return true
       end,
       sorter = sorters.generic_sorter,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

`_close` in `telescope.actions` is deprecated, telescope docs says to use `close` instead

<!--- Please list any dependencies that are required for this change. --->

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->

