### PR TITLE
feat(breadcrumbs): replace Circle with Plus

### DIFF
--- a/lua/lvim/core/breadcrumbs.lua
+++ b/lua/lvim/core/breadcrumbs.lua
@@ -185,8 +185,7 @@ M.get_winbar = function()
   end
 
   if not f.isempty(value) and f.get_buf_option "mod" then
-    -- TODO: replace with circle
-    local mod = "%#LspCodeLens#" .. lvim.icons.ui.Circle .. "%*"
+    local mod = "%#LspCodeLens#" .. lvim.icons.ui.Plus .. "%*"
     if gps_added then
       value = value .. " " .. mod
     else


### PR DESCRIPTION
This PR simply changes the modified-file sign from a Circle to a Plus sign.

Exhibit A: Circle
<img width="885" alt="Screen Shot 2023-04-30 at 1 42 37 PM" src="https://user-images.githubusercontent.com/148098/235351225-edd80bea-28ae-4efb-9600-212a485929a7.png">

Exhibit B: Plus
<img width="822" alt="Screen Shot 2023-05-01 at 6 55 56 AM" src="https://user-images.githubusercontent.com/148098/235408802-75456553-841d-427a-be43-4b4e803947b0.png">


I think this is more vim-like and even more aesthetically pleasing to have the Plus sign.