### PR TITLE
fix(lualine): use get_active_clients instead of deprecated function

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -94,7 +94,7 @@ return {
   lsp = {
     function(msg)
       msg = msg or "LS Inactive"
-      local buf_clients = vim.lsp.buf_get_clients()
+      local buf_clients = vim.lsp.get_active_clients()
       if next(buf_clients) == nil then
         -- TODO: clean up this if statement
         if type(msg) == "boolean" or #msg == 0 then

--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -93,7 +93,7 @@ return {
   },
   lsp = {
     function()
-      local buf_clients = vim.lsp.get_active_clients()
+      local buf_clients = vim.lsp.get_active_clients { bufnr = 0 }
       if #buf_clients == 0 then
         return "LSP Inactive"
       end

--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -92,16 +92,12 @@ return {
     cond = conditions.hide_in_width,
   },
   lsp = {
-    function(msg)
-      msg = msg or "LS Inactive"
+    function()
       local buf_clients = vim.lsp.get_active_clients()
-      if next(buf_clients) == nil then
-        -- TODO: clean up this if statement
-        if type(msg) == "boolean" or #msg == 0 then
-          return "LS Inactive"
-        end
-        return msg
+      if #buf_clients == 0 then
+        return "LSP Inactive"
       end
+
       local buf_ft = vim.bo.filetype
       local buf_client_names = {}
       local copilot_active = false


### PR DESCRIPTION
* fix(lualine): use get_active_clients instead of deprecated function

  `vim.lsp.get_active_clients()` accepts a table to filter returned
  clients by id, bufnr and name. In this case when want to get clients for
  current buffer, if bufnr is not given then it defaults to current
  buffer, so need to pass anything here.

  See `help vim.lsp.buf_get_clients()`

* refactor(lualine): simplify LSP component

  `vim.lsp.get_active_clients` always returns a table, if that table is
  empty, there's no clients attached, hence return appropriate message. No
  need to use `next()`

  Remove all the complicated logic with the `msg` parameter, no argument
  is passed in any of the places that component is used, no need to have it.
