### PR TITLE
feat(plugins): migrate `indent-blankline` to v3

### DIFF
--- a/lua/lvim/core/indentlines.lua
+++ b/lua/lvim/core/indentlines.lua
@@ -6,34 +6,84 @@ M.config = function()
     on_config_done = nil,
     options = {
       enabled = true,
-      buftype_exclude = { "terminal", "nofile" },
-      filetype_exclude = {
-        "help",
-        "startify",
-        "dashboard",
-        "lazy",
-        "neogitstatus",
-        "NvimTree",
-        "Trouble",
-        "text",
+      debounce = 200,
+      viewport_buffer = {
+        min = 30,
+        max = 500,
       },
-      char = lvim.icons.ui.LineLeft,
-      context_char = lvim.icons.ui.LineLeft,
-      show_trailing_blankline_indent = false,
-      show_first_indent_level = true,
-      use_treesitter = true,
-      show_current_context = true,
+      indent = {
+        char = lvim.icons.ui.LineLeft,
+        tab_char = nil,
+        highlight = "IblIndent",
+        smart_indent_cap = true,
+        priority = 1,
+      },
+      whitespace = {
+        highlight = "IblWhitespace",
+        remove_blankline_trail = true,
+      },
+      exclude = {
+        buftypes = { "terminal", "nofile", "quickfix", "prompt" },
+        filetypes = {
+          "NvimTree",
+          "Trouble",
+          "dashboard",
+          "help",
+          "lazy",
+          "neogitstatus",
+          "startify",
+          "text",
+        },
+      },
+      scope = {
+        enabled = true,
+        char = lvim.icons.ui.LineLeft,
+        show_start = true,
+        show_end = true,
+        show_exact_scope = false,
+        injected_languages = true,
+        highlight = "IblScope",
+        priority = 1024,
+        include = {
+          node_type = {},
+        },
+        exclude = {
+          language = {},
+          node_type = {
+            ["*"] = {
+              "source_file",
+              "program",
+            },
+            lua = {
+              "chunk",
+            },
+            python = {
+              "module",
+            },
+          },
+        },
+      },
     },
   }
 end
 
 M.setup = function()
-  local status_ok, indent_blankline = pcall(require, "indent_blankline")
+  local status_ok, indent_blankline = pcall(require, "ibl")
   if not status_ok then
     return
   end
 
-  indent_blankline.setup(lvim.builtin.indentlines.options)
+  local _, err = pcall(indent_blankline.setup, lvim.builtin.indentlines.options)
+
+  if err then
+    local invalid_key = err:match "'(.*)'"
+
+    vim.notify(
+      "`lvim.builtin.indentlines.options."
+        .. invalid_key
+        .. "` has been deprecated. Please take a look at `:h ibl.config` to learn about new config and update."
+    )
+  end
 
   if lvim.builtin.indentlines.on_config_done then
     lvim.builtin.indentlines.on_config_done()

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -36,7 +36,7 @@
     "commit": "ff01d34"
   },
   "indent-blankline.nvim": {
-    "commit": "9637670"
+    "commit": "29be091"
   },
   "lazy.nvim": {
     "commit": "f739865"


### PR DESCRIPTION
# Description

Update [indent-blankline](https://github.com/lukas-reineke/indent-blankline.nvim) to latest version 3.

## How this has been test
A message will popup to indicate that you are using old config and require you to update to match new version.

<img width="1245" alt="Screenshot 2023-11-28 at 18 57 36" src="https://github.com/LunarVim/LunarVim/assets/42694704/b0211c38-5390-4870-83f4-23736fd198e3">

Currently there is no specific message from original plugin on how to migrate config exactly.