### PR TITLE
test: trigger loading event manually for mason

### DIFF
--- a/lua/lvim/core/autocmds.lua
+++ b/lua/lvim/core/autocmds.lua
@@ -143,7 +143,7 @@ function M.load_defaults()
           local buftype = vim.api.nvim_get_option_value("buftype", { buf = args.buf })
           if not (vim.fn.expand "%" == "" or buftype == "nofile") then
             vim.api.nvim_del_augroup_by_name "_file_opened"
-            vim.cmd "do User FileOpened"
+            vim.api.nvim_exec_autocmds("User", { pattern = "FileOpened" })
             require("lvim.lsp").setup()
           end
         end,

--- a/tests/specs/lsp_spec.lua
+++ b/tests/specs/lsp_spec.lua
@@ -24,6 +24,9 @@ describe("lsp workflow", function()
   local plugins = require "lvim.plugins"
   require("lvim.plugin-loader").load { plugins, lvim.plugins }
 
+  -- trigger loading event manually for mason
+  vim.api.nvim_exec_autocmds("User", { pattern = "FileOpened" })
+
   it("should be able to delete ftplugin templates", function()
     if utils.is_directory(lvim.lsp.templates_dir) then
       assert.equal(vim.fn.delete(lvim.lsp.templates_dir, "rf"), 0)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Another step towards eliminating flakiness in the CI.

Fixes https://github.com/LunarVim/LunarVim/actions/runs/5989427656/job/16245599387?pr=4341
<!--- Please list any dependencies that are required for this change. --->

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->

https://github.com/LunarVim/LunarVim/actions/runs/5989460159/job/16245668584?pr=4341
