### PR TITLE
fix: correct runtimepath order

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,7 @@ local base_dir = vim.env.LUNARVIM_BASE_DIR
   end)()
 
 if not vim.tbl_contains(vim.opt.rtp:get(), base_dir) then
-  vim.opt.rtp:append(base_dir)
+  vim.opt.rtp:prepend(base_dir)
 end
 
 require("lvim.bootstrap"):init(base_dir)

--- a/lua/lvim/plugin-loader.lua
+++ b/lua/lvim/plugin-loader.lua
@@ -42,8 +42,19 @@ function plugin_loader.init(opts)
     vim.api.nvim_create_autocmd("User", { pattern = "LazyDone", callback = require("lvim.lsp").setup })
   end
 
-  vim.opt.runtimepath:append(lazy_install_dir)
-  vim.opt.runtimepath:append(join_paths(plugins_dir, "*"))
+  local rtp = vim.opt.rtp:get()
+  local base_dir = (vim.env.LUNARVIM_BASE_DIR or get_runtime_dir() .. "/lvim"):gsub("\\", "/")
+  local idx_base = #rtp + 1
+  for i, path in ipairs(rtp) do
+    path = path:gsub("\\", "/")
+    if path == base_dir then
+      idx_base = i + 1
+      break
+    end
+  end
+  table.insert(rtp, idx_base, lazy_install_dir)
+  table.insert(rtp, idx_base + 1, join_paths(plugins_dir, "*"))
+  vim.opt.rtp = rtp
 
   pcall(function()
     -- set a custom path for lazy's cache


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

before: 
```sh
~/.config/lvim
/usr/share/nvim/site
~/.local/share/lunarvim/lvim
plugins # should be before `/usr/share/nvim/site`
plugins/after
~/.local/share/lunarvim/site/after
~/.config/lvimd/after
```

after:

```sh 
# now the priority is correct: 1.user 2.lvim 3.plugins 4.nvim
~/.config/lvim
~/.local/share/lunarvim/lvim
plugins
/usr/share/nvim/...
plugins/after
~/.local/share/lunarvim/site/after
~/.config/lvim/after
```


<!--- Please list any dependencies that are required for this change. --->

fixes #3723  #3941

## How Has This Been Tested?

`:set rtp?`
