### PR TITLE
feat(plugin): add rounded borders to :LspInfo window.

### DIFF
--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -120,6 +120,11 @@ function M.setup()
 
   set_handler_opts_if_not_set("textDocument/hover", vim.lsp.handlers.hover, { border = "rounded" })
   set_handler_opts_if_not_set("textDocument/signatureHelp", vim.lsp.handlers.signature_help, { border = "rounded" })
+
+  -- Enable rounded borders in :LspInfo window.
+  pcall(function()
+    require("lspconfig.ui.windows").default_options.border = "rounded"
+  end)
 end
 
 return M


### PR DESCRIPTION
# Description
Added rounded borders to `:LspInfo window` to make LunarVim experience more cohesive.

## How Has This Been Tested?
`:LspInfo`

## Screenshot
![Screenshot_2023-05-27_16:54:25](https://github.com/LunarVim/LunarVim/assets/86684667/44523700-a396-4b43-99e3-cfe79393753f)