### PR TITLE
chore(plugins): remove `popup.nvim` as it is deprecated

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -38,8 +38,6 @@ local core_plugins = {
     lazy = lvim.colorscheme ~= "lunar",
   },
   { "Tastyep/structlog.nvim", lazy = true },
-
-  { "nvim-lua/popup.nvim", lazy = true },
   { "nvim-lua/plenary.nvim", cmd = { "PlenaryBustedFile", "PlenaryBustedDirectory" }, lazy = true },
   -- Telescope
   {

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -101,9 +101,6 @@
   "plenary.nvim": {
     "commit": "253d348"
   },
-  "popup.nvim": {
-    "commit": "b7404d3"
-  },
   "project.nvim": {
     "commit": "1c2e9c9"
   },


### PR DESCRIPTION
According to https://github.com/nvim-lua/plenary.nvim/pull/209 , `nvim-lua/popup.nvim` is deprecated and was fully merged into `plenary.nvim`.   
`popup.nvim` is originally installed as a dependency of `telescope.nvim` but it is nolonger required, see https://github.com/nvim-telescope/telescope.nvim#required-dependencies

I've removed `popup.nvim` from the plugin list.