### PR TITLE
chore(lsp): add `biome` to `skipped_servers` list

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -3,6 +3,7 @@ local skipped_servers = {
   "ansiblels",
   "antlersls",
   "azure_pipelines_ls",
+  "biome",
   "ccls",
   "custom_elements_ls",
   "omnisharp",


### PR DESCRIPTION
Mason recently added `biome` server in https://github.com/williamboman/mason-lspconfig.nvim/commit/1e10ef512d8f7038bfbb651c894dfc8ae2521b57 causes automation tests to fail.

<img width="788" alt="Screenshot 2023-10-17 at 04 31 13" src="https://github.com/LunarVim/LunarVim/assets/42694704/12deb5b8-a7bb-4e64-9f41-effd7286a8de">