### PR TITLE
fix(default-options): remove invalid guifont

### DIFF
--- a/lua/lvim/config/settings.lua
+++ b/lua/lvim/config/settings.lua
@@ -19,7 +19,6 @@ M.load_default_options = function()
     fileencoding = "utf-8", -- the encoding written to a file
     foldmethod = "manual", -- folding, set to "expr" for treesitter based folding
     foldexpr = "", -- set to "nvim_treesitter#foldexpr()" for treesitter based folding
-    guifont = "monospace:h17", -- the font used in graphical neovim applications
     hidden = true, -- required to keep multiple buffers and open multiple buffers
     hlsearch = true, -- highlight all matches on previous search pattern
     ignorecase = true, -- ignore case in search patterns


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Remove  'guifont' from default options.
The value of 'guifont' is unreasonable, 'monospace:h17' is not a universally pre-installed font on most devices.
An erroneous 'guifont' configuration may lead to GUI operational errors.

<!--- Please list any dependencies that are required for this change. --->

fixes (https://github.com/LunarVim/LunarVim/issues/4446)

