### PR TITLE
chore(lsp): add `mdx_analyzer` to `skipped_server` list

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -22,6 +22,7 @@ local skipped_servers = {
   "java_language_server",
   "jedi_language_server",
   "ltex",
+  "mdx_analyzer",
   "neocmake",
   "ocamlls",
   "phpactor",


### PR DESCRIPTION
Another server from Mason need to be skipped since https://github.com/williamboman/mason-lspconfig.nvim/commit/047438fceff58b26520e3a6487724fad9536f158

<img width="788" alt="Screenshot 2023-10-17 at 14 15 19" src="https://github.com/LunarVim/LunarVim/assets/42694704/512b1c3d-df8c-4860-a674-451aa6fea028">