### PR TITLE
fix(installer): use a tmp dir during lazy setup

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -437,7 +437,7 @@ function setup_lvim() {
 
   echo "Preparing Lazy setup"
 
-  "$INSTALL_PREFIX/bin/$NVIM_APPNAME" --headless -c 'quitall'
+  LUNARVIM_CONFIG_DIR="$(mktemp -d)" "$INSTALL_PREFIX/bin/$NVIM_APPNAME" --headless -c 'quitall'
 
   printf "\nLazy setup complete"
 


### PR DESCRIPTION
makes the installation more reliable, lazy.nvim lockfile might have caused problems and sometimes plugins would have wrong versions / installations would fail