### PR TITLE
fix(install): add newline after Lazy setup complete message

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -447,7 +447,7 @@ function setup_lvim() {
 
   "$INSTALL_PREFIX/bin/$NVIM_APPNAME" --headless -c 'quitall'
 
-  printf "\nLazy setup complete"
+  printf "\nLazy setup complete\n"
 
   verify_core_plugins
 }


### PR DESCRIPTION
# Description

Fixes a minor issue with the installation message "Lazy setup complete".

## How Has This Been Tested?

- Run command `install.sh`

Before the fix:

```
Preparing Lazy setup                                                                                                                      
Initializing first time setup                                                                                                             
Lazy setup complete--------------------------------------------------------------------------------                                       
Verifying core plugins                                                                                                                    
Verification complete!                                                                                                                    
--------------------------------------------------------------------------------                                                                                                                                                                                                    --------------------------------------------------------------------------------
```

After the fix:

```
Preparing Lazy setup
Initializing first time setup
Lazy setup complete
--------------------------------------------------------------------------------
Verifying core plugins
Verification complete!
--------------------------------------------------------------------------------

--------------------------------------------------------------------------------
```
