### PR TITLE
fix: duplicated pairs in autopairs

### DIFF
--- a/lua/lvim/core/autopairs.lua
+++ b/lua/lvim/core/autopairs.lua
@@ -10,7 +10,7 @@ function M.config()
       tex = "{",
     },
     ---@usage check bracket in same line
-    enable_check_bracket_line = false,
+    enable_check_bracket_line = true,
     ---@usage check treesitter
     check_ts = true,
     ts_config = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This bug was first reported here:
https://github.com/LunarVim/LunarVim/issues/2015

At some point there was a regression and now the fix has the opposite for me.

## How Has This Been Tested?

Press { and it produces }
Autocompleting a function only produces a single pair of (
