### PR TITLE
fix(lsp): skip auto config server even if it's ensure installed

### DIFF
--- a/lua/lvim/lsp/templates.lua
+++ b/lua/lvim/lsp/templates.lua
@@ -17,13 +17,11 @@ end
 
 local skipped_filetypes = lvim.lsp.automatic_configuration.skipped_filetypes
 local skipped_servers = lvim.lsp.automatic_configuration.skipped_servers
-local ensure_installed_servers = lvim.lsp.installer.setup.ensure_installed
 
 ---Check if we should skip generating an ftplugin file based on the server_name
 ---@param server_name string name of a valid language server
 local function should_skip(server_name)
-  -- ensure_installed_servers should take priority over skipped_servers
-  return vim.tbl_contains(skipped_servers, server_name) and not vim.tbl_contains(ensure_installed_servers, server_name)
+  return vim.tbl_contains(skipped_servers, server_name)
 end
 
 ---Generates an ftplugin file based on the server_name in the selected directory


### PR DESCRIPTION
`lsp.installer.setup.ensure_installed` takes priority over `lvim.lsp.automatic_configuration.skipped_servers` causes users cannot skip the default template generations. So if they want to customize their server options they need to skip the entire filetype instead (it's not expected). 

This makes sure the server always be skipped if it's in `skipped_server` list.