### PR TITLE
fix: use `require` instead of `reload` in pcalls 

### DIFF
--- a/lua/lvim/core/illuminate.lua
+++ b/lua/lvim/core/illuminate.lua
@@ -54,7 +54,7 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, illuminate = pcall(reload, "illuminate")
+  local status_ok, illuminate = pcall(require, "illuminate")
   if not status_ok then
     return
   end

--- a/lua/lvim/core/indentlines.lua
+++ b/lua/lvim/core/indentlines.lua
@@ -28,7 +28,7 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, indent_blankline = pcall(reload, "indent_blankline")
+  local status_ok, indent_blankline = pcall(require, "indent_blankline")
   if not status_ok then
     return
   end

--- a/lua/lvim/core/lir.lua
+++ b/lua/lvim/core/lir.lua
@@ -100,7 +100,7 @@ function M.icon_setup()
 end
 
 function M.setup()
-  local status_ok, lir = pcall(reload, "lir")
+  local status_ok, lir = pcall(require, "lir")
   if not status_ok then
     return
   end

--- a/lua/lvim/core/mason.lua
+++ b/lua/lvim/core/mason.lua
@@ -103,7 +103,7 @@ function M.bootstrap()
 end
 
 function M.setup()
-  local status_ok, mason = pcall(reload, "mason")
+  local status_ok, mason = pcall(require, "mason")
   if not status_ok then
     return
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When no package loaded by `require_safe` , it signals no error, which results `local status_ok, xxx = pcall(reload, xxx)`  receives a wrong `status_ok` when `xxx` module not found.

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)
#4024 #4037
