### PR TITLE
fix(lsp): adapt recent changes in `nvim-lspconfig`

### DIFF
--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -52,7 +52,7 @@ end
 -- manually start the server and don't wait for the usual filetype trigger from lspconfig
 local function buf_try_add(server_name, bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
-  require("lspconfig")[server_name].manager.try_add_wrapper(bufnr)
+  require("lspconfig")[server_name].manager:try_add_wrapper(bufnr)
 end
 
 -- check if the manager autocomd has already been configured since some servers can take a while to initialize


### PR DESCRIPTION
# Description
Lsp manager has been move to separate module in 
https://github.com/neovim/nvim-lspconfig/commit/204f08ea407e4b3b7ad272287e1821f47e52d4b3


