### PR TITLE
Feat/installer auto set path

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -243,29 +243,26 @@ function validate_install_prefix() {
   local profile="$HOME/.profile"
   local user_shell="$(getent passwd $LOGNAME | cut -d: -f7)"
   case "${user_shell}" in
-      *"zsh"*)
-          profile="$HOME/.zshenv"
-          ;;
-      *"fish"*)
-          profile="$HOME/.config/fish/config.fish"
-          ;;
+    *"zsh"*)
+      profile="$HOME/.zshenv"
+      ;;
+    *"fish"*)
+      profile="$HOME/.config/fish/config.fish"
+      ;;
   esac
 
   if [ "$INTERACTIVE_MODE" -eq 1 ]; then
-      if confirm "$prefix/bin is not on your path. would you like to add it to $profile?"; then
-        echo "appending $prefix/bin to path"
-        if [ "${user_shell##*/}" = "fish" ]; then
-            echo "fish_add_path $prefix/bin" >> $profile
-        else
-            echo "export PATH=\$PATH:$prefix/bin" >> $profile
-        fi
+    if confirm "$prefix/bin is not on your path. would you like to add it to $profile?"; then
+      echo "appending $prefix/bin to path"
+      if [ "${user_shell##*/}" = "fish" ]; then
+        echo "fish_add_path $prefix/bin" >>$profile
       else
-        ADDITIONAL_WARNINGS="[WARN] the folder $prefix/bin is not on PATH, consider adding 'export PATH=$prefix/bin:\$PATH' to your $profile"
+        echo "export PATH=\$PATH:$prefix/bin" >>$profile
       fi
+    else
+      ADDITIONAL_WARNINGS="[WARN] the folder $prefix/bin is not on PATH, consider adding 'export PATH=$prefix/bin:\$PATH' to your $profile"
     fi
-
-
-
+  fi
 
   # avoid problems when calling any verify_* function
   export PATH="$prefix/bin:$PATH"
@@ -481,7 +478,6 @@ function create_desktop_file() {
 
   xdg-desktop-menu install --novendor "$LUNARVIM_BASE_DIR/utils/desktop/lvim.desktop" || true
 }
-
 
 function print_logo() {
   cat <<'EOF'

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -239,9 +239,33 @@ function validate_install_prefix() {
       return
       ;;
   esac
+
   local profile="$HOME/.profile"
-  test -z "$ZSH_VERSION" && profile="$HOME/.zshenv"
-  ADDITIONAL_WARNINGS="[WARN] the folder $prefix/bin is not on PATH, consider adding 'export PATH=$prefix/bin:\$PATH' to your $profile"
+  local user_shell="$(getent passwd $LOGNAME | cut -d: -f7)"
+  case "${user_shell}" in
+      *"zsh"*)
+          profile="$HOME/.zshenv"
+          ;;
+      *"fish"*)
+          profile="$HOME/.config/fish/config.fish"
+          ;;
+  esac
+
+  if [ "$INTERACTIVE_MODE" -eq 1 ]; then
+      if confirm "$prefix/bin is not on your path. would you like to add it to $profile?"; then
+        echo "appending $prefix/bin to path"
+        if [ "${user_shell##*/}" = "fish" ]; then
+            echo "fish_add_path $prefix/bin" >> $profile
+        else
+            echo "export PATH=\$PATH:$prefix/bin" >> $profile
+        fi
+      else
+        ADDITIONAL_WARNINGS="[WARN] the folder $prefix/bin is not on PATH, consider adding 'export PATH=$prefix/bin:\$PATH' to your $profile"
+      fi
+    fi
+
+
+
 
   # avoid problems when calling any verify_* function
   export PATH="$prefix/bin:$PATH"
@@ -457,6 +481,7 @@ function create_desktop_file() {
 
   xdg-desktop-menu install --novendor "$LUNARVIM_BASE_DIR/utils/desktop/lvim.desktop" || true
 }
+
 
 function print_logo() {
   cat <<'EOF'


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Updated the installer script to be able to detect the user's current login shell and add the install prefix (.local/bin by default) to the path of its corresponding dotfile. it prompts the user to do this if the script was launched in interactive mode and the script does not detect that the install prefix is in the current path. If the script is not in interactive mode, the script performs its current behavior of echoing a warning at the end of installation.

Currently, it will only autodetect zsh and fish and change their paths, while defaulting to changing ~/.profile if the login shell is something else. This can easily be expanded with further commits.

<!--- Please list any dependencies that are required for this change. --->

fixes #4135 

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
I have set up clean virtual machines and attempted installation with the user shell set as zsh, bash, and fish. In each instance, it appended to the file correctly, and after re-sourcing the dotifles, lvim was able to be executed. Additionally, attempting installation with the install prefix already on the path correctly skipped this step.

