### PR TITLE
fix(installer): validation step was failing on windows

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -234,7 +234,7 @@ function setup_lvim() {
 function validate_lunarvim_files() {
     Set-Alias lvim "$INSTALL_PREFIX\bin\lvim.ps1"
     try {
-        $verify_version_cmd="if v:errmsg != `"`" | cquit | else | quit | endif"
+        $verify_version_cmd="if !empty(v:errmsg) | cquit | else | quit | endif"
         Invoke-Command -ScriptBlock { lvim --headless -c 'LvimUpdate' -c "$verify_version_cmd" } -ErrorAction SilentlyContinue
     }
     catch {


### PR DESCRIPTION
# Description

On Windows 10 the installation of LunarVim using the powershell script is failing on my machine with the following error:

```
$LV_BRANCH='release-1.2/neovim-0.8'; Invoke-WebRequest https://raw.githubusercontent.com/LunarVim/LunarVim/fc6873809934917b470bff1b072171879899a36b/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression


                88\                                                   88\
                88 |                                                  \__|
                88 |88\   88\ 888888$\   888888\   888888\ 88\    88\ 88\ 888888\8888\
                88 |88 |  88 |88  __88\  \____88\ 88  __88\\88\  88  |88 |88  _88  _88\
                88 |88 |  88 |88 |  88 | 888888$ |88 |  \__|\88\88  / 88 |88 / 88 / 88 |
                88 |88 |  88 |88 |  88 |88  __88 |88 |       \88$  /  88 |88 | 88 | 88 |
                88 |\888888  |88 |  88 |\888888$ |88 |        \$  /   88 |88 | 88 | 88 |
                \__| \______/ \__|  \__| \_______|\__|         \_/    \__|\__| \__| \__|


Backup operation complete
--------------------------------------------------------------------------------

Checking dependencies..
--------------------------------------------------------------------------------

Would you like to check lunarvim's NodeJS dependencies? [y]es or [n]o (default: no) : n
Would you like to check lunarvim's Python dependencies? [y]es or [n]o (default: no) : n
Updating LunarVim
--------------------------------------------------------------------------------

17:37:45 [INFO ] lvim: "Trying to update LunarVim..." file="[C]", line=-1
Error detected while processing command line:
E15: Invalid expression: \"\" | cquit | else | quit | endif
```

The cause seems in the powershell script function `validate_lunarvim_files` In particular this line is failing:
```
$verify_version_cmd="if v:errmsg != \`"\`" | cquit | else | quit | endif"
Invoke-Command -ScriptBlock { lvim --headless -c 'LvimUpdate' -c "$verify_version_cmd" } -ErrorAction SilentlyContinue
```

After `Invoke-Command` is called the issue described in the log above appears.

Details:
Windows version: Windows 10 22H - Build 19045
Powershell version 7.3.3

fixes #(issue)

The fix was to change the `verify_version_cmd` to `$verify_version_cmd="if !empty(v:errmsg) | cquit | else | quit | endif"`

## How Has This Been Tested?

I run the same command as before, but this time using my branch:

```
$LV_BRANCH='release-1.2/neovim-0.8'; Invoke-WebRequest https://raw.githubusercontent.com/elvisdukaj/LunarVim/edukaj/fix/windows_installer_issue/utils/installer/install.ps1 -UseBasicParsing | Invoke-Expression
```

