### PR TITLE
fix(dap): invalid border value

### DIFF
--- a/lua/lvim/core/dap.lua
+++ b/lua/lvim/core/dap.lua
@@ -82,7 +82,7 @@ M.config = function()
         floating = {
           max_height = 0.9,
           max_width = 0.5, -- Floats will be treated as percentage of your screen.
-          border = vim.g.border_chars, -- Border style. Can be 'single', 'double' or 'rounded'
+          border = "rounded",
           mappings = {
             close = { "q", "<Esc>" },
           },


### PR DESCRIPTION
`vim.g.border_chars` is not defined.