### PR TITLE
feat(lsp): finding correct root directory for csharp_ls

### DIFF
--- a/lua/lvim/lsp/providers/csharp_ls.lua
+++ b/lua/lvim/lsp/providers/csharp_ls.lua
@@ -1,0 +1,11 @@
+local opts = {
+  root_dir = function(fname)
+    local util = require "lspconfig/util"
+    return util.root_pattern("*.sln")(fname)
+      or util.root_pattern("*.csproj")(fname)
+      or util.root_pattern("*.fsproj")(fname)
+      or util.root_pattern(".git")(fname)
+  end,
+}
+
+return opts


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Have added default configuration for csharp_ls to find the root directory based on your project type: https://github.com/LunarVim/LunarVim/issues/4327


## How Has This Been Tested?
Loading csharp project that has following structure

```
/MyProject
    MyProject.sln
    /MyProject.Program
        MyProject.Program.csproj
        Program.cs
    /MyProject.Library
        MyProject.Library.csproj
        Class1.cs
```
Run `:LspInfo`