### PR TITLE
fix(toggleterm): missing search in lazygit

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -153,7 +153,7 @@ M.lazygit_toggle = function()
     hidden = true,
     direction = "float",
     float_opts = {
-      border = "none",
+      border = "single",
       width = 100000,
       height = 100000,
     },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This change fixes a bug where the search UI at the bottom of the Lazygit interface is missing.

I fixed the issue by adding a border to the toggleterm when using Lazygit. Any suggestions for improving the fix are welcome, but the main idea is that the search UI at the bottom is missing.

Screenshots:

Missing search at the bottom:
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/22177776/231526351-d3bd8393-d746-49cf-bfe4-0a79892cebd8.png">

With search:
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/22177776/231526857-121765a5-289e-49dd-b9c9-fd72bd400157.png">


<!--- Please list any dependencies that are required for this change. --->


## How Has This Been Tested?

I have been using this configuration for a while and would like to contribute this fix to the issue.

I tested this fix by:
1. Open Lazygit using the `<leader>gg` keymap.
2. Go to branch tab by pressing `3`
3. Press `/` to start searching branches.
4. Verify that the search UI now appears at the bottom of the interface.