### PR TITLE
fix(deprecation): only deprecate `tag == "*"` in lvim.plugins

### DIFF
--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -110,7 +110,6 @@ function M.post_load()
       opt = "lazy",
       run = "build",
       lock = "pin",
-      tag = "version",
       requires = "dependencies",
     }
 

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -114,6 +114,13 @@ function M.post_load()
       requires = "dependencies",
     }
 
+    alternatives.tag = function()
+      if spec.tag == "*" then
+        spec.version = "*"
+        return [[version = "*"]]
+      end
+    end
+
     alternatives.disable = function()
       if type(spec.disabled) == "function" then
         spec.enabled = function()
@@ -138,34 +145,39 @@ function M.post_load()
     for old_key, alternative in pairs(alternatives) do
       if spec[old_key] ~= nil then
         local message
+        local old_value = vim.inspect(spec[old_key]) or "value"
 
         if type(alternative) == "function" then
           message = alternative()
         else
           spec[alternative] = spec[old_key]
         end
-        spec[old_key] = nil
 
-        local new_value = vim.inspect(spec[alternative] or "[value]")
-        message = message or string.format("%s = %s", alternative, new_value)
-        vim.schedule(function()
-          vim.notify_once(
-            string.format(
-              [[`%s` in `lvim.plugins` has been deprecated since the migration to lazy.nvim. Use `%s` instead.
+        if type(alternative) ~= "function" or message then
+          spec[old_key] = nil
+
+          local new_value = vim.inspect(spec[alternative] or "[value]")
+          message = message or string.format("%s = %s", alternative, new_value)
+          vim.schedule(function()
+            vim.notify_once(
+              string.format(
+                [[`%s = %s` in `lvim.plugins` has been deprecated since the migration to lazy.nvim. Use `%s` instead.
 Example:
 `lvim.plugins = {... {... %s = %s ...} ...}`
 ->
 `lvim.plugins = {... {... %s ...} ...}`
 See https://github.com/folke/lazy.nvim#-migration-guide"]],
-              old_key,
-              message,
-              old_key,
-              new_value,
-              message
-            ),
-            vim.log.levels.WARN
-          )
-        end)
+                old_key,
+                old_value,
+                message,
+                old_key,
+                old_value,
+                message
+              ),
+              vim.log.levels.WARN
+            )
+          end)
+        end
       end
     end
 

--- a/lua/lvim/config/_deprecated.lua
+++ b/lua/lvim/config/_deprecated.lua
@@ -152,6 +152,7 @@ function M.post_load()
           spec[alternative] = spec[old_key]
         end
 
+        -- not every function in alternatives returns a message (e.g. tag)
         if type(alternative) ~= "function" or message then
           spec[old_key] = nil
 


### PR DESCRIPTION
fixes #4237
![image](https://github.com/LunarVim/LunarVim/assets/110467150/2ff37116-092b-4261-94f4-6b23275c832c)
