### PR TITLE
fix(nvim-tree): use local buffer keymaps

### DIFF
--- a/lua/lvim/core/nvimtree.lua
+++ b/lua/lvim/core/nvimtree.lua
@@ -243,17 +243,21 @@ local function on_attach(bufnr)
     require("lvim.core.nvimtree").start_telescope "live_grep"
   end
 
+  local function opts(desc)
+    return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
+  end
+
   api.config.mappings.default_on_attach(bufnr)
 
   local useful_keys = {
-    ["l"] = api.node.open.edit,
-    ["o"] = api.node.open.edit,
-    ["<CR>"] = api.node.open.edit,
-    ["v"] = api.node.open.vertical,
-    ["h"] = api.node.navigate.parent_close,
-    ["C"] = api.tree.change_root_to_node,
-    ["gtg"] = telescope_live_grep,
-    ["gtf"] = telescope_find_files,
+    ["l"] = { api.node.open.edit, opts "Open" },
+    ["o"] = { api.node.open.edit, opts "Open" },
+    ["<CR>"] = { api.node.open.edit, opts "Open" },
+    ["v"] = { api.node.open.vertical, opts "Open: Vertical Split" },
+    ["h"] = { api.node.navigate.parent_close, opts "Close Directory" },
+    ["C"] = { api.tree.change_root_to_node, opts "CD" },
+    ["gtg"] = { telescope_live_grep, opts "Telescope Live Grep" },
+    ["gtf"] = { telescope_find_files, opts "Telescope Find File" },
   }
 
   require("lvim.keymappings").load_mode("n", useful_keys)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

<!--- Please list any dependencies that are required for this change. --->

Due to #4054, there was a change to `nvim-tree` custom keymappings to suppress the deprecation warning. These changes override the keymaps outside of the tree causing error when pressing `h,l,o`.

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Open buffer with `lvim`
- Press `h,l,o` inside buffer won't log error of invalid window id from `nvim-tree`
