### PR TITLE
feat(mason): add on_config_done option to lvim.builtin.mason

### DIFF
--- a/lua/lvim/core/mason.lua
+++ b/lua/lvim/core/mason.lua
@@ -49,6 +49,8 @@ function M.config()
       -- 3. The asset name (e.g. "rust-analyzer-v0.3.0-x86_64-unknown-linux-gnu.tar.gz")
       download_url_template = "https://github.com/%s/releases/download/%s/%s",
     },
+
+    on_config_done = nil,
   }
 end
 
@@ -84,6 +86,10 @@ function M.setup()
   add_to_path(lvim.builtin.mason.PATH == "append")
 
   mason.setup(lvim.builtin.mason)
+
+  if lvim.builtin.mason.on_config_done then
+    lvim.builtin.mason.on_config_done(mason)
+  end
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Aditionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This PR adds the `on_config_done` option to `lvim.builtin.mason`. This behaves like `on_config_done` for other plugins, such as `lvim.builtin.nvimtree.on_config_done`. That is, if a function is assigned to `on_config_done`, it will be called at the end of the `lvim.core.mason.setup()` with an argument of the loaded `mason` module.

This enables users to define setup logic in `config.lua` using the correctly set up `mason` module. 
For example, `require("mason-registry").get_installed_packages()` does not work as expected before `mason` is set up.

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Assign a function to `lvim.builtin.mason.on_config_done`,  and check if the `mason` module has been setup properly when that function is called.


