### PR TITLE
refactor(lualine): use `string.format` to return unique names

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -123,9 +123,8 @@ return {
       local supported_linters = linters.list_registered(buf_ft)
       vim.list_extend(buf_client_names, supported_linters)
 
-      local unique_client_names = vim.fn.uniq(buf_client_names)
-
-      local language_servers = "[" .. table.concat(unique_client_names, ", ") .. "]"
+      local unique_client_names = table.concat(buf_client_names, ", ")
+      local language_servers = string.format("[%s]", unique_client_names)
 
       if copilot_active then
         language_servers = language_servers .. "%#SLCopilot#" .. " " .. lvim.icons.git.Octoface .. "%*"


### PR DESCRIPTION
To purpose of this change is to make code more redeable by making `unique_client_names` a string with the unique names instead of a table and later on calling `table.concat`. Then use `string.format` instead of string concatenation with `..` 

