### PR TITLE
refactor(lsp): allow to disable custom handlers config

### DIFF
--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -54,6 +54,14 @@ function M.handle()
   setmetatable(lvim.lsp.popup_border, mt)
 
   ---@deprecated
+  lvim.lsp.float = {}
+  setmetatable(lvim.lsp.float, {
+    __newindex = function(_, k, _)
+      deprecate("lvim.lsp.float." .. k, "Use `lvim.lsp.handlers.override_config instead.")
+    end,
+  })
+
+  ---@deprecated
   lvim.lang = {}
   setmetatable(lvim.lang, mt)
 end

--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -86,10 +86,12 @@ return {
   },
   document_highlight = false,
   code_lens_refresh = true,
-  float = {
-    focusable = true,
-    style = "minimal",
-    border = "rounded",
+  handlers = {
+    override_config = {
+      focusable = true,
+      style = "minimal",
+      border = "rounded",
+    },
   },
   on_attach_callback = nil,
   on_init_callback = nil,

--- a/lua/lvim/lsp/handlers.lua
+++ b/lua/lvim/lsp/handlers.lua
@@ -12,8 +12,12 @@ function M.setup()
     float = lvim.lsp.diagnostics.float,
   }
   vim.diagnostic.config(config)
-  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, lvim.lsp.float)
-  vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, lvim.lsp.float)
+
+  if lvim.lsp.handlers.override_config then
+    vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, lvim.lsp.handlers.override_config)
+    vim.lsp.handlers["textDocument/signatureHelp"] =
+      vim.lsp.with(vim.lsp.handlers.signature_help, lvim.lsp.handlers.override_config)
+  end
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Provide a more intuitive option for users to easily change or disable the handlers config

fixes #3874

## How Has This Been Tested?

- `lvim.lsp.float.xxx` is deprecated
- `lvim.lsp.handlers.override_config = nil` disable custom handlers

