### PR TITLE
fix(treesitter): remove deprecated key from context_commenstring

### DIFF
--- a/lua/lvim/core/treesitter.lua
+++ b/lua/lvim/core/treesitter.lua
@@ -39,7 +39,6 @@ function M.config()
       end,
     },
     context_commentstring = {
-      enable = true,
       enable_autocmd = false,
       config = {
         -- Languages that have a single comment style


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix the warning message observed from issue #4522 . The reason has been discussed in that issue, the author of nvim-ts-context-commentstring suggest to remove the enable key as it has already been enabled by default. This breaking change has been introduced in last November, so removing it now shouldn't be a problem.

## How Has This Been Tested?

I've tested on my machine and no problem occurred.

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
