### PR TITLE
feat: add example to the packer deprecation message

### DIFF
--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -159,7 +159,7 @@ function M.post_load()
         vim.schedule(function()
           vim.notify_once(
             string.format(
-              [[We switched from packer.nvim to lazy.nvim. `%s` in `lvim.plugins` is deprecated. Use `%s` instead.
+              [[`%s` in `lvim.plugins` has been deprecated since the migration to lazy.nvim. Use `%s` instead.
 Example:
 `lvim.plugins = {... {... *%s* = [value] ...} ...}` ->
 `lvim.plugins = {... {... %s ...} ...}`
@@ -181,7 +181,7 @@ See https://github.com/folke/lazy.nvim#-migration-guide"]],
 
       vim.schedule(function()
         vim.notify_once(
-          [[We switched from packer.nvim to lazy.nvim. `"http..."` in `lvim.plugins` is deprecated. Use `url = "http..."` instead.
+          [[`"http..."` in `lvim.plugins` has been deprecated since the migration to lazy.nvim. Use `url = "http..."` instead.
 Example:
 `lvim.plugins = {... { "http..." ...} ...}` ->
 `lvim.plugins = {... { url = "http..." ...} ...}`

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -120,7 +120,7 @@ function M.post_load()
         spec.dependencies = spec.requires
       end
 
-      return "Use `{... dependencies = [value] ...}` instead"
+      return "*dependencies* = [value]"
     end
 
     alternatives.disable = function()
@@ -131,17 +131,17 @@ function M.post_load()
       else
         spec.enabled = not spec.disabled
       end
-      return "Use `{... enabled = [value] ...}` instead"
+      return "*enabled* = [value]"
     end
 
     alternatives.wants = function()
-      return "It's not needed in most cases, otherwise use `{... dependencies = [value] ...}`."
+      return "*dependencies* = [value]"
     end
     alternatives.needs = alternatives.wants
 
     alternatives.module = function()
       spec.lazy = true
-      return "Use `{... lazy = true ...}` instead."
+      return "*lazy* = true"
     end
 
     for old_key, alternative in pairs(alternatives) do
@@ -155,11 +155,23 @@ function M.post_load()
         end
         spec[old_key] = nil
 
-        message = message or string.format("Use `{... %s = [value] ...}` instead.", alternative)
-        deprecate(
-          string.format("{... %s = [value] ...}` in `lvim.plugins = {...}", old_key),
-          message .. " See https://github.com/folke/lazy.nvim#-migration-guide"
-        )
+        message = message or string.format("*%s* = [value]", alternative)
+        vim.schedule(function()
+          vim.notify_once(
+            string.format(
+              [[We switched from packer.nvim to lazy.nvim. `%s` in `lvim.plugins` is deprecated. Use `%s` instead.
+Example:
+`lvim.plugins = {... {... *%s* = [value] ...} ...}` ->
+`lvim.plugins = {... {... %s ...} ...}`
+See https://github.com/folke/lazy.nvim#-migration-guide"]],
+              old_key,
+              message,
+              old_key,
+              message
+            ),
+            vim.log.levels.WARN
+          )
+        end)
       end
     end
 

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -120,7 +120,7 @@ function M.post_load()
         spec.dependencies = spec.requires
       end
 
-      return "Use `dependencies` instead"
+      return "Use `{... dependencies = [value] ...}` instead"
     end
 
     alternatives.disable = function()
@@ -131,17 +131,17 @@ function M.post_load()
       else
         spec.enabled = not spec.disabled
       end
-      return "Use `enabled` instead"
+      return "Use `{... enabled = [value] ...}` instead"
     end
 
     alternatives.wants = function()
-      return "It's not needed in most cases, otherwise use `dependencies`."
+      return "It's not needed in most cases, otherwise use `{... dependencies = [value] ...}`."
     end
     alternatives.needs = alternatives.wants
 
     alternatives.module = function()
       spec.lazy = true
-      return "Use `lazy = true` instead."
+      return "Use `{... lazy = true ...}` instead."
     end
 
     for old_key, alternative in pairs(alternatives) do
@@ -155,9 +155,9 @@ function M.post_load()
         end
         spec[old_key] = nil
 
-        message = message or string.format("Use `%s` instead.", alternative)
+        message = message or string.format("Use `{... %s = [value] ...}` instead.", alternative)
         deprecate(
-          string.format("%s` in `lvim.plugins", old_key),
+          string.format("{... %s = [value] ...}` in `lvim.plugins = {...}", old_key),
           message .. " See https://github.com/folke/lazy.nvim#-migration-guide"
         )
       end

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -178,7 +178,17 @@ See https://github.com/folke/lazy.nvim#-migration-guide"]],
     if spec[1] and spec[1]:match "^http" then
       spec.url = spec[1]
       spec[1] = nil
-      deprecate("{ 'http...' }` in `lvim.plugins", "Use { url = 'http...' } instead.")
+
+      vim.schedule(function()
+        vim.notify_once(
+          [[We switched from packer.nvim to lazy.nvim. `"http..."` in `lvim.plugins` is deprecated. Use `url = "http..."` instead.
+Example:
+`lvim.plugins = {... { "http..." ...} ...}` ->
+`lvim.plugins = {... { url = "http..." ...} ...}`
+See https://github.com/folke/lazy.nvim#-migration-guide"]],
+          vim.log.levels.WARN
+        )
+      end)
     end
   end
 


### PR DESCRIPTION
the old deprecation message confused some users

before: 
![image](https://github.com/LunarVim/LunarVim/assets/110467150/521277d8-ea1c-4106-a598-4048966fe409)

after:
![image](https://github.com/LunarVim/LunarVim/assets/110467150/bb724bc0-586c-4d3c-8a63-ee64496861fd)

fixes  #4150