### PR TITLE
fix(win): remove '-NoLogo' from vim.opt.shell

### DIFF
--- a/utils/installer/config_win.example.lua
+++ b/utils/installer/config_win.example.lua
@@ -5,7 +5,7 @@
 -- Discord: https://discord.com/invite/Xb9B4Ny
 
 -- Enable powershell as your default shell
-vim.opt.shell = "pwsh.exe -NoLogo"
+vim.opt.shell = "pwsh.exe"
 vim.opt.shellcmdflag =
   "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
 vim.cmd [[


### PR DESCRIPTION
# Description
On Windows, an initial launch of LunarVim will see [telescope-fzf-native.nvim](https://github.com/nvim-telescope/telescope-fzf-native.nvim) fail to build (when it tries to run make) with the following message:

>"Failed to spawn process pwsh.exe -NoLogo { ... }"

The issue is the following line in config_win.example.lua (used to generate config.lua):
```lua
vim.opt.shell = "pwsh.exe -NoLogo"
```

Neovim seems to treat " -NoLogo" as if it's part of the executable name rather than an argument. Changing this to the following fixes the issue:
```lua
vim.opt.shell = "pwsh.exe"
```
The "-NoLogo argument" is already specified in vim.opt.shellcmdflag below this line.

## How Has This Been Tested?
Installed LunarVim from scratch with the alteration above. telescope-fzf-native.nvim now correctly installs.

