### PR TITLE
fix(nvimtree): don't overwrite update_focused_file.ignore_list

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -245,7 +245,8 @@ function M.setup()
   if lvim.builtin.project.active then
     lvim.builtin.nvimtree.setup.respect_buf_cwd = true
     lvim.builtin.nvimtree.setup.update_cwd = true
-    lvim.builtin.nvimtree.setup.update_focused_file = { enable = true, update_cwd = true }
+    lvim.builtin.nvimtree.setup.update_focused_file.enable = true
+    lvim.builtin.nvimtree.setup.update_focused_file.update_cwd = true
   end
 
   local function telescope_find_files(_)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Prevents overwrite of `nvim-tree.update_focused_file.ignore_list` configuration.

<!--- Please list any dependencies that are required for this change. --->

Fixes #3985

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Create a configuration with an ignore_list for nvim-tree. That list should be respected after the fix is applied.
- Specifically I use a plugin called DiffView, and every time I execute `DiffviewOpen` when nvim-tree is open, I get a nasty error taking up my whole screen. With the following line in my `config.lua`, it is supposed to prevent the error from appearing: `lvim.builtin.nvimtree.setup.update_focused_file.ignore_list = { 'DiffViewFiles' }`. However, without this fix the error still appears.

