### PR TITLE
feat(plugin): add rounded borders to :LspInfo window

### DIFF
--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -122,9 +122,7 @@ function M.setup()
   set_handler_opts_if_not_set("textDocument/signatureHelp", vim.lsp.handlers.signature_help, { border = "rounded" })
 
   -- Enable rounded borders in :LspInfo window.
-  pcall(function()
-    require("lspconfig.ui.windows").default_options.border = "rounded"
-  end)
+   require("lspconfig.ui.windows").default_options.border = "rounded"
 end
 
 return M

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -122,7 +122,7 @@ function M.setup()
   set_handler_opts_if_not_set("textDocument/signatureHelp", vim.lsp.handlers.signature_help, { border = "rounded" })
 
   -- Enable rounded borders in :LspInfo window.
-   require("lspconfig.ui.windows").default_options.border = "rounded"
+  require("lspconfig.ui.windows").default_options.border = "rounded"
 end
 
 return M

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -120,6 +120,11 @@ function M.setup()
 
   set_handler_opts_if_not_set("textDocument/hover", vim.lsp.handlers.hover, { border = "rounded" })
   set_handler_opts_if_not_set("textDocument/signatureHelp", vim.lsp.handlers.signature_help, { border = "rounded" })
+
+  -- Enable rounded borders in :LspInfo window.
+  pcall(function()
+    require("lspconfig.ui.windows").default_options.border = "rounded"
+  end)
 end
 
 return M


### PR DESCRIPTION
# Description
Added rounded borders to `:LspInfo` window to make LunarVim experience more cohesive.

## How Has This Been Tested?
`:LspInfo`

## Screenshots

### Previous
![Screenshot_2023-05-27_17:13:07](https://github.com/LunarVim/LunarVim/assets/86684667/2dc80098-8ecb-4339-a6a6-c3f3e4ef1dd0)

### After
![Screenshot_2023-05-27_16:54:25](https://github.com/LunarVim/LunarVim/assets/86684667/9fd1e343-cde1-429f-98cd-2232cfcc0e06)