### PR TITLE
feat(lsp): filter diagnostic codes

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -129,6 +129,7 @@ return {
     },
     config = {},
   },
+  ignored_diagnostic_codes = {},
   ---@deprecated use lvim.lsp.automatic_configuration.skipped_servers instead
   override = {},
   ---@deprecated use lvim.lsp.installer.setup.automatic_installation instead

--- a/lua/lvim/lsp/init.lua
+++ b/lua/lvim/lsp/init.lua
@@ -24,6 +24,15 @@ local function add_lsp_buffer_keybindings(bufnr)
   end
 end
 
+local function filter_diagnostics(_, result, ctx, config)
+  for idx = 1, #result.diagnostics, 1 do
+    if vim.tbl_contains(lvim.lsp.ignored_diagnostic_codes, result.diagnostics[idx].code) then
+      table.remove(result.diagnostics, idx)
+    end
+  end
+  vim.lsp.diagnostic.on_publish_diagnostics(_, result, ctx, config)
+end
+
 function M.common_capabilities()
   local status_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
   if status_ok then
@@ -39,6 +48,7 @@ function M.common_capabilities()
       "additionalTextEdits",
     },
   }
+  capabilities.textDocument.publishDiagnostics = filter_diagnostics
 
   return capabilities
 end


### PR DESCRIPTION
# Description

This PR adds the possibility of filtering out specific diagnostic codes from lsp, which is useful if you have something that you don't want to be displayed.

It came after I was struggling with a js/ts error that I don't want to be shown.
I fixed it following this discussion: https://github.com/LunarVim/LunarVim/discussions/4239 

## The fix

Created a property on lsp config which is a table that contains all diagnostic codes to be filtered.

Changed the LSP `textDocument.publishDiagnostics` capability to remove errors with the specified codes. 

## How Has This Been Tested?
- Find a file with a given specific diagnostic that you don't want to show.
  - Eg: `.eslintrc.js` usually have a warning like "File is a CommonJS module; it may be converted to an ES module." with the code of 80001.
- Add that diagnostic code to the filtered list.
  - `lvim.lsp.ignored_diagnostic_codes = { 80001 }`
- Check if the diagnostic still there on the file.

## Documentation

I didn't wrote documentation for that yet because first I want to check the community feedback, please let me know if this is really a useful feature and I can write docs on how to use it properly.

Also, if you have any concerns or think I can handle that differently, please leave a comment.