### PR TITLE
feat: allow user to not spawn git at startup

### DIFF
--- a/lua/lvim/core/alpha.lua
+++ b/lua/lvim/core/alpha.lua
@@ -49,6 +49,9 @@ local function resolve_config(theme_name)
   local section = lvim.builtin.alpha[theme_name].section
 
   for name, el in pairs(section) do
+    if type(el) == "function" then
+      el = el()
+    end
     for k, v in pairs(el) do
       if name:match "buttons" and k == "entries" then
         resolved_section[name].val = resolve_buttons(theme_name, el)

--- a/lua/lvim/core/alpha/dashboard.lua
+++ b/lua/lvim/core/alpha/dashboard.lua
@@ -104,20 +104,22 @@ function M.get_sections()
   }
 
   local text = require "lvim.interface.text"
-  local lvim_version = require("lvim.utils.git").get_lvim_version()
 
-  local footer = {
-    type = "text",
-    val = text.align_center({ width = 0 }, {
-      "",
-      "lunarvim.org",
-      lvim_version,
-    }, 0.5),
-    opts = {
-      position = "center",
-      hl = "Number",
-    },
-  }
+  local footer = function()
+    local lvim_version = require("lvim.utils.git").get_lvim_version()
+    return {
+      type = "text",
+      val = text.align_center({ width = 0 }, {
+        "",
+        "lunarvim.org",
+        lvim_version,
+      }, 0.5),
+      opts = {
+        position = "center",
+        hl = "Number",
+      },
+    }
+  end
 
   local buttons = {
     opts = {


### PR DESCRIPTION
Currently lvim always spawns git at startup (doesn't matter if alpha is active or not) because of `get_lvim_version`

This PR allows setting alpha section as functions, this differs execution of `git` and allows the user to remove it completly by overriding footer section for example `lvim.builtin.alpha.dashboard.section.footer = {}`

The motivation is I feel like this impacts startuptime (didn't measure it) and I do from time to time get timeout errors at startup waiting for git to finish