### PR TITLE
fix(breadcrumbs): disable for neotest

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -32,6 +32,7 @@ M.config = function()
       "lab",
       "notify",
       "noice",
+      "neotest-summary",
       "",
     },
     options = {


### PR DESCRIPTION
Neotest already shows the adapter names
![image](https://user-images.githubusercontent.com/9511136/222829845-4cb41fef-e745-4112-b9fd-7aa0f66132b3.png)
