### PR TITLE
fix(installer): Install Nightly Neovim if master

### DIFF
--- a/utils/installer/install.ps1
+++ b/utils/installer/install.ps1
@@ -86,7 +86,11 @@ function print_missing_dep_msg($dep) {
 }
 
 $winget_package_matrix=@{"git" = "Git.Git"; "nvim" = "Neovim.Neovim"; "make" = "GnuWin32.Make"; "node" = "OpenJS.NodeJS"; "pip" = "Python.Python.3"}
-$scoop_package_matrix=@{"git" = "git"; "nvim" = "neovim-nightly"; "make" = "make"; "node" = "nodejs"; "pip" = "python3"}
+$scoop_package_matrix=@{"git" = "git"; "nvim" = "neovim"; "make" = "make"; "node" = "nodejs"; "pip" = "python3"}
+if ($LV_BRANCH -eq "master") {
+    $winget_package_matrix["nvim"] = "Neovim.Neovim.Nightly"
+    $scoop_package_matrix["nvim"] = "neovim-nightly"
+}
 
 function install_system_package($dep) {
     if (Get-Command -Name "winget" -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
Scoop would install the Nightly version if `nvim` command wasn't found. No matter if `LV_BRANCH` was set in release.

If the `LV_BRANCH` is set to `master`, then install Neovim Nightly from `winget` or `scoop`.