### PR TITLE
fix: add missing LF to install script

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -439,7 +439,7 @@ function setup_lvim() {
 
   "$INSTALL_PREFIX/bin/$NVIM_APPNAME" --headless -c 'quitall'
 
-  echo "Lazy setup complete"
+  echo "\nLazy setup complete"
 
   verify_core_plugins
 }

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -439,7 +439,8 @@ function setup_lvim() {
 
   "$INSTALL_PREFIX/bin/$NVIM_APPNAME" --headless -c 'quitall'
 
-  echo "\nLazy setup complete"
+  echo ""
+  echo "Lazy setup complete"
 
   verify_core_plugins
 }


### PR DESCRIPTION
When running the installation script, the following appear as a single line. "Initializing first time setupLazy setup complete"

![image](https://user-images.githubusercontent.com/33818/233815768-29654f43-0862-4c01-a6b6-46abd30e3e37.png)

Added an extra LF to the script to resolve

![image](https://user-images.githubusercontent.com/33818/233815907-dec08bad-595b-45a7-8c3e-dc3bfc0fd5af.png)
