### PR TITLE
fix: copilot indent reset (#3343)

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -331,6 +331,12 @@ M.config = function()
           if is_insert_mode() then -- prevent overwriting brackets
             confirm_opts.behavior = ConfirmBehavior.Insert
           end
+          local entry = cmp.get_selected_entry()
+          local is_copilot = entry and entry.source.name == "copilot"
+          if is_copilot then
+            confirm_opts.behavior = ConfirmBehavior.Replace
+            confirm_opts.select = true
+          end
           if cmp.confirm(confirm_opts) then
             return -- success, exit early
           end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

# Description

Sets cmp.confirm_opts.behavior to replace when entry is from copilot
fixes #3343
Idea stolen from Lazyvim's fix for the same issue: https://github.com/LazyVim/LazyVim/discussions/387#discussioncomment-5207870
