### PR TITLE
fix(plugin): fix nvim-dap plugin dependencies

### DIFF
--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -209,6 +209,9 @@ local core_plugins = {
   {
     "mfussenegger/nvim-dap",
     -- event = "BufWinEnter",
+    dependencies = {
+      "rcarriga/nvim-dap-ui",
+    },
     config = function()
       require("lvim.core.dap").setup()
     end,


### PR DESCRIPTION
As it seems, thanks to the lazy-loading nature of the plugin-loader in lvim it's possible that the plugin nvim-dap loads without having nvim-dap-ui available in time, which leads to the event listeners that automatically opens dap-ui to not be registered in dap.

This PR is intended to add dap-ui as explicit dependency of dap which guarantees the listeners will work.

fixes #4105 , more discussion is available in that issue.
