### PR TITLE
fix(user_command): update url in `LvimDocs` command

### DIFF
--- a/lua/lvim/core/commands.lua
+++ b/lua/lvim/core/commands.lua
@@ -32,7 +32,7 @@ M.defaults = {
   {
     name = "LvimDocs",
     fn = function()
-      local documentation_url = "https://www.lunarvim.org/docs/quick-start"
+      local documentation_url = "https://www.lunarvim.org/docs/beginners-guide"
       if vim.fn.has "mac" == 1 or vim.fn.has "macunix" == 1 then
         vim.fn.execute("!open " .. documentation_url)
       elseif vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This MR updates the `documentation_url`, which was pointing to a nonexisting webpage. Running `<space> L d` on the `master` branch currently results in the following page being opened:

![image](https://user-images.githubusercontent.com/19196352/233993724-afa26f18-509e-4c79-becc-96d93fcb17d9.png)


## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run `<space> L d` after applying the fix onto a local installation
- Verified that an existing documentation webpage is opened (I've chosen the [begginer's guide](https://www.lunarvim.org/docs/beginners-guide))

