### PR TITLE
fix: handle context-commentstring setup

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -38,20 +38,6 @@ function M.config()
         return status_ok and big_file_detected
       end,
     },
-    context_commentstring = {
-      enable = true,
-      enable_autocmd = false,
-      config = {
-        -- Languages that have a single comment style
-        typescript = "// %s",
-        css = "/* %s */",
-        scss = "/* %s */",
-        html = "<!-- %s -->",
-        svelte = "<!-- %s -->",
-        vue = "<!-- %s -->",
-        json = "",
-      },
-    },
     indent = { enable = true, disable = { "yaml", "python" } },
     autotag = { enable = false },
     textobjects = {

--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -38,6 +38,20 @@ function M.config()
         return status_ok and big_file_detected
       end,
     },
+    context_commentstring = {
+      enable = true,
+      enable_autocmd = false,
+      config = {
+        -- Languages that have a single comment style
+        typescript = "// %s",
+        css = "/* %s */",
+        scss = "/* %s */",
+        html = "<!-- %s -->",
+        svelte = "<!-- %s -->",
+        vue = "<!-- %s -->",
+        json = "",
+      },
+    },
     indent = { enable = true, disable = { "yaml", "python" } },
     autotag = { enable = false },
     textobjects = {
@@ -88,13 +102,23 @@ function M.setup()
     return
   end
 
-  local status_ok, treesitter_configs = pcall(require, "nvim-treesitter.configs")
-  if not status_ok then
+  local ts_status_ok, treesitter_configs = pcall(require, "nvim-treesitter.configs")
+  if not ts_status_ok then
     Log:error "Failed to load nvim-treesitter.configs"
     return
   end
 
+  local status_ok, ts_context_commentstring = pcall(require, "ts_context_commentstring")
+  if not status_ok then
+    Log:error "Failed to load ts_context_commentstring"
+    return
+  end
+
   local opts = vim.deepcopy(lvim.builtin.treesitter)
+
+  -- handle deprecated API, https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/82
+  ts_context_commentstring.setup(opts.context_commentstring)
+  opts.context_commentstring = nil
 
   treesitter_configs.setup(opts)
 

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -150,20 +150,6 @@ local core_plugins = {
     -- Lazy loaded by Comment.nvim pre_hook
     "JoosepAlviste/nvim-ts-context-commentstring",
     lazy = true,
-    opts = {
-      enable_autocmd = false,
-      config = {
-        -- Languages that have a single comment style
-        typescript = "// %s",
-        css = "/* %s */",
-        scss = "/* %s */",
-        html = "<!-- %s -->",
-        svelte = "<!-- %s -->",
-        vue = "<!-- %s -->",
-        json = "",
-      },
-    },
-    enabled = lvim.builtin.comment.active,
   },
 
   -- NvimTree

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -150,6 +150,20 @@ local core_plugins = {
     -- Lazy loaded by Comment.nvim pre_hook
     "JoosepAlviste/nvim-ts-context-commentstring",
     lazy = true,
+    opts = {
+      enable_autocmd = false,
+      config = {
+        -- Languages that have a single comment style
+        typescript = "// %s",
+        css = "/* %s */",
+        scss = "/* %s */",
+        html = "<!-- %s -->",
+        svelte = "<!-- %s -->",
+        vue = "<!-- %s -->",
+        json = "",
+      },
+    },
+    enabled = lvim.builtin.comment.active,
   },
 
   -- NvimTree

--- a/snapshots/default.json
+++ b/snapshots/default.json
@@ -87,10 +87,10 @@
     "commit": "64f61e4"
   },
   "nvim-treesitter": {
-    "commit": "1e64838"
+    "commit": "d5a1c2b"
   },
   "nvim-ts-context-commentstring": {
-    "commit": "b8ff464"
+    "commit": "0bdccb9"
   },
   "nvim-web-devicons": {
     "commit": "5b90678"


### PR DESCRIPTION
# Description

This PR fixes a deprecation warning from the `JoosepAlviste/nvim-ts-context-commentstring` plugin.

<img width="1470" alt="Screenshot 2023-12-26 at 09 40 36" src="https://github.com/LunarVim/LunarVim/assets/20072509/cb737b61-4988-4ed0-8316-ef47a28c315a">

This has been done following the migration steps mentioned in https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/82#issuecomment-1817659634.

_The changes are internal to the setup function, and no further action is required from the user._

_All the options under `lvim.builtin.treesitter.context_commentstring`  will be directly passed to `require('ts_context_commentstring').setup()`_

~~With these changes, we're removing the possibility of customizing the plugin using the `lvim.builtin.treesitter` table. So users won't be able to add more languages to the table for example (but I don't know if that's something users usually do). So yes, in theory this is a breaking change.~~

## How Has This Been Tested?

comment out these two lines in `lua/lvim/core/treesitter.lua` to trigger the deprecation warning

```lua
  ts_context_commentstring.setup(opts.context_commentstring)
  opts.context_commentstring = nil
```

