### PR TITLE
fix(lsp): diagnostic codes already show by default

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -75,13 +75,6 @@ return {
       source = "always",
       header = "",
       prefix = "",
-      format = function(d)
-        local code = d.code or (d.user_data and d.user_data.lsp.code)
-        if code then
-          return string.format("%s [%s]", d.message, code):gsub("1. ", "")
-        end
-        return d.message
-      end,
     },
   },
   document_highlight = false,


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Avoid viewing duplicate diagnostic codes since they are now already shown by default since https://github.com/neovim/neovim/pull/21130/commits/c2d7b22646ec383da69b850f80dce3fa9f816e41

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- view a diagnostic in a hover window with `gl`
- check that the codes aren't duped compared to before
