### PR TITLE
feat(terminal): fire neo tree git event when closing lazygit

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -160,7 +160,13 @@ M.lazygit_toggle = function()
     on_open = function(_)
       vim.cmd "startinsert!"
     end,
-    on_close = function(_) end,
+    on_close = function(_)
+      local ok, neo_tree_events = pcall(require, "neo-tree.events")
+      if not ok then
+        return
+      end
+      neo_tree_events.fire_event "git_event"
+    end,
     count = 99,
   }
   lazygit:toggle()


### PR DESCRIPTION
Hi,

Thank you for the awesome project. I use neo-tree and found that the git status in neo-tree is not in sync after performing some git actions in lazygit through toggleterm. I then found a way to trigger git status update in neo-tree when closing lazygit (cf https://github.com/nvim-neo-tree/neo-tree.nvim/issues/337#issuecomment-1114340769). I think it would be useful to add this in lunarvim. Protected call is used so the code won't do anything if neo-tree is not used.


