### PR TITLE
docs: update broken links in example configs

### DIFF
--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -47,7 +47,7 @@ lvim.builtin.treesitter.auto_install = true
 -- -- always installed on startup, useful for parsers without a strict filetype
 -- lvim.builtin.treesitter.ensure_installed = { "comment", "markdown_inline", "regex" }
 
--- -- generic LSP settings <https://www.lunarvim.org/docs/languages#lsp-support>
+-- -- generic LSP settings <https://www.lunarvim.org/docs/configuration/language-features/language-servers>
 
 -- --- disable automatic installation of servers
 -- lvim.lsp.installer.setup.automatic_installation = false
@@ -74,7 +74,7 @@ lvim.builtin.treesitter.auto_install = true
 --   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
 -- end
 
--- -- linters, formatters and code actions <https://www.lunarvim.org/docs/languages#lintingformatting>
+-- -- linters, formatters and code actions <https://www.lunarvim.org/docs/configuration/language-features/linting-and-formatting>
 -- local formatters = require "lvim.lsp.null-ls.formatters"
 -- formatters.setup {
 --   { command = "stylua" },
@@ -100,7 +100,7 @@ lvim.builtin.treesitter.auto_install = true
 --   },
 -- }
 
--- -- Additional Plugins <https://www.lunarvim.org/docs/plugins#user-plugins>
+-- -- Additional Plugins <https://www.lunarvim.org/docs/configuration/plugins/user-plugins>
 -- lvim.plugins = {
 --     {
 --       "folke/trouble.nvim",

--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -69,7 +69,7 @@ lvim.builtin.treesitter.auto_install = true
 -- -- ensure these parsers are always installed, useful for those without a strict filetype
 -- lvim.builtin.treesitter.ensure_installed = { "comment", "markdown_inline", "regex" }
 
--- -- generic LSP settings <https://www.lunarvim.org/docs/languages#lsp-support>
+-- -- generic LSP settings <https://www.lunarvim.org/docs/configuration/language-features/language-servers>
 
 -- --- disable automatic installation of servers
 -- lvim.lsp.installer.setup.automatic_installation = false
@@ -96,7 +96,7 @@ lvim.builtin.treesitter.auto_install = true
 --   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
 -- end
 
--- -- linters and formatters <https://www.lunarvim.org/docs/languages#lintingformatting>
+-- -- linters, formatters and code actions <https://www.lunarvim.org/docs/configuration/language-features/linting-and-formatting>
 -- local formatters = require "lvim.lsp.null-ls.formatters"
 -- formatters.setup {
 --   { command = "stylua" },
@@ -115,7 +115,7 @@ lvim.builtin.treesitter.auto_install = true
 --   },
 -- }
 
--- -- Additional Plugins <https://www.lunarvim.org/docs/plugins#user-plugins>
+-- -- Additional Plugins <https://www.lunarvim.org/docs/configuration/plugins/user-plugins>
 -- lvim.plugins = {
 --     {
 --       "folke/trouble.nvim",


### PR DESCRIPTION
# Description

Update broken links in example configs

I guess  example configs is little bit out-of-date and required update.

especially this section (link isn't replaced yet):

https://github.com/letavocado/LunarVim/blob/21080bf6a23c220b78a0d766a3b418770352e460/utils/installer/config.example.lua#L67-L75

```lua
-- -- you can set a custom on_attach function that will be used for all the language servers
-- -- See <https://github.com/neovim/nvim-lspconfig#keybindings-and-completion>
-- lvim.lsp.on_attach_callback = function(client, bufnr)
--   local function buf_set_option(...)
--     vim.api.nvim_buf_set_option(bufnr, ...)
--   end
--   --Enable completion triggered by <c-x><c-o>
--   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
-- end
```