### PR TITLE
perf(`utils/installer`): speed up lvim installation

### DIFF
--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -21,7 +21,7 @@ local function git_cmd(opts)
     on_stderr = function(_, data)
       table.insert(stderr, data)
     end,
-  }):sync()
+  }):sync(10000)
 
   if not vim.tbl_isempty(stderr) then
     Log:debug(stderr)

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -392,7 +392,7 @@ function verify_lvim_dirs() {
 
 function clone_lvim() {
   msg "Cloning LunarVim configuration"
-  if ! git clone --depth 1 --branch "$LV_BRANCH" \
+  if ! git clone --progress --depth 1 --branch "$LV_BRANCH" \
     "https://github.com/${LV_REMOTE}" "$LUNARVIM_BASE_DIR"; then
     echo "Failed to clone repository. Installation failed."
     exit 1

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -392,7 +392,7 @@ function verify_lvim_dirs() {
 
 function clone_lvim() {
   msg "Cloning LunarVim configuration"
-  if ! git clone --branch "$LV_BRANCH" \
+  if ! git clone --depth 1 --branch "$LV_BRANCH" \
     "https://github.com/${LV_REMOTE}" "$LUNARVIM_BASE_DIR"; then
     echo "Failed to clone repository. Installation failed."
     exit 1


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

A full clone of this repository is not efficient (due to Repository size).

The [--depth](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) option tells Git to only download  commits up to a certain depth, which in this case is 1 commit. It also implies `--single-branch` flag automatically, thus ensuring that only one branch (and not multiple branches) will be downloaded.".

<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
```bash
docker run -w /tmp -it --rm alpine:edge sh -uelic 'addgroup -S lunaruser && adduser -S lunaruser -G lunaruser --shell /bin/sh && apk add yarn git python3 cargo neovim ripgrep alpine-sdk bash --update && SCRIPT_URL='https://raw.githubusercontent.com/uid54289/LunarVim/142ee5e0e0322c84e3219fe7c4d6430eb0866d72/utils/installer/install.sh' LV_BRANCH='release-1.3/neovim-0.9' su -c "bash <(curl -s $SCRIPT_URL)" lunaruser && su -c /home/lunaruser/.local/bin/lvim lunaruser'
```
