### PR TITLE
feat(cmp): enable the user to easily add new completion sources

### DIFF
--- a/lua/lvim/core/cmp.lua
+++ b/lua/lvim/core/cmp.lua
@@ -156,62 +156,66 @@ M.config = function()
       fields = { "kind", "abbr", "menu" },
       max_width = 0,
       kind_icons = lvim.icons.kind,
-      source_names = {
-        nvim_lsp = "(LSP)",
-        emoji = "(Emoji)",
-        path = "(Path)",
-        calc = "(Calc)",
-        cmp_tabnine = "(Tabnine)",
-        vsnip = "(Snippet)",
-        luasnip = "(Snippet)",
-        buffer = "(Buffer)",
-        tmux = "(TMUX)",
-        copilot = "(Copilot)",
-        treesitter = "(TreeSitter)",
-      },
-      duplicates = {
-        buffer = 1,
-        path = 1,
-        nvim_lsp = 0,
-        luasnip = 1,
+      source_settings = {
+        copilot = {
+          menu_name = "(Copilot)",
+          icon = lvim.icons.git.Octoface,
+          hl_group = "CmpItemKindCopilot",
+        },
+        emoji = {
+          menu_name = "(Emoji)",
+          icon = lvim.icons.misc.Smiley,
+          hl_group = "CmpItemKindEmoji",
+        },
+        cmp_tabnine = {
+          menu_name = "(Tabnine)",
+          icon = lvim.icons.misc.Robot,
+          hl_group = "CmpItemKindTabnine",
+        },
+        crates = {
+          menu_name = "(Crates)",
+          icon = lvim.icons.misc.Package,
+          hl_group = "CmpItemKindCrate",
+        },
+        ["lab.quick_data"] = {
+          menu_name = "(QuickData)",
+          icon = lvim.icons.misc.CircuitBoard,
+          hl_group = "CmpItemKindConstant",
+        },
+        nvim_lsp = {
+          menu_name = "(LSP)",
+          duplicates = 0,
+        },
+        path = {
+          menu_name = "(Path)",
+          duplicates = 1,
+        },
+        luasnip = {
+          menu_name = "(Snippet)",
+          duplicates = 1,
+        },
+        buffer = {
+          menu_name = "(Buffer)",
+          duplicates = 1,
+        },
+        calc = { menu_name = "(Calc)" },
+        vsnip = { menu_name = "(Snippet)" },
+        treesitter = { menu_name = "(TreeSitter)" },
+        tmux = { menu_name = "(TMUX)" },
       },
       duplicates_default = 0,
       format = function(entry, vim_item)
         local max_width = lvim.builtin.cmp.formatting.max_width
+        local source_settings = lvim.builtin.cmp.formatting.source_settings[entry.source.name]
         if max_width ~= 0 and #vim_item.abbr > max_width then
           vim_item.abbr = string.sub(vim_item.abbr, 1, max_width - 1) .. lvim.icons.ui.Ellipsis
         end
         if lvim.use_icons then
-          vim_item.kind = lvim.builtin.cmp.formatting.kind_icons[vim_item.kind]
-
-          if entry.source.name == "copilot" then
-            vim_item.kind = lvim.icons.git.Octoface
-            vim_item.kind_hl_group = "CmpItemKindCopilot"
-          end
-
-          if entry.source.name == "cmp_tabnine" then
-            vim_item.kind = lvim.icons.misc.Robot
-            vim_item.kind_hl_group = "CmpItemKindTabnine"
-          end
-
-          if entry.source.name == "crates" then
-            vim_item.kind = lvim.icons.misc.Package
-            vim_item.kind_hl_group = "CmpItemKindCrate"
-          end
-
-          if entry.source.name == "lab.quick_data" then
-            vim_item.kind = lvim.icons.misc.CircuitBoard
-            vim_item.kind_hl_group = "CmpItemKindConstant"
-          end
-
-          if entry.source.name == "emoji" then
-            vim_item.kind = lvim.icons.misc.Smiley
-            vim_item.kind_hl_group = "CmpItemKindEmoji"
-          end
+          vim_item.kind = source_settings.icon or lvim.builtin.cmp.formatting.kind_icons[vim_item.kind]
+          vim_item.kind_hl_group = source_settings.hl_group
         end
-        vim_item.menu = lvim.builtin.cmp.formatting.source_names[entry.source.name]
-        vim_item.dup = lvim.builtin.cmp.formatting.duplicates[entry.source.name]
-          or lvim.builtin.cmp.formatting.duplicates_default
+        vim_item.menu = source_settings.menu_name
+        vim_item.dup = source_settings.duplicates or lvim.builtin.cmp.formatting.duplicates_default
         return vim_item
       end,
     },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
* Consolidate lvim.builtin.cmp.formatting.source_names and lvim.builtin.cmp.formatting.duplicates into a new lvim.builtin.cmp.formatting.source_settings table
* Update lvim.builtin.cmp.formatting.format function to use source_settings table to determine the menu name, icon, highlight group, and duplicate flag
* Add menu names for crates, and lab.quick_data
* These changes make it easy for users to add new completion sources by adding a new entry to the lvim.builtin.cmp.formatting.source_settings table
summary of the change
* This change will break any users who accessed lvim.builtin.cmp.formatting.source_names or lvim.builtin.cmp.formatting.duplicates directly

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?
Manual testing in config.lua
```
lvim.plugins = {
...
  {
    "jcdickinson/codeium.nvim",
    dependencies = { "hrsh7th/nvim-cmp" },
    config = function()
      require("codeium").setup({})
    end
  },
}
table.insert(lvim.builtin.cmp.sources, { name = "codeium" })
lvim.builtin.cmp.source_settings.codeium = {
  menu_name = "(Codeium)",
  icon = "",
  hl_group = "CmpItemKindTabnine",
}
```