### PR TITLE
fix(plugins): call bigfile setup correctly

### DIFF
--- a/lua/lvim/core/log.lua
+++ b/lua/lvim/core/log.lua
@@ -7,7 +7,6 @@ Log.levels = {
   WARN = 4,
   ERROR = 5,
 }
-vim.tbl_add_reverse_lookup(Log.levels)
 
 local notify_opts = {}
 local log_notify_as_notification = false

--- a/lua/lvim/plugins.lua
+++ b/lua/lvim/plugins.lua
@@ -350,10 +350,11 @@ local core_plugins = {
     "lunarvim/bigfile.nvim",
     config = function()
       pcall(function()
-        require("bigfile").config(lvim.builtin.bigfile.config)
+        require("bigfile").setup(lvim.builtin.bigfile.config)
       end)
     end,
     enabled = lvim.builtin.bigfile.active,
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
     event = { "FileReadPre", "BufReadPre", "User FileOpened" },
   },
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - feat: for feature addition / improvements
 - fix: when fixing a functionality
 - refactor: when moving code without adding any functionality
 - docs: on documentation updates

Additionally you can specify the scope of the PR in parenthesis, ex `fix(cmp):` or `feat(which-key):` or `docs(readme):`

- I read the contributing guide [CONTRIBUTING.md](../CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- handle the change in https://github.com/LunarVim/bigfile.nvim/issues/12 by avoiding the default setup function
- add `nvim-treesitter/nvim-treesitter` as a dependency just to make sure it's loaded anyway 