### PR TITLE
fix(terminal): show lazygit bottom line

### DIFF
--- a/lua/lvim/core/terminal.lua
+++ b/lua/lvim/core/terminal.lua
@@ -156,6 +156,7 @@ M.lazygit_toggle = function()
       border = "none",
       width = 100000,
       height = 100000,
+      zindex = 200,
     },
     on_open = function(_)
       vim.cmd "startinsert!"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The cmdline covers the bottom line of the Lazygit window. Increasing the zindex of the Lazygit window makes the bottom line show.

Fixes #4541 

## How Has This Been Tested?

Opened Lazygit using <leader>gg and bottom line appeared. 

