### PR TITLE
fix: Copilot.vim LSP Name Change

### DIFF
--- a/lua/lvim/core/lualine/components.lua
+++ b/lua/lvim/core/lualine/components.lua
@@ -104,11 +104,11 @@ return {
 
       -- add client
       for _, client in pairs(buf_clients) do
-        if client.name ~= "null-ls" and client.name ~= "copilot" then
+        if client.name ~= "null-ls" and client.name ~= "GitHub Copilot" then
           table.insert(buf_client_names, client.name)
         end
 
-        if client.name == "copilot" then
+        if client.name == "GitHub Copilot" then
           copilot_active = true
         end
       end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

summary of the change

<!--- Please list any dependencies that are required for this change. --->

fixes #(issue)

## How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. --->
<!--- Also list any relevant details for your test configuration. --->
<!--- Provide instructions so we can reproduce -->
- Run command `:mycommand`
- Check logs
- ...

As of 2 days ago. Copilot.vim release 1.29.0 has changed the name of the LSP from "copilot" to "GitHub Copilot", this PR simply updates the lualine LSP component to reflect this new change.

![CleanShot 2024-04-14 at 11 04 00@2x](https://github.com/LunarVim/LunarVim/assets/21297100/72455e73-0d84-4c77-bcdd-ec281bf9ba11)


